### PR TITLE
Issue 37278: IllegalStateException in print view of table with XML-customized buttons

### DIFF
--- a/flow/src/org/labkey/flow/view/FlowQueryView.java
+++ b/flow/src/org/labkey/flow/view/FlowQueryView.java
@@ -264,7 +264,7 @@ public class FlowQueryView extends QueryView
                     publishURL.addParameter("containerFilterName", getTable().getContainerFilter().getType().name());
 
                 ActionButton publishButton = new ActionButton(publishURL,
-                        "Copy to Study", DataRegion.MODE_GRID, ActionButton.Action.POST);
+                        "Copy to Study", ActionButton.Action.POST);
                 publishButton.setDisplayPermission(InsertPermission.class);
                 publishButton.setRequiresSelection(true);
 

--- a/microarray/src/org/labkey/microarray/controllers/FeatureAnnotationSetController.java
+++ b/microarray/src/org/labkey/microarray/controllers/FeatureAnnotationSetController.java
@@ -302,7 +302,7 @@ public class FeatureAnnotationSetController extends SpringActionController
             editURL.addParameter("RowId", form.getRowId());
             editURL.addReturnURL(getViewContext().getActionURL());
 
-            ActionButton edit = new ActionButton(editURL, "Edit", DataRegion.MODE_DETAILS);
+            ActionButton edit = new ActionButton(editURL, "Edit");
             edit.setActionType(ActionButton.Action.LINK);
             edit.setDisplayPermission(UpdatePermission.class);
             bb.add(edit);

--- a/microarray/src/org/labkey/microarray/view/FeatureAnnotationSetQueryView.java
+++ b/microarray/src/org/labkey/microarray/view/FeatureAnnotationSetQueryView.java
@@ -74,7 +74,7 @@ public class FeatureAnnotationSetQueryView extends QueryView
     protected void populateButtonBar(DataView view, ButtonBar bar)
     {
         super.populateButtonBar(view, bar);
-        ActionButton deleteButton = new ActionButton(FeatureAnnotationSetController.DeleteAction.class, "Delete", DataRegion.MODE_GRID, ActionButton.Action.GET);
+        ActionButton deleteButton = new ActionButton(FeatureAnnotationSetController.DeleteAction.class, "Delete", ActionButton.Action.GET);
         deleteButton.setDisplayPermission(DeletePermission.class);
         ActionURL deleteURL = new ActionURL(FeatureAnnotationSetController.DeleteAction.class, getContainer());
         deleteURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
@@ -83,14 +83,14 @@ public class FeatureAnnotationSetQueryView extends QueryView
         deleteButton.setRequiresSelection(true);
         bar.add(deleteButton);
 
-        ActionButton uploadButton = new ActionButton(FeatureAnnotationSetController.UploadAction.class, "Import Feature Annotation Set", DataRegion.MODE_GRID, ActionButton.Action.LINK);
+        ActionButton uploadButton = new ActionButton(FeatureAnnotationSetController.UploadAction.class, "Import Feature Annotation Set", ActionButton.Action.LINK);
         ActionURL uploadURL = new ActionURL(FeatureAnnotationSetController.UploadAction.class, getContainer());
         uploadURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
         uploadButton.setURL(uploadURL);
         uploadButton.setDisplayPermission(UpdatePermission.class);
         bar.add(uploadButton);
 
-        bar.add(new ActionButton(new ActionURL(FeatureAnnotationSetController.UploadAction.class, getContainer()), "Submit", DataRegion.MODE_UPDATE));
+        bar.add(new ActionButton(new ActionURL(FeatureAnnotationSetController.UploadAction.class, getContainer()), "Submit"));
     }
 
 

--- a/ms1/src/org/labkey/ms1/MS1ExperimentRunType.java
+++ b/ms1/src/org/labkey/ms1/MS1ExperimentRunType.java
@@ -44,7 +44,7 @@ public class MS1ExperimentRunType extends ExperimentRunType
     {
         ActionURL compareUrl = new ActionURL(MS1Controller.CompareRunsSetupAction.class, context.getContainer());
         String script = MS1Controller.createVerifySelectedScript(view, compareUrl);
-        ActionButton b = new ActionButton(compareUrl, "Compare", DataRegion.MODE_ALL, ActionButton.Action.LINK);
+        ActionButton b = new ActionButton(compareUrl, "Compare", ActionButton.Action.LINK);
         b.setScript(script);
         bar.add(b);
     }


### PR DESCRIPTION
Remove immutable default ButtonBars, unscoped to a controller. Update the small number of places I could find that rely on those default button, mainly very old code in experiment, user, and mothership UI.

Remove display mode from DisplayElement. Only configure the buttons and columns that are desired for the type of view that is being used (insert, update, grid, details, etc)