### PR TITLE
Issue 38649: flow: parse fractional seconds used in $BTIM keyword

### DIFF
--- a/flow/src/org/labkey/flow/FlowModule.java
+++ b/flow/src/org/labkey/flow/FlowModule.java
@@ -18,6 +18,7 @@ package org.labkey.flow;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AssayService;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.DefaultAuditProvider;
 import org.labkey.api.data.Container;
@@ -37,7 +38,6 @@ import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.QuerySchema;
 import org.labkey.api.reports.ReportService;
 import org.labkey.api.search.SearchService;
-import org.labkey.api.assay.AssayService;
 import org.labkey.api.usageMetrics.UsageMetricsService;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.UsageReportingLevel;
@@ -325,8 +325,7 @@ public class FlowModule extends SpringModule
                 FlowJoWorkspace.LoadTests.class,
                 AnalysisSerializer.TestCase.class,
                 CompensationMatrix.TestFCS.class,
-                ExportAnalysisManifest.TestCase.class,
-                FCSHeader.TestCase.class
+                ExportAnalysisManifest.TestCase.class
                 ));
     }
 

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -46,9 +46,9 @@ import org.labkey.api.exp.property.ExperimentProperty;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
+import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.UnexpectedException;
-import org.labkey.flow.analysis.model.FCSHeader;
 import org.labkey.flow.analysis.web.GraphSpec;
 import org.labkey.flow.analysis.web.StatisticSpec;
 import org.labkey.flow.data.AttributeType;
@@ -1600,7 +1600,7 @@ public class FlowManager
                     return;
                 }
 
-                long date = FCSHeader.parseDateTime(dateStr);
+                long date = DateUtil.parseDateTime(dateStr);
                 Date d = new Date(date);
 
                 // get the existing property if any


### PR DESCRIPTION
- parse fractional seconds as milliseconds
- move fix for Issue 36691 into DateUtil: trim millis to 3 decimal places