### PR TITLE
Item 6493: Add createDomain to MassSpecFractionsDomainKind

### DIFF
--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -232,7 +232,7 @@ public abstract class LuminexTest extends BaseWebDriverTest
             runPanel.addField("PositivityFoldChange").setLabel("Positivity Fold Change").setType(FieldDefinition.ColumnType.Integer);
 
             // add analyte property for tracking lot number
-            DomainFormPanel analytePanel = assayDesignerPage.goToFieldsPanel("Analyte");
+            DomainFormPanel analytePanel = assayDesignerPage.expandFieldsPanel("Analyte");
             analytePanel.addField("LotNumber").setLabel("Lot Number").setType(FieldDefinition.ColumnType.String);
             analytePanel.addField("NegativeControl").setLabel("Negative Control").setType(FieldDefinition.ColumnType.Boolean);
 

--- a/ms2/src/org/labkey/ms2/metadata/MassSpecFractionsDomainKind.java
+++ b/ms2/src/org/labkey/ms2/metadata/MassSpecFractionsDomainKind.java
@@ -17,15 +17,21 @@ package org.labkey.ms2.metadata;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.exp.DomainDescriptor;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.assay.AssayDomainKind;
+import org.labkey.api.exp.OntologyManager;
+import org.labkey.api.exp.TemplateInfo;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.PropertyService;
+import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.security.User;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.experiment.api.SampleSetDomainKind;
 
+import java.util.Map;
 import java.util.Set;
 
 public class MassSpecFractionsDomainKind extends SampleSetDomainKind
@@ -115,5 +121,15 @@ public class MassSpecFractionsDomainKind extends SampleSetDomainKind
     public void appendNavTrail(NavTree root, Container c, User user)
     {
         _assayDelegate.appendNavTrail(root, c, user);
+    }
+
+    @Override
+    public Domain createDomain(GWTDomain domain, Map<String, Object> arguments, Container container, User user, @Nullable TemplateInfo templateInfo)
+    {
+        DomainDescriptor dd = OntologyManager.ensureDomainDescriptor(domain.getDomainURI(), domain.getName(), container);
+        dd = dd.edit().setDescription(domain.getDescription()).build();
+        OntologyManager.updateDomainDescriptor(dd);
+
+        return PropertyService.get().getDomain(container, dd.getDomainURI());
     }
 }


### PR DESCRIPTION
This was initially in AssayService but moving to domain kinds so assay creation can use DomainUtil validation which calls createDomain in the domain kinds.