### PR TITLE
Make FieldPropertyDock more amenable to polymorphism

### DIFF
--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -578,7 +578,7 @@ public abstract class LuminexTest extends BaseWebDriverTest
     {
         PropertiesEditor propertiesEditor = PropertiesEditor(getDriver()).withTitleContaining(where).find();
         propertiesEditor.selectField(index);
-        propertiesEditor.fieldProperties().selectFormatTab().propertyFormat.set(formatStr);
+        propertiesEditor.fieldProperties().selectFormatTab().setPropertyFormat(formatStr);
     }
 
     public void importLuminexRunPageTwo(String name, String isotype, String conjugate, String stndCurveFitInput,


### PR DESCRIPTION
Use setter and getters instead of direct access to member variables.