### PR TITLE
Make NAb actions 404 when a non-NAb runId is specified

### DIFF
--- a/nab/src/org/labkey/nab/NabAssayController.java
+++ b/nab/src/org/labkey/nab/NabAssayController.java
@@ -201,7 +201,7 @@ public class NabAssayController extends SpringActionController
     {
         AssayProvider provider = AssayService.get().getProvider(run.getProtocol());
         if (!(provider instanceof DilutionAssayProvider))
-            throw new IllegalArgumentException("Run " + run.getRowId() + " is not a NAb run.");
+            throw new NotFoundException("Run " + run.getRowId() + " is not a NAb run.");
         return (DilutionAssayProvider) provider;
     }
 


### PR DESCRIPTION
We currently throw a 500 response with something like:
```
java.lang.IllegalArgumentException: Run 7 is not a NAb run.
       at org.labkey.nab.NabAssayController.getProvider(NabAssayController.java:204)
       at org.labkey.nab.NabAssayController.getCustomViewModifiedDate(NabAssayController.java:249)
       at org.labkey.nab.NabAssayController.getCachedRun(NabAssayController.java:274)
       at org.labkey.nab.NabAssayController._getNabAssayRun(NabAssayController.java:290)
       at org.labkey.nab.NabAssayController$DetailsAction.getNabAssayRun(NabAssayController.java:318)
```