### PR TITLE
Re-enable simple Mascot client junit test

### DIFF
--- a/ms2/src/org/labkey/ms2/MS2Module.java
+++ b/ms2/src/org/labkey/ms2/MS2Module.java
@@ -336,7 +336,7 @@ public class MS2Module extends SpringModule implements ProteomicsModule
         return Set.of(
             Comet2014ParamsBuilder.FullParseTestCase.class,
             Comet2015ParamsBuilder.FullParseTestCase.class,
-//            MascotClientImpl.TestCase.class,
+            MascotClientImpl.TestCase.class,
             MS2Controller.TestCase.class,
             ThermoSequestParamsBuilder.TestCase.class
         );


### PR DESCRIPTION
#### Rationale
`MascotClientImpl.TestCase` tests a small fraction of the Mascot integration functionality, but Josh and I decided it's better than nothing.

#### Changes
* Re-enable MascotClientImpl.TestCase
