### PR TITLE
Issue 37449: Case-sensitivity on flow gates ignores Aliasing

### DIFF
--- a/flow/src/org/labkey/flow/controllers/WorkspaceData.java
+++ b/flow/src/org/labkey/flow/controllers/WorkspaceData.java
@@ -34,6 +34,7 @@ import org.labkey.flow.analysis.web.GraphSpec;
 import org.labkey.flow.analysis.web.SpecBase;
 import org.labkey.flow.analysis.web.StatisticSpec;
 import org.labkey.flow.analysis.web.SubsetSpec;
+import org.labkey.flow.data.FlowProtocol;
 import org.labkey.flow.persist.AnalysisSerializer;
 import org.labkey.flow.persist.AttributeCache;
 import org.springframework.validation.Errors;
@@ -42,8 +43,11 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -195,7 +199,10 @@ public class WorkspaceData implements Serializable
                 }
 
                 _object = readWorkspace(file, path);
-                validateCasing(container, errors);
+
+                FlowProtocol protocol = FlowProtocol.getForContainer(container);
+                validateKeywordCasing(container, errors, protocol.isCaseSensitiveKeywords());
+                validateStatAndGraphCasing(container, errors, protocol.isCaseSensitiveStatsAndGraphs());
             }
             else
             {
@@ -204,9 +211,27 @@ public class WorkspaceData implements Serializable
         }
     }
 
-    private void validateCasing(Container c, Errors errors)
+    private void validateKeywordCasing(Container c, Errors errors, boolean isCaseSensitive)
     {
+        List<String> messages = new ArrayList<>(10);
         Set<String> seenKeyword = new HashSet<>();
+
+        for (ISampleInfo sample : _object.getSamples())
+        {
+            for (String keyword : sample.getKeywords().keySet())
+            {
+                checkAttribute(c, messages, sample, keyword, AttributeCache.KEYWORDS, seenKeyword, null, null);
+                if (messages.size() > 10)
+                    break;
+            }
+        }
+
+        addCaseSensitiveWarnings(errors, messages, isCaseSensitive);
+    }
+
+    private void validateStatAndGraphCasing(Container c, Errors errors, boolean isCaseSensitive)
+    {
+        List<String> messages = new ArrayList<>(10);
         Set<StatisticSpec> seenStat = new HashSet<>();
         Set<GraphSpec> seenGraph = new HashSet<>();
 
@@ -215,38 +240,33 @@ public class WorkspaceData implements Serializable
 
         for (ISampleInfo sample : _object.getSamples())
         {
-            for (String keyword : sample.getKeywords().keySet())
-            {
-                checkAttribute(c, errors, sample, keyword, AttributeCache.KEYWORDS, seenKeyword, null, null);
-                if (errors.getErrorCount() > 10)
-                    break;
-            }
-
             Analysis analysis = _object.getSampleAnalysis(sample);
             if (analysis == null)
                 continue;
 
             for (StatisticSpec spec : analysis.getStatistics())
             {
-                checkAttribute(c, errors, sample, spec, AttributeCache.STATS, seenStat, subsetMismatches, parameterMismatches);
-                if (errors.getErrorCount() > 10)
+                checkAttribute(c, messages, sample, spec, AttributeCache.STATS, seenStat, subsetMismatches, parameterMismatches);
+                if (messages.size() > 10)
                     break;
             }
 
             for (GraphSpec spec : analysis.getGraphs())
             {
-                checkAttribute(c, errors, sample, spec, AttributeCache.GRAPHS, seenGraph, subsetMismatches, parameterMismatches);
-                if (errors.getErrorCount() > 10)
+                checkAttribute(c, messages, sample, spec, AttributeCache.GRAPHS, seenGraph, subsetMismatches, parameterMismatches);
+                if (messages.size() > 10)
                     break;
             }
         }
 
         if (!subsetMismatches.isEmpty() && !parameterMismatches.isEmpty())
             _log.debug("Mismatch counts while parsing workspace: " + _object.getName() + "\n" + subsetMismatches.toString() + "\n" + parameterMismatches.toString());
+
+        addCaseSensitiveWarnings(errors, messages, isCaseSensitive);
     }
 
     <Z extends Comparable<Z>> void checkAttribute(
-            Container c, Errors errors, ISampleInfo sample, Z attr, AttributeCache cache, Set<Z> seen,
+            Container c, List<String> messages, ISampleInfo sample, Z attr, AttributeCache cache, Set<Z> seen,
             Map<SubsetSpec, Integer> subsetMismatches, Map<String, Integer> parameterMismatches)
     {
         // Skip checking if we've already seen this attribute
@@ -261,7 +281,7 @@ public class WorkspaceData implements Serializable
 
         // If we have an existing attribute, check if the casing matches
         String attrString = attr.toString();
-        if (!attrString.equals(entry.getAttribute().toString()))
+        if (!matchesCasing(entry, attrString))
         {
             if (attr instanceof SpecBase)
             {
@@ -271,8 +291,48 @@ public class WorkspaceData implements Serializable
                     return;
             }
 
-            errors.reject(ERROR_MSG, _object.getName() + ": Sample " + sample.getLabel() + ": " + entry.getType() + " '" + attrString + "' has different casing than existing entry '" + entry.getAttribute() + "'." +
-                    " Please correct the casing before importing or create '" + attrString + "' as an alias for '" + entry.getAttribute() + "'.");
+            messages.add(_object.getName() + ": Sample " + sample.getLabel() + ": " + entry.getType() + " '" + attrString + "' has different casing than existing entry '" + entry.getAttribute() + "'." +
+                    " Please consider correcting the casing before importing or create '" + attrString + "' as an alias for '" + entry.getAttribute() + "'.");
+        }
+    }
+
+    // Issue 37449: Case-sensitivity on flow gates ignores aliasing
+    // Check if the casing of the attribute string matches the attribute entry or one of it's aliases
+    boolean matchesCasing(AttributeCache.Entry entry, String attrString)
+    {
+        // Check that the entry's attribute matches the expected value
+        if (attrString.equals(entry.getAttribute().toString()))
+            return true;
+
+        // If the passed in attribute isn't the preferred attribute, fetch it now.
+        AttributeCache.Entry preferred = entry.getAliasedEntry();
+
+        // Check that any of the preferred entry's aliases matches the expected value
+        Collection<AttributeCache.Entry> aliases = preferred != null ? preferred.getAliases() : entry.getAliases();
+        for (AttributeCache.Entry alias : aliases)
+        {
+            if (attrString.equals(alias.getAttribute().toString()))
+                return true;
+        }
+
+        // no match found
+        return false;
+    }
+
+    // Add the messages to either the Errors collection or the workspace's warning list
+    private void addCaseSensitiveWarnings(Errors errors, List<String> messages, boolean isCaseSensitive)
+    {
+        if (messages.isEmpty())
+            return;
+
+        if (isCaseSensitive)
+        {
+            for (String msg : messages)
+                errors.reject(ERROR_MSG, msg);
+        }
+        else
+        {
+            _object.getWarnings().addAll(messages);
         }
     }
 

--- a/flow/src/org/labkey/flow/controllers/attribute/AttributeController.java
+++ b/flow/src/org/labkey/flow/controllers/attribute/AttributeController.java
@@ -453,6 +453,74 @@ public class AttributeController extends BaseFlowController
         }
     }
 
+
+    public static class CaseSensitivityForm extends ReturnUrlForm
+    {
+        private boolean _caseSensitiveKeywords;
+        private boolean _caseSensitiveStatsAndGraphs;
+
+        public boolean isCaseSensitiveKeywords()
+        {
+            return _caseSensitiveKeywords;
+        }
+
+        public void setCaseSensitiveKeywords(boolean caseSensitiveKeywords)
+        {
+            _caseSensitiveKeywords = caseSensitiveKeywords;
+        }
+
+        public boolean isCaseSensitiveStatsAndGraphs()
+        {
+            return _caseSensitiveStatsAndGraphs;
+        }
+
+        public void setCaseSensitiveStatsAndGraphs(boolean caseSensitiveStatsAndGraphs)
+        {
+            _caseSensitiveStatsAndGraphs = caseSensitiveStatsAndGraphs;
+        }
+    }
+
+    @RequiresPermission(AdminPermission.class)
+    public class CaseSensitivityAction extends FormViewAction<CaseSensitivityForm>
+    {
+        @Override
+        public void validateCommand(CaseSensitivityForm form, Errors errors)
+        {
+        }
+
+        @Override
+        public ModelAndView getView(CaseSensitivityForm form, boolean reshow, BindException errors) throws Exception
+        {
+            FlowProtocol protocol = FlowProtocol.getForContainer(getContainer());
+            CaseSensitivityForm bean = new CaseSensitivityForm();
+            bean._caseSensitiveKeywords = protocol.isCaseSensitiveKeywords();
+            bean._caseSensitiveStatsAndGraphs = protocol.isCaseSensitiveStatsAndGraphs();
+
+            return new JspView<>("/org/labkey/flow/controllers/attribute/caseSensitivity.jsp", bean, errors);
+        }
+
+        @Override
+        public boolean handlePost(CaseSensitivityForm form, BindException errors) throws Exception
+        {
+            FlowProtocol protocol = FlowProtocol.getForContainer(getContainer());
+            protocol.setCaseSensitiveKeywords(getUser(), form.isCaseSensitiveKeywords());
+            protocol.setCaseSensitiveStatsAndGraphs(getUser(), form.isCaseSensitiveStatsAndGraphs());
+            return true;
+        }
+
+        @Override
+        public URLHelper getSuccessURL(CaseSensitivityForm form)
+        {
+            return form.getReturnActionURL(new ActionURL(ProtocolController.ShowProtocolAction.class, getContainer()));
+        }
+
+        @Override
+        public NavTree appendNavTrail(NavTree root)
+        {
+            return root.addChild("Case Sensitivity");
+        }
+    }
+
     @RequiresPermission(AdminPermission.class)
     public class MakePrimaryAction extends ConfirmAction<AttributeForm>
     {

--- a/flow/src/org/labkey/flow/controllers/attribute/caseSensitivity.jsp
+++ b/flow/src/org/labkey/flow/controllers/attribute/caseSensitivity.jsp
@@ -1,0 +1,44 @@
+<%
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+%>
+<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.flow.controllers.attribute.AttributeController" %>
+<%@ page import="org.labkey.flow.controllers.protocol.ProtocolController" %>
+<%@ page extends="org.labkey.api.jsp.FormPage" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+<%
+    AttributeController.CaseSensitivityForm form = (AttributeController.CaseSensitivityForm)getModelBean();
+%>
+
+When checked, an error will be raised when importing flow data containing an attribute
+that has different casing than an existing attribute.<br>
+When unchecked, attributes that differ by case is allowed.
+<p>
+<labkey:form method="POST" action="<%=new ActionURL(AttributeController.CaseSensitivityAction.class, getContainer())%>">
+    <labkey:checkbox name="caseSensitiveKeywords" id="caseSensitiveKeywords"
+                     checked="<%=form.isCaseSensitiveKeywords()%>" value="true"/>
+    <label for="caseSensitiveKeywords">Case-sensitive keywords</label><br>
+
+    <labkey:checkbox name="caseSensitiveStatsAndGraphs" id="caseSensitiveStatsAndGraphs"
+                     checked="<%=form.isCaseSensitiveStatsAndGraphs()%>" value="true"/>
+    <label for="caseSensitiveStatsAndGraphs">Case-sensitive statistic and graph specifications</label><br>
+
+    <br>
+
+    <%= button("Cancel").href(form.getReturnActionURL(new ActionURL(ProtocolController.ShowProtocolAction.class, getContainer()))) %>
+    <%= button("Submit").submit(true) %>
+</labkey:form>

--- a/flow/src/org/labkey/flow/controllers/protocol/showProtocol.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/showProtocol.jsp
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 %>
+<%@ page import="org.labkey.flow.controllers.attribute.AttributeController"%>
 <%@ page import="org.labkey.flow.controllers.protocol.ProtocolController"%>
-<%@ page import="org.labkey.flow.controllers.protocol.ProtocolController.JoinSampleSetAction"%>
+<%@ page import="org.labkey.flow.controllers.protocol.ProtocolController.JoinSampleSetAction" %>
 <%@ page import="org.labkey.flow.controllers.protocol.ProtocolForm" %>
-<%@ page import="org.labkey.flow.data.FlowProtocol" %>
 <%@ page import="org.labkey.flow.data.AttributeType" %>
-<%@ page import="org.labkey.flow.controllers.attribute.AttributeController" %>
+<%@ page import="org.labkey.flow.data.FlowProtocol" %>
 <%@ page extends="org.labkey.api.jsp.FormPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <% ProtocolForm form = (ProtocolForm) __form;
@@ -60,6 +60,7 @@
 </p>
 <p><b>Manage Names and Aliases</b><br>
     Create and remove names and aliases for Keywords, Statistics, and Graphs.<br>
+    <labkey:link href='<%=protocol.urlFor(AttributeController.CaseSensitivityAction.class).addReturnURL(getActionURL())%>' text="Case sensitivity"/><br/>
     <labkey:link href='<%=protocol.urlFor(AttributeController.DeleteUnusedAction.class).addReturnURL(getActionURL())%>' text="Delete Unused"/><br/>
     <labkey:link href='<%=protocol.urlFor(AttributeController.SummaryAction.class).addParameter(AttributeController.Param.type, AttributeType.keyword.name())%>' text="Manage Keywords"/><br/>
     <labkey:link href='<%=protocol.urlFor(AttributeController.SummaryAction.class).addParameter(AttributeController.Param.type, AttributeType.statistic.name())%>' text="Manage Statistics"/><br/>

--- a/flow/src/org/labkey/flow/data/AttributeType.java
+++ b/flow/src/org/labkey/flow/data/AttributeType.java
@@ -16,6 +16,7 @@
 
 package org.labkey.flow.data;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.TableInfo;
 import org.labkey.flow.analysis.web.GraphSpec;
 import org.labkey.flow.analysis.web.StatisticSpec;
@@ -61,6 +62,12 @@ public enum AttributeType
                 {
                     return AttributeCache.KEYWORDS;
                 }
+
+                @Override
+                public boolean isCaseSensitive(@NotNull FlowProtocol protocol)
+                {
+                    return protocol.isCaseSensitiveKeywords();
+                }
             },
 
     statistic
@@ -100,6 +107,12 @@ public enum AttributeType
                 {
                     return AttributeCache.STATS;
                 }
+
+                @Override
+                public boolean isCaseSensitive(@NotNull FlowProtocol protocol)
+                {
+                    return protocol.isCaseSensitiveStatsAndGraphs();
+                }
             },
     graph
             {
@@ -138,6 +151,12 @@ public enum AttributeType
                 {
                     return AttributeCache.GRAPHS;
                 }
+
+                @Override
+                public boolean isCaseSensitive(@NotNull FlowProtocol protocol)
+                {
+                    return protocol.isCaseSensitiveStatsAndGraphs();
+                }
             };
 
     /** Created a parsed representation of the attribute. */
@@ -154,6 +173,8 @@ public enum AttributeType
 
     /** The column name of original attribute id column on the value table. */
     public abstract String getValueTableOriginalAttributeIdColumn();
+
+    public abstract boolean isCaseSensitive(FlowProtocol protocol);
 
     public abstract AttributeCache getCache();
 

--- a/flow/src/org/labkey/flow/data/FlowProperty.java
+++ b/flow/src/org/labkey/flow/data/FlowProperty.java
@@ -28,6 +28,9 @@ abstract public class FlowProperty
     static public final SystemProperty FCSAnalysisFilter = new SystemProperty(PROPERTY_BASE + "FCSAnalysisFilter", PropertyType.STRING);
     static public final SystemProperty ICSMetadata = new SystemProperty(PROPERTY_BASE + "ICSMetadata", PropertyType.STRING);
 
+    static public final SystemProperty CaseSensitiveKeywords = new SystemProperty(PROPERTY_BASE + "CaseSensitiveKeywords", PropertyType.BOOLEAN);
+    static public final SystemProperty CaseSensitiveStatsAndGraphs = new SystemProperty(PROPERTY_BASE + "CaseSensitiveStatsAndGraphs", PropertyType.BOOLEAN);
+
     // Property on FlowRun ExpRun object: name of analysis engine (AnalysisEngine)
     static public final SystemProperty AnalysisEngine = new SystemProperty(PROPERTY_BASE + "AnalysisEngine", PropertyType.STRING);
 

--- a/flow/src/org/labkey/flow/data/FlowProtocol.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocol.java
@@ -96,7 +96,10 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
 {
     static private final Logger _log = Logger.getLogger(FlowProtocol.class);
     static protected final String DEFAULT_PROTOCOL_NAME = "Flow";
-    static final private String SAMPLESET_NAME = "Samples";
+    static private final String SAMPLESET_NAME = "Samples";
+
+    static private final boolean DEFAULT_CASE_SENSITIVE_KEYWORDS = true;
+    static private final boolean DEFAULT_CASE_SENSITIVE_STATS_AND_GRAPHS = false;
 
     static public String getProtocolLSIDPrefix()
     {
@@ -737,6 +740,28 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
     public void setFCSAnalysisFilter(User user, String value) throws SQLException
     {
         setProperty(user, FlowProperty.FCSAnalysisFilter.getPropertyDescriptor(), value);
+    }
+
+    public boolean isCaseSensitiveKeywords()
+    {
+        Boolean value = (Boolean)getProperty(FlowProperty.CaseSensitiveKeywords.getPropertyDescriptor());
+        return value != null ? value.booleanValue() : DEFAULT_CASE_SENSITIVE_KEYWORDS;
+    }
+
+    public void setCaseSensitiveKeywords(User user, boolean caseSensitive) throws SQLException
+    {
+        setProperty(user, FlowProperty.CaseSensitiveKeywords.getPropertyDescriptor(), caseSensitive);
+    }
+
+    public boolean isCaseSensitiveStatsAndGraphs()
+    {
+        Boolean value = (Boolean)getProperty(FlowProperty.CaseSensitiveStatsAndGraphs.getPropertyDescriptor());
+        return value != null ? value.booleanValue() : DEFAULT_CASE_SENSITIVE_STATS_AND_GRAPHS;
+    }
+
+    public void setCaseSensitiveStatsAndGraphs(User user, boolean caseSensitive) throws SQLException
+    {
+        setProperty(user, FlowProperty.CaseSensitiveStatsAndGraphs.getPropertyDescriptor(), caseSensitive);
     }
 
     public String getICSMetadataString()


### PR DESCRIPTION
- add setting to control case-sensitivity for flow attributes
- allow case-insensitive attributes when parsing the workspace and when creating new attributes