### PR TITLE
Remove tests from 'FileBrowser' suite

### DIFF
--- a/ms2/test/src/org/labkey/test/tests/ms2/CometTest.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/CometTest.java
@@ -23,7 +23,6 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.DailyB;
-import org.labkey.test.categories.FileBrowser;
 import org.labkey.test.categories.MS2;
 import org.labkey.test.ms2.AbstractMS2SearchEngineTest;
 
@@ -31,7 +30,7 @@ import java.io.File;
 
 import static org.junit.Assert.fail;
 
-@Category({MS2.class, DailyB.class, FileBrowser.class})
+@Category({MS2.class, DailyB.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
 public class CometTest extends AbstractMS2SearchEngineTest
 {

--- a/ms2/test/src/org/labkey/test/tests/ms2/PipelineTest.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/PipelineTest.java
@@ -22,7 +22,6 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.BVT;
-import org.labkey.test.categories.FileBrowser;
 import org.labkey.test.components.dumbster.EmailRecordTable;
 import org.labkey.test.ms2.MS2PipelineFolder;
 import org.labkey.test.ms2.params.MS2EmailSuccessParams;
@@ -38,7 +37,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({BVT.class, FileBrowser.class})
+@Category({BVT.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
 public class PipelineTest extends PipelineWebTestBase
 {

--- a/ms2/test/src/org/labkey/test/tests/ms2/SequestImportTest.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/SequestImportTest.java
@@ -22,7 +22,6 @@ import org.labkey.test.Locator;
 import org.labkey.test.ModulePropertyValue;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.DailyB;
-import org.labkey.test.categories.FileBrowser;
 import org.labkey.test.categories.MS2;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.util.DataRegionTable;
@@ -33,7 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-@Category({DailyB.class, MS2.class, FileBrowser.class})
+@Category({DailyB.class, MS2.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
 public class SequestImportTest extends BaseWebDriverTest
 {


### PR DESCRIPTION
These tests interact with the file browser but don't provide interesting coverage of it