### PR TITLE
Prevent race condition when editing guide set details

### DIFF
--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetDisablingTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetDisablingTest.java
@@ -255,7 +255,7 @@ public final class LuminexGuideSetDisablingTest extends LuminexTest
     {
         // Wait for grid to refresh before checking QC flags
         doAndWaitForElementToRefresh(() -> click(Ext4Helper.Locators.windowButton(GUIDE_SET_WINDOW_NAME, "Save")),
-                Locator.tagWithId("div", "trackingDataPanel").append(Locator.byClass("x-grid3-body")), shortWait());
+                Locator.tagWithId("div", "trackingDataPanel").append(Locator.byClass("x-grid3-row-table")), shortWait());
         _guideSetHelper.waitForGuideSetExtMaskToDisappear();
     }
 


### PR DESCRIPTION
Accidentally committed my first attempt directly to `develop`. This passes locally.