### PR TITLE
Issue 38592: Rename webapps/Experiment directory to have same casing as resources directory

### DIFF
--- a/luminex/src/org/labkey/luminex/view/leveyJenningsReport.jsp
+++ b/luminex/src/org/labkey/luminex/view/leveyJenningsReport.jsp
@@ -32,7 +32,7 @@
     public void addClientDependencies(ClientDependencies dependencies)
     {
         dependencies.add("luminexLeveyJennings");
-        dependencies.add("Experiment/QCFlagToggleWindow.js");
+        dependencies.add("experiment/QCFlagToggleWindow.js");
         dependencies.add("fileAddRemoveIcon.css");
     }
 %>

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
@@ -280,7 +280,7 @@ public final class LuminexGuideSetTest extends LuminexTest
         // verify that the PDF of curves file was generated along with the xls file and the Rout file
         DataRegionTable table = new DataRegionTable("Runs", getDriver());
         table.setFilter("Name", "Equals", "Guide Set plate " + index);
-        clickAndWait(Locator.tagWithAttribute("img", "src", "/labkey/Experiment/images/graphIcon.gif"));
+        clickAndWait(Locator.tagWithAttribute("img", "src", "/labkey/experiment/images/graphIcon.gif"));
         clickAndWait(Locator.linkWithText("Text View"));
         waitForElement(Locator.css(".labkey-protocol-applications")); // bottom section of the "Text View" tab for the run details page
         waitForElements(Locator.linkWithText("Guide Set plate " + index + ".Standard1_Control_Curves_4PL.pdf"), 3);

--- a/ms2/test/src/org/labkey/test/tests/ms2/MS2Test.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/MS2Test.java
@@ -803,7 +803,7 @@ public class MS2Test extends AbstractMS2ImportTest
     {
         log("Test creating run groups");
         navigateToFolder(FOLDER_NAME);
-        clickAndWait(Locator.linkWithImage(WebTestHelper.getContextPath() + "/Experiment/images/graphIcon.gif"));
+        clickAndWait(Locator.linkWithImage(WebTestHelper.getContextPath() + "/experiment/images/graphIcon.gif"));
         clickAndWait(Locator.id("expandCollapse-experimentRunGroup"), 0);
         clickButton("Create new group");
         setFormElement(Locator.name("name"), RUN_GROUP1_NAME1);


### PR DESCRIPTION
#### Rationale
Though the renaming of these paths is not strictly necessary it will avoid confusion and make searching easier for references to the things in the webapps/experiment directory easier.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1140
* https://github.com/LabKey/testAutomation/pull/328

#### Changes
* Rename paths that reference resources from experiment, just to avoid confusion