### PR TITLE
Migrate more attributes() usages to new simple setters

### DIFF
--- a/flow/src/org/labkey/flow/controllers/compensation/showCompensation.jsp
+++ b/flow/src/org/labkey/flow/controllers/compensation/showCompensation.jsp
@@ -189,7 +189,7 @@
     <%}%>
 </table>
 <% } %>
-<labkey:link href="<%=flowComp.urlDownload()%>" text="Download" rel="nofollow"/><br>
+<%=link("Download").href(flowComp.urlDownload()).nofollow()%><br>
 <%
     DiscussionService service = DiscussionService.get();
     if (service != null)

--- a/flow/src/org/labkey/flow/controllers/well/editWell.jsp
+++ b/flow/src/org/labkey/flow/controllers/well/editWell.jsp
@@ -137,7 +137,7 @@
             cancelURL = new ActionURL(form.editWellReturnUrl).toString();
         }
     %>
-    <labkey:button text="cancel" href="<%=text(cancelURL)%>"/>
+    <labkey:button text="cancel" href="<%=cancelURL%>"/>
 </labkey:form>
 <script type="text/javascript">
     (function ($) {


### PR DESCRIPTION
Slim down LinkTag and ButtonTag - remove unused (and NYI) setters plus corresponding handling

Remove double encoding (ButtonTag.setHref())