### PR TITLE
Issue 39676: provenance: exception publishing assay for unsupported assays

### DIFF
--- a/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
+++ b/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
@@ -142,7 +142,7 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
 
     public ElisaAssayProvider()
     {
-        super("ElisaAssayProtocol", "ElisaAssayRun", (AssayDataType) ExperimentService.get().getDataType(ElisaDataHandler.NAMESPACE), ModuleLoader.getInstance().getModule(ElisaModule.class));
+        super("ElisaAssayProtocol", "ElisaAssayRun", "Elisa" + RESULT_LSID_PREFIX_PART, (AssayDataType) ExperimentService.get().getDataType(ElisaDataHandler.NAMESPACE), ModuleLoader.getInstance().getModule(ElisaModule.class));
     }
 
     @NotNull
@@ -154,7 +154,9 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
                 protocol,
                 FieldKey.fromParts(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY, "Property"),
                 FieldKey.fromParts("Run"),
-                FieldKey.fromParts(AbstractTsvAssayProvider.ROW_ID_COLUMN_NAME));
+                FieldKey.fromParts(AbstractTsvAssayProvider.ROW_ID_COLUMN_NAME),
+                AbstractTsvAssayProvider.ROW_ID_COLUMN_NAME,
+                FieldKey.fromParts("LSID"));
     }
 
     @Override

--- a/elisa/src/org/labkey/elisa/ElisaDataHandler.java
+++ b/elisa/src/org/labkey/elisa/ElisaDataHandler.java
@@ -19,6 +19,20 @@ package org.labkey.elisa;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.math3.stat.regression.SimpleRegression;
 import org.apache.log4j.Logger;
+import org.labkey.api.assay.AbstractAssayTsvDataHandler;
+import org.labkey.api.assay.AssayDataType;
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssayRunUploadContext;
+import org.labkey.api.assay.AssayService;
+import org.labkey.api.assay.AssayUploadXarContext;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateBasedAssayProvider;
+import org.labkey.api.assay.plate.PlateReader;
+import org.labkey.api.assay.plate.PlateService;
+import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Position;
+import org.labkey.api.assay.plate.Well;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.XarContext;
@@ -26,24 +40,11 @@ import org.labkey.api.exp.api.DataType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ProvenanceService;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.qc.DataLoaderSettings;
 import org.labkey.api.qc.TransformDataHandler;
 import org.labkey.api.query.ValidationException;
-import org.labkey.api.assay.plate.Plate;
-import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.PlateTemplate;
-import org.labkey.api.assay.plate.Position;
-import org.labkey.api.assay.plate.Well;
-import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.AbstractAssayTsvDataHandler;
-import org.labkey.api.assay.AssayDataType;
-import org.labkey.api.assay.AssayProvider;
-import org.labkey.api.assay.AssayRunUploadContext;
-import org.labkey.api.assay.AssayService;
-import org.labkey.api.assay.AssayUploadXarContext;
-import org.labkey.api.assay.plate.PlateBasedAssayProvider;
-import org.labkey.api.assay.plate.PlateReader;
 import org.labkey.api.util.FileType;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.elisa.actions.ElisaRunUploadForm;
@@ -161,7 +162,11 @@ public class ElisaDataHandler extends AbstractAssayTsvDataHandler implements Tra
                                 {
                                     ExpMaterial material = materialMap.get(specimenGroupMap.get(position));
                                     if (material != null)
+                                    {
                                         row.put(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY, material.getLSID());
+                                        // TODO: Support adding the material to existing provenance inputs on the row, if any
+                                        row.put(ProvenanceService.PROVENANCE_INPUT_PROPERTY, List.of(material.getLSID()));
+                                    }
                                 }
 
                                 if (conc != -1)
@@ -198,7 +203,11 @@ public class ElisaDataHandler extends AbstractAssayTsvDataHandler implements Tra
                                     {
                                         ExpMaterial material = materialMap.get(specimenGroupMap.get(position));
                                         if (material != null)
+                                        {
                                             row.put(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY, material.getLSID());
+                                            // TODO: Support adding the material to existing provenance inputs on the row, if any
+                                            row.put(ProvenanceService.PROVENANCE_INPUT_PROPERTY, List.of(material.getLSID()));
+                                        }
                                     }
 
                                     // compute the concentration

--- a/elisa/src/org/labkey/elisa/ElisaDataHandler.java
+++ b/elisa/src/org/labkey/elisa/ElisaDataHandler.java
@@ -93,6 +93,7 @@ public class ElisaDataHandler extends AbstractAssayTsvDataHandler implements Tra
     @Override
     public Map<DataType, List<Map<String, Object>>> getValidationDataMap(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context, DataLoaderSettings settings) throws ExperimentException
     {
+        final ProvenanceService pvs = ProvenanceService.get();
         List<Map<String, Object>> results = new ArrayList<>();
         ExpProtocol protocol = data.getRun().getProtocol();
         Container container = data.getContainer();
@@ -165,7 +166,8 @@ public class ElisaDataHandler extends AbstractAssayTsvDataHandler implements Tra
                                     {
                                         row.put(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY, material.getLSID());
                                         // TODO: Support adding the material to existing provenance inputs on the row, if any
-                                        row.put(ProvenanceService.PROVENANCE_INPUT_PROPERTY, List.of(material.getLSID()));
+                                        if (pvs != null)
+                                            row.put(ProvenanceService.PROVENANCE_INPUT_PROPERTY, List.of(material.getLSID()));
                                     }
                                 }
 
@@ -206,7 +208,8 @@ public class ElisaDataHandler extends AbstractAssayTsvDataHandler implements Tra
                                         {
                                             row.put(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY, material.getLSID());
                                             // TODO: Support adding the material to existing provenance inputs on the row, if any
-                                            row.put(ProvenanceService.PROVENANCE_INPUT_PROPERTY, List.of(material.getLSID()));
+                                            if (pvs != null)
+                                                row.put(ProvenanceService.PROVENANCE_INPUT_PROPERTY, List.of(material.getLSID()));
                                         }
                                     }
 

--- a/elispotassay/src/org/labkey/elispot/ElispotAssayProvider.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotAssayProvider.java
@@ -168,7 +168,7 @@ public class ElispotAssayProvider extends AbstractPlateBasedAssayProvider implem
 
     public ElispotAssayProvider()
     {
-        super("ElispotAssayProtocol", "ElispotAssayRun", (AssayDataType) ExperimentService.get().getDataType(ElispotDataHandler.NAMESPACE), ModuleLoader.getInstance().getModule(ElispotModule.class));
+        super("ElispotAssayProtocol", "ElispotAssayRun", null, (AssayDataType) ExperimentService.get().getDataType(ElispotDataHandler.NAMESPACE), ModuleLoader.getInstance().getModule(ElispotModule.class));
     }
 
     public ExpData getDataForDataRow(Object dataRowId, ExpProtocol protocol)
@@ -210,7 +210,9 @@ public class ElispotAssayProvider extends AbstractPlateBasedAssayProvider implem
                 protocol,
                 FieldKey.fromParts(ElispotDataHandler.ELISPOT_INPUT_MATERIAL_DATA_PROPERTY, "Property"),
                 FieldKey.fromParts("Run"),
-                FieldKey.fromParts("RowId"));
+                FieldKey.fromParts("RowId"),
+                "RowId",
+                null);
     }
 
     public Domain getResultsDomain(ExpProtocol protocol)

--- a/nab/src/org/labkey/nab/NabAssayProvider.java
+++ b/nab/src/org/labkey/nab/NabAssayProvider.java
@@ -19,15 +19,32 @@ package org.labkey.nab;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.assay.AssayDataType;
+import org.labkey.api.assay.AssayPipelineProvider;
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssayProviderSchema;
+import org.labkey.api.assay.AssayRunCreator;
+import org.labkey.api.assay.AssaySchema;
+import org.labkey.api.assay.AssayService;
+import org.labkey.api.assay.AssayUrls;
+import org.labkey.api.assay.actions.AssayRunUploadForm;
+import org.labkey.api.assay.actions.PlateUploadForm;
 import org.labkey.api.assay.dilution.AbstractDilutionAssayProvider;
 import org.labkey.api.assay.dilution.DilutionDataHandler;
 import org.labkey.api.assay.nab.NabSpecimen;
+import org.labkey.api.assay.plate.PlateSamplePropertyHelper;
+import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableSelector;
+import org.labkey.api.exp.IdentifiableBase;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.LsidManager;
+import org.labkey.api.exp.OntologyManager;
+import org.labkey.api.exp.OntologyObject;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -42,19 +59,7 @@ import org.labkey.api.pipeline.PipelineProvider;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.assay.plate.PlateTemplate;
-import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.actions.AssayRunUploadForm;
-import org.labkey.api.assay.actions.PlateUploadForm;
-import org.labkey.api.assay.AssayDataType;
-import org.labkey.api.assay.AssayPipelineProvider;
-import org.labkey.api.assay.AssayProvider;
-import org.labkey.api.assay.AssayProviderSchema;
-import org.labkey.api.assay.AssayRunCreator;
-import org.labkey.api.assay.AssaySchema;
-import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.study.assay.ParticipantVisitResolverType;
-import org.labkey.api.assay.plate.PlateSamplePropertyHelper;
 import org.labkey.api.study.assay.SampleMetadataInputFormat;
 import org.labkey.api.study.assay.ThawListResolverType;
 import org.labkey.api.util.PageFlowUtil;
@@ -103,12 +108,13 @@ public class NabAssayProvider extends AbstractDilutionAssayProvider<NabRunUpload
 
     public NabAssayProvider()
     {
-        super(NAB_ASSAY_PROTOCOL, NAB_RUN_LSID_PREFIX, SinglePlateNabDataHandler.NAB_DATA_TYPE, ModuleLoader.getInstance().getModule(NabModule.class));
+        // NOTE: Can't use NAB_DATA_ROW_LSID_PREFIX for assayResultRowLsid as it's not unique for each row in the Nab results table
+        super(NAB_ASSAY_PROTOCOL, NAB_RUN_LSID_PREFIX, null, SinglePlateNabDataHandler.NAB_DATA_TYPE, ModuleLoader.getInstance().getModule(NabModule.class));
     }
 
-    public NabAssayProvider(String protocolLSIDPrefix, String runLSIDPrefix, AssayDataType dataType)
+    public NabAssayProvider(String protocolLSIDPrefix, String runLSIDPrefix, String resultRowLSIDPrefix, AssayDataType dataType)
     {
-        super(protocolLSIDPrefix, runLSIDPrefix, dataType, ModuleLoader.getInstance().getModule(NabModule.class));
+        super(protocolLSIDPrefix, runLSIDPrefix, resultRowLSIDPrefix, dataType, ModuleLoader.getInstance().getModule(NabModule.class));
     }
 
     @Override

--- a/nab/src/org/labkey/nab/multiplate/CrossPlateDilutionNabAssayProvider.java
+++ b/nab/src/org/labkey/nab/multiplate/CrossPlateDilutionNabAssayProvider.java
@@ -43,7 +43,7 @@ public class CrossPlateDilutionNabAssayProvider extends HighThroughputNabAssayPr
 
     public CrossPlateDilutionNabAssayProvider()
     {
-        super(NAB_ASSAY_PROTOCOL, NAB_RUN_LSID_PREFIX, CrossPlateDilutionNabDataHandler.NAB_HIGH_THROUGHPUT_DATA_TYPE);
+        super(NAB_ASSAY_PROTOCOL, NAB_RUN_LSID_PREFIX, null, CrossPlateDilutionNabDataHandler.NAB_HIGH_THROUGHPUT_DATA_TYPE);
     }
 
     @Override

--- a/nab/src/org/labkey/nab/multiplate/HighThroughputNabAssayProvider.java
+++ b/nab/src/org/labkey/nab/multiplate/HighThroughputNabAssayProvider.java
@@ -37,9 +37,9 @@ import java.util.List;
  */
 public abstract class HighThroughputNabAssayProvider extends NabAssayProvider
 {
-    public HighThroughputNabAssayProvider(String protocolLSIDPrefix, String runLSIDPrefix, AssayDataType dataType)
+    public HighThroughputNabAssayProvider(String protocolLSIDPrefix, String runLSIDPrefix, String resultLSIDPrefix, AssayDataType dataType)
     {
-        super(protocolLSIDPrefix, runLSIDPrefix, dataType);
+        super(protocolLSIDPrefix, runLSIDPrefix, resultLSIDPrefix, dataType);
     }
 
     public abstract String getName();

--- a/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabAssayProvider.java
+++ b/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabAssayProvider.java
@@ -56,7 +56,7 @@ public class SinglePlateDilutionNabAssayProvider extends HighThroughputNabAssayP
 
     public SinglePlateDilutionNabAssayProvider()
     {
-        super(NAB_ASSAY_PROTOCOL, NAB_RUN_LSID_PREFIX, SinglePlateDilutionNabDataHandler.SINGLE_PLATE_DILUTION_DATA_TYPE);
+        super(NAB_ASSAY_PROTOCOL, NAB_RUN_LSID_PREFIX, null, SinglePlateDilutionNabDataHandler.SINGLE_PLATE_DILUTION_DATA_TYPE);
     }
 
     @Override

--- a/nab/src/org/labkey/nab/query/NabRunDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabRunDataTable.java
@@ -227,12 +227,11 @@ public class NabRunDataTable extends NabBaseTable
         Collection<PropertyDescriptor> pds = getExistingDataProperties(protocol);
 
         var objectUriColumn = addWrapColumn(_rootTable.getColumn("ObjectUri"));
-        objectUriColumn.setIsUnselectable(true);
         objectUriColumn.setHidden(true);
+
         var rowIdColumn = addWrapColumn(_rootTable.getColumn("RowId"));
         rowIdColumn.setKeyField(true);
         rowIdColumn.setHidden(true);
-        rowIdColumn.setIsUnselectable(true);
 
         // add object ID again, this time as a lookup to a virtual property table that contains our selected NAB properties:
 


### PR DESCRIPTION
- don't blow up when publishing to study for assays that doesn't support provenance
- add provenance support on assay import and study publish for elisa
- delete study publish run when all referenced LSIDs are deleted