### PR TITLE
QueryView.setShowDeleteButtonConfirmationText refactor

### DIFF
--- a/flow/src/org/labkey/flow/webparts/AnalysesWebPart.java
+++ b/flow/src/org/labkey/flow/webparts/AnalysesWebPart.java
@@ -45,6 +45,8 @@ public class AnalysesWebPart extends FlowQueryView
         setSettings(settings);
         
         setTitle("Flow Analyses");
+        // Use default delete button, but without showing the confirmation text -- DeleteSelectedExperimentsAction will show a confirmation page.
+        setShowDeleteButtonConfirmationText(false);
         setShowExportButtons(false);
         setShowPagination(false);
         // Workaround for "Issue 18903: can't change query on showRuns.view" -- for now, just don't display the [details] link which includes the returnURL parameter.
@@ -83,15 +85,4 @@ public class AnalysesWebPart extends FlowQueryView
         }
     }
 
-    @Override
-    public ActionButton createDeleteButton()
-    {
-        // Use default delete button, but without showing the confirmation text -- DeleteSelectedExperimentsAction will show a confirmation page.
-        ActionButton button = super.createDeleteButton();
-        if (button != null)
-        {
-            button.setRequiresSelection(true);
-        }
-        return button;
-    }
 }


### PR DESCRIPTION
- add QueryView.setShowDeleteButtonConfirmationText() to avoid overriding createDeleteButton
- switch ProtocolWebPart to use exp.Protocols query table
- only show name, created, description as default columns for exp.Protocols
- add RunCount column to exp.Protocols query table
- show fewer runs and protocols on experiment-begin.view page