### PR TITLE
Prevent NPEs in mascot client due to undefined server URL

### DIFF
--- a/ms2/src/org/labkey/ms2/pipeline/mascot/MascotClientImpl.java
+++ b/ms2/src/org/labkey/ms2/pipeline/mascot/MascotClientImpl.java
@@ -92,7 +92,7 @@ public class MascotClientImpl implements SearchClient
 
     public MascotClientImpl(String url, Logger instanceLogger, String userAccount, String userPassword)
     {
-        _url = url;
+        _url = (null == url) ? "" : url;
         _instanceLogger = (null == instanceLogger) ? _log : instanceLogger;
         _userAccount = (null == userAccount) ? "" : userAccount;
         _userPassword = (null == userPassword) ? "" : userPassword;


### PR DESCRIPTION
Hitting the blank MascotTestAction throws a 500 like:
```
java.lang.NullPointerException
       at org.labkey.ms2.pipeline.mascot.MascotClientImpl.findWorkableSettings(MascotClientImpl.java:230)
       at org.labkey.ms2.MS2Controller$MascotTestAction.getView(MS2Controller.java:4745)
       at org.labkey.ms2.MS2Controller$MascotTestAction.getView(MS2Controller.java:4736)
```