### PR TITLE
Issue 39223: conditional format filters don't support ~me~ value replacement

### DIFF
--- a/flow/src/org/labkey/flow/data/FlowProtocol.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocol.java
@@ -682,6 +682,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
         return (String) getProperty(FlowProperty.FCSAnalysisFilter);
     }
 
+    // Filter columns are relative to the FCSFiles table
     public SimpleFilter getFCSAnalysisFilter()
     {
         SimpleFilter ret = new SimpleFilter();

--- a/flow/src/org/labkey/flow/script/AbstractExternalAnalysisJob.java
+++ b/flow/src/org/labkey/flow/script/AbstractExternalAnalysisJob.java
@@ -24,6 +24,7 @@ import org.fhcrc.cpas.flow.script.xml.ScriptDocument;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -256,7 +257,7 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
         }
     }
 
-    protected boolean matchesFilter(SimpleFilter filter, String sampleName, Map<String, String> keywords)
+    protected boolean matchesFilter(TableInfo fcsFilesTable, SimpleFilter filter, String sampleName, Map<String, String> keywords)
     {
         // Build a map that uses FieldKey strings as keys to represent a fake row of the FCSFiles table.
         // The pairs in the map are those allowed by the ProtocolForm.getKeywordFieldMap().
@@ -271,7 +272,7 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
             fakeRow.put(new FieldKey(keyKeyword, keyword), keywordValue);
         }
 
-        return filter.meetsCriteria(fakeRow);
+        return filter.meetsCriteria(fcsFilesTable, fakeRow);
     }
 
     protected abstract FlowRun createExperimentRun() throws Exception;

--- a/flow/src/org/labkey/flow/script/WorkspaceJob.java
+++ b/flow/src/org/labkey/flow/script/WorkspaceJob.java
@@ -23,7 +23,9 @@ import org.fhcrc.cpas.flow.script.xml.ScriptDef;
 import org.fhcrc.cpas.flow.script.xml.ScriptDocument;
 import org.labkey.api.collections.CaseInsensitiveArrayListValuedMap;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpProtocolApplication;
@@ -53,6 +55,8 @@ import org.labkey.flow.persist.AttributeSet;
 import org.labkey.flow.persist.AttributeSetHelper;
 import org.labkey.flow.persist.InputRole;
 import org.labkey.flow.persist.ObjectType;
+import org.labkey.flow.query.FlowSchema;
+import org.labkey.flow.query.FlowTableType;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -198,11 +202,15 @@ public class WorkspaceJob extends AbstractExternalAnalysisJob
         {
             info("Using protocol FCS analysis filter: " + analysisFilter.getFilterText());
 
+            User user = User.getSearchUser();
+            Container c = flowProtocol.getContainer();
+            TableInfo fcsFilesTable = new FlowSchema(user, c).getTable(FlowTableType.FCSFiles, ContainerFilter.CURRENT);
+
             List<String> filteredSampleIDs = new ArrayList<>(sampleIDs.size());
             for (String sampleID : sampleIDs)
             {
                 Workspace.SampleInfo sampleInfo = workspace.getSample(sampleID);
-                if (matchesFilter(analysisFilter, sampleInfo.getLabel(), sampleInfo.getKeywords()))
+                if (matchesFilter(fcsFilesTable, analysisFilter, sampleInfo.getLabel(), sampleInfo.getKeywords()))
                 {
                     filteredSampleIDs.add(sampleID);
                 }


### PR DESCRIPTION
- validate conditional formats when saving domain and before rendering DataRegion
- support '~me~' in conditional filter value for user columns
- support relative date parsing of conditional format filter value
- use date parsing when matching BETWEEN filter of a conditional format of a date column
  e.g, to highlight dates for today use a conditional format like query.dateColumn~between=-0d,+0d