### PR TITLE
Migrate NavTree appendNavTrail() to void addNavTrail()

### DIFF
--- a/elispotassay/src/org/labkey/elispot/ElispotController.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotController.java
@@ -96,9 +96,8 @@ public class ElispotController extends SpringActionController
             return HttpView.redirect(PageFlowUtil.urlProvider(AssayUrls.class).getAssayListURL(getContainer()));
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -184,7 +183,7 @@ public class ElispotController extends SpringActionController
             return false;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             String title;
 
@@ -201,8 +200,6 @@ public class ElispotController extends SpringActionController
             root.addChild(_protocol.getName() + " Runs", runListURL);
             root.addChild(_protocol.getName() + " Data", runDataURL);
             root.addChild(title);
-
-            return root;
         }
     }
 

--- a/flow/src/org/labkey/flow/controllers/BaseFlowController.java
+++ b/flow/src/org/labkey/flow/controllers/BaseFlowController.java
@@ -96,13 +96,13 @@ public abstract class BaseFlowController extends SpringActionController
 
     // override to append root nav to all paths
     @Override
-    protected void appendNavTrail(Controller action, NavTree root)
+    protected void addNavTrail(Controller action, NavTree root)
     {
         PageConfig page = null;
         if (action instanceof HasPageConfig)
             page = ((HasPageConfig)action).getPageConfig();
         root.addChild(getFlowNavStart(page, getViewContext()));
-        super.appendNavTrail(action, root);
+        super.addNavTrail(action, root);
     }
 
     public NavTree appendFlowNavTrail(PageConfig page, NavTree root, FlowObject object, String title)

--- a/flow/src/org/labkey/flow/controllers/BaseFlowController.java
+++ b/flow/src/org/labkey/flow/controllers/BaseFlowController.java
@@ -105,7 +105,7 @@ public abstract class BaseFlowController extends SpringActionController
         super.addNavTrail(action, root);
     }
 
-    public NavTree appendFlowNavTrail(PageConfig page, NavTree root, FlowObject object, String title)
+    public void appendFlowNavTrail(PageConfig page, NavTree root, FlowObject object, String title)
     {
         ArrayList<NavTree> children = new ArrayList<>();
         while (object != null)
@@ -120,8 +120,6 @@ public abstract class BaseFlowController extends SpringActionController
 
         if (page.getHelpTopic() == HelpTopic.DEFAULT_HELP_TOPIC)
             page.setHelpTopic(getHelpTopic());
-
-        return root;
     }
 
 
@@ -156,9 +154,9 @@ public abstract class BaseFlowController extends SpringActionController
         protected abstract String getPageTitle();
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, _form.getFlowObject(), getPageTitle());
+            appendFlowNavTrail(getPageConfig(), root, _form.getFlowObject(), getPageTitle());
         }
     }
 
@@ -175,9 +173,9 @@ public abstract class BaseFlowController extends SpringActionController
         protected abstract String getPageTitle();
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, _form.getFlowObject(), getPageTitle());
+            appendFlowNavTrail(getPageConfig(), root, _form.getFlowObject(), getPageTitle());
         }
     }
 

--- a/flow/src/org/labkey/flow/controllers/FlowController.java
+++ b/flow/src/org/labkey/flow/controllers/FlowController.java
@@ -110,9 +110,9 @@ public class FlowController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return getFlowNavStart(getPageConfig(), getViewContext());
+            getFlowNavStart(getPageConfig(), getViewContext());
         }
     }
 
@@ -180,7 +180,7 @@ public class FlowController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if (experiment == null)
                 root.addChild("All Analysis Folders", getActionURL());
@@ -191,7 +191,6 @@ public class FlowController extends BaseFlowController
                 root.addChild(run.getLabel(), run.urlShow());
 
             root.addChild(query);
-            return root;
         }
     }
 
@@ -272,12 +271,10 @@ public class FlowController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Status File", new ActionURL(ShowStatusJobAction.class, getContainer()));
-            return root;
         }
-
     }
 
     public static class StatusJobForm
@@ -372,11 +369,10 @@ public class FlowController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             ActionURL jobsURL = PageFlowUtil.urlProvider(PipelineStatusUrls.class).urlBegin(getContainer());
             root.addChild("Error Cancelling Job", jobsURL);
-            return root;
         }
     }
 
@@ -491,10 +487,9 @@ public class FlowController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("New Folder", new ActionURL(NewFolderAction.class, getContainer()));
-            return root;
         }
     }
 
@@ -552,10 +547,9 @@ public class FlowController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Flow Module Settings");
-            return root;
         }
     }
 
@@ -571,9 +565,8 @@ public class FlowController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -594,9 +587,8 @@ public class FlowController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 

--- a/flow/src/org/labkey/flow/controllers/ReportsController.java
+++ b/flow/src/org/labkey/flow/controllers/ReportsController.java
@@ -106,10 +106,10 @@ public class ReportsController extends BaseFlowController
             return new BeginView();
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        @Override
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Reports", new ActionURL(BeginAction.class, getContainer()));
-            return root;
         }
     }
 
@@ -189,12 +189,11 @@ public class ReportsController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            new BeginAction(getViewContext()).appendNavTrail(root);
+            new BeginAction(getViewContext()).addNavTrail(root);
             if (r != null)
                 root.addChild("Create new report: " + r.getTypeDescription());
-            return root;
         }
     }
     
@@ -207,12 +206,12 @@ public class ReportsController extends BaseFlowController
             r = getReport(getViewContext(), form);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        @Override
+        public void addNavTrail(NavTree root)
         {
-            new BeginAction(getViewContext()).appendNavTrail(root);
+            new BeginAction(getViewContext()).addNavTrail(root);
             if (r != null)
                 root.addChild("Edit report: " + r.getDescriptor().getReportName());
-            return root;
         }
     }
 
@@ -295,12 +294,11 @@ public class ReportsController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            new BeginAction(getViewContext()).appendNavTrail(root);
+            new BeginAction(getViewContext()).addNavTrail(root);
             if (r != null)
             root.addChild("Copy report: " + r.getDescriptor().getReportName());
-            return root;
         }
     }
 
@@ -409,11 +407,10 @@ public class ReportsController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            new BeginAction(getViewContext()).appendNavTrail(root);
+            new BeginAction(getViewContext()).addNavTrail(root);
             root.addChild("View report: " + r.getDescriptor().getReportName());
-            return root;
         }
     }
 

--- a/flow/src/org/labkey/flow/controllers/attribute/AttributeController.java
+++ b/flow/src/org/labkey/flow/controllers/attribute/AttributeController.java
@@ -129,21 +129,19 @@ public class AttributeController extends BaseFlowController
         }
     }
 
-    public NavTree appendAttributeNavTrail(PageConfig pageConfig, NavTree root, AttributeType type, String title)
+    public void appendAttributeNavTrail(PageConfig pageConfig, NavTree root, AttributeType type, String title)
     {
         FlowProtocol protocol = FlowProtocol.getForContainer(getContainer());
-        NavTree tree = appendFlowNavTrail(pageConfig, root, protocol, null);
+        appendFlowNavTrail(pageConfig, root, protocol, null);
 
         if (type != null)
         {
             ActionURL summaryURL = new ActionURL(SummaryAction.class, getContainer()).addParameter(Param.type.name(), type.name());
-            tree.addChild(StringUtils.capitalize(type.name() + " Summary"), summaryURL);
+            root.addChild(StringUtils.capitalize(type.name() + " Summary"), summaryURL);
         }
 
         if (title != null)
-            tree.addChild(title);
-
-        return tree;
+            root.addChild(title);
     }
 
     @RequiresPermission(AdminPermission.class)
@@ -158,9 +156,9 @@ public class AttributeController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendAttributeNavTrail(getPageConfig(), root, _type, null);
+            appendAttributeNavTrail(getPageConfig(), root, _type, null);
         }
     }
 
@@ -180,11 +178,11 @@ public class AttributeController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             AttributeType type = _entry == null ? null : _entry.getType();
             String title = _entry == null ? null : (_entry.getName() + " Details");
-            return appendAttributeNavTrail(getPageConfig(), root, type, title);
+            appendAttributeNavTrail(getPageConfig(), root, type, title);
         }
     }
 
@@ -276,11 +274,11 @@ public class AttributeController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             AttributeType type = _entry == null ? null : _entry.getType();
             String title = _entry == null ? null : ("Edit " + _entry.getName());
-            return appendAttributeNavTrail(getPageConfig(), root, type, title);
+            appendAttributeNavTrail(getPageConfig(), root, type, title);
         }
     }
 
@@ -370,11 +368,11 @@ public class AttributeController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             AttributeType type = _entry == null ? null : _entry.getType();
             String title = _entry == null ? null : ("Create Alias for " + _entry.getName());
-            return appendAttributeNavTrail(getPageConfig(), root, type, title);
+            appendAttributeNavTrail(getPageConfig(), root, type, title);
         }
     }
 
@@ -515,9 +513,9 @@ public class AttributeController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Case Sensitivity");
+            root.addChild("Case Sensitivity");
         }
     }
 

--- a/flow/src/org/labkey/flow/controllers/compensation/CompensationController.java
+++ b/flow/src/org/labkey/flow/controllers/compensation/CompensationController.java
@@ -74,10 +74,9 @@ public class CompensationController extends BaseFlowController
             return new CompensationListView(settings);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Compensation Matrices", new ActionURL(BeginAction.class, getContainer()));
-            return root;
         }
     }
 
@@ -142,9 +141,9 @@ public class CompensationController extends BaseFlowController
             return _flowComp.urlShow();
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, null, "Upload a new compensation matrix");
+            appendFlowNavTrail(getPageConfig(), root, null, "Upload a new compensation matrix");
         }
     }
 
@@ -178,9 +177,8 @@ public class CompensationController extends BaseFlowController
             return null;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -196,19 +194,19 @@ public class CompensationController extends BaseFlowController
             return FormPage.getView("/org/labkey/flow/controllers/compensation/showCompensation.jsp", form);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            if (null == _comp)
-                return root;
-            // show run this compensation was derived from
-            if (_comp.getParent() != null)
-                return appendFlowNavTrail(getPageConfig(), root, _comp, "Show Compensation " + _comp.getName());
-            // fall back on showing compensation query
-            else
+            if (null != _comp)
             {
-                root.addChild("Compensation Matrices", new ActionURL(BeginAction.class, getContainer()));
-                root.addChild(_comp.getLabel(), _comp.urlShow());
-                return root;
+                // show run this compensation was derived from
+                if (_comp.getParent() != null)
+                    appendFlowNavTrail(getPageConfig(), root, _comp, "Show Compensation " + _comp.getName());
+                    // fall back on showing compensation query
+                else
+                {
+                    root.addChild("Compensation Matrices", new ActionURL(BeginAction.class, getContainer()));
+                    root.addChild(_comp.getLabel(), _comp.urlShow());
+                }
             }
         }
     }

--- a/flow/src/org/labkey/flow/controllers/editscript/ScriptController.java
+++ b/flow/src/org/labkey/flow/controllers/editscript/ScriptController.java
@@ -118,9 +118,8 @@ public class ScriptController extends BaseFlowController
             return HttpView.redirect(script.urlShow());
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -142,9 +141,8 @@ public class ScriptController extends BaseFlowController
             return null;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -240,10 +238,9 @@ public class ScriptController extends BaseFlowController
             return page;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("New Analysis Script", new ActionURL(NewProtocolAction.class, getContainer()));
-            return root;
         }
 
         protected ActionURL createScript(NewProtocolForm form, BindException errors)

--- a/flow/src/org/labkey/flow/controllers/executescript/AnalysisScriptController.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/AnalysisScriptController.java
@@ -129,9 +129,9 @@ public class AnalysisScriptController extends BaseFlowController
             return new JspView<>("/org/labkey/flow/controllers/executescript/showScript.jsp", script, errors);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, script, null);
+            appendFlowNavTrail(getPageConfig(), root, script, null);
         }
     }
 
@@ -176,9 +176,9 @@ public class AnalysisScriptController extends BaseFlowController
             return HttpView.redirect(executeScript(job));
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, script, nav.first);
+            appendFlowNavTrail(getPageConfig(), root, script, nav.first);
         }
     }
 
@@ -375,9 +375,9 @@ public class AnalysisScriptController extends BaseFlowController
             return HttpView.redirect(executeScript(job));
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, null, "Import Flow FCS Files");
+            appendFlowNavTrail(getPageConfig(), root, null, "Import Flow FCS Files");
         }
     }
 
@@ -525,9 +525,8 @@ public class AnalysisScriptController extends BaseFlowController
             return new HttpPostRedirectView(url.getLocalURIString(), inputs);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -1386,12 +1385,11 @@ public class AnalysisScriptController extends BaseFlowController
             return null;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             String display = "Import Analysis";
             if (title != null)
                 display += ": " + title;
-            return root.addChild(display);
         }
     }
 
@@ -1461,7 +1459,7 @@ public class AnalysisScriptController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             return root.addChild("Import Analysis");
         }

--- a/flow/src/org/labkey/flow/controllers/protocol/ProtocolController.java
+++ b/flow/src/org/labkey/flow/controllers/protocol/ProtocolController.java
@@ -78,9 +78,8 @@ public class ProtocolController extends BaseFlowController
             return HttpView.redirect(urlFor(ProtocolController.ShowProtocolAction.class));
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -95,9 +94,9 @@ public class ProtocolController extends BaseFlowController
             return FormPage.getView("/org/labkey/flow/controllers/protocol/showProtocol.jsp", form, errors);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, protocol, "Protocol");
+            appendFlowNavTrail(getPageConfig(), root, protocol, "Protocol");
         }
     }
 
@@ -112,9 +111,9 @@ public class ProtocolController extends BaseFlowController
             return FormPage.getView("/org/labkey/flow/controllers/protocol/showSamples2.jsp", form, errors);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, protocol, "Show Samples");
+            appendFlowNavTrail(getPageConfig(), root, protocol, "Show Samples");
         }
     }
 
@@ -155,9 +154,9 @@ public class ProtocolController extends BaseFlowController
             return getProtocol().urlFor(UpdateSamplesAction.class).addParameter("fileCount", _fileCount);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, getProtocol(), "Join Samples");
+            appendFlowNavTrail(getPageConfig(), root, getProtocol(), "Join Samples");
         }
     }
 
@@ -172,9 +171,9 @@ public class ProtocolController extends BaseFlowController
             return FormPage.getView("/org/labkey/flow/controllers/protocol/updateSamples.jsp", form);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, protocol, "Update Samples");
+            appendFlowNavTrail(getPageConfig(), root, protocol, "Update Samples");
         }
     }
 
@@ -203,9 +202,9 @@ public class ProtocolController extends BaseFlowController
             return getProtocol().urlShow();
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, getProtocol(), "Edit FCS Analysis Name");
+            appendFlowNavTrail(getPageConfig(), root, getProtocol(), "Edit FCS Analysis Name");
         }
     }
 
@@ -233,9 +232,9 @@ public class ProtocolController extends BaseFlowController
             return getProtocol().urlShow();
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, getProtocol(), "Edit FCS Analysis Filter");
+            appendFlowNavTrail(getPageConfig(), root, getProtocol(), "Edit FCS Analysis Filter");
         }
     }
 
@@ -295,9 +294,9 @@ public class ProtocolController extends BaseFlowController
             return url;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, getProtocol(), "Edit Metadata");
+            appendFlowNavTrail(getPageConfig(), root, getProtocol(), "Edit Metadata");
         }
     }
 }

--- a/flow/src/org/labkey/flow/controllers/run/RunController.java
+++ b/flow/src/org/labkey/flow/controllers/run/RunController.java
@@ -135,9 +135,8 @@ public class RunController extends BaseFlowController
             return HttpView.redirect(urlFor(RunController.ShowRunAction.class));
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -161,10 +160,10 @@ public class RunController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             String label = run != null ? null : "Run not found";
-            return appendFlowNavTrail(getPageConfig(), root, run, label);
+            appendFlowNavTrail(getPageConfig(), root, run, label);
         }
     }
 
@@ -186,7 +185,7 @@ public class RunController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if (experiment == null)
                 root.addChild("All Analysis Folders", new ActionURL(ShowRunsAction.class, getContainer()));
@@ -197,7 +196,6 @@ public class RunController extends BaseFlowController
 //                root.addChild(script.getLabel(), script.urlShow());
 
             root.addChild("Runs");
-            return root;
         }
     }
 
@@ -261,10 +259,9 @@ public class RunController extends BaseFlowController
             }
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Download Run");
-            return root;
         }
     }
 
@@ -707,11 +704,10 @@ public class RunController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, null, "Export Analysis");
+            appendFlowNavTrail(getPageConfig(), root, null, "Export Analysis");
         }
-
     }
 
     private static class ExportToScriptJob extends PipelineJob

--- a/flow/src/org/labkey/flow/controllers/well/WellController.java
+++ b/flow/src/org/labkey/flow/controllers/well/WellController.java
@@ -117,9 +117,8 @@ public class WellController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -204,10 +203,10 @@ public class WellController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             String label = _well != null ? null : "Well not found";
-            return appendFlowNavTrail(getPageConfig(), root, _well, label);
+            appendFlowNavTrail(getPageConfig(), root, _well, label);
         }
     }
 
@@ -351,17 +350,17 @@ public class WellController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if (_isBulkEdit)
             {
                 ActionURL urlFcsFiles = FlowTableType.FCSFiles.urlFor(getUser(), getContainer(), QueryAction.executeQuery);
                 root.addChild(new NavTree("FSC Files",urlFcsFiles));
                 root.addChild(new NavTree("Edit Keywords"));
-                return root;
+                return;
             }
             String label = _wells != null && !_wells.isEmpty() ? "Edit " + _wells.get(0).getLabel() : "Well not found";
-            return appendFlowNavTrail(getPageConfig(), root, _wells.get(0), label);
+            appendFlowNavTrail(getPageConfig(), root, _wells.get(0), label);
         }
     }
 
@@ -404,9 +403,9 @@ public class WellController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendFlowNavTrail(getPageConfig(), root, _well, "Choose Graph");
+            appendFlowNavTrail(getPageConfig(), root, _well, "Choose Graph");
         }
     }
 
@@ -471,9 +470,8 @@ public class WellController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -529,9 +527,8 @@ public class WellController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -581,9 +578,8 @@ public class WellController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
     
@@ -601,9 +597,8 @@ public class WellController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -653,9 +648,8 @@ public class WellController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -702,9 +696,8 @@ public class WellController extends BaseFlowController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
 
         @Override

--- a/luminex/src/org/labkey/luminex/LuminexController.java
+++ b/luminex/src/org/labkey/luminex/LuminexController.java
@@ -125,7 +125,7 @@ public class LuminexController extends SpringActionController
             return HttpView.redirect(PageFlowUtil.urlProvider(AssayUrls.class).getAssayListURL(getContainer()));
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             throw new UnsupportedOperationException();
         }
@@ -189,20 +189,18 @@ public class LuminexController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            super.appendNavTrail(root);
+            super.addNavTrail(root);
             root.addChild(_protocol.getName() + " Excluded Data");
-
-            return root;
         }
     }
 
     private class GraphLinkQueryView extends QueryView
     {
-        private String _tableName;
-        private String _controlType;
-        private ExpProtocol _protocol;
+        private final String _tableName;
+        private final String _controlType;
+        private final ExpProtocol _protocol;
 
         public GraphLinkQueryView(String tableName, String controlType, ExpProtocol protocol, UserSchema schema, QuerySettings settings, @Nullable Errors errors)
         {
@@ -254,13 +252,11 @@ public class LuminexController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Assay List", PageFlowUtil.urlProvider(AssayUrls.class).getAssayListURL(getContainer()));
             root.addChild(_protocol.getName(), PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), _protocol));
             root.addChild("Titration QC Report");
-
-            return root;
         }
     }
 
@@ -286,13 +282,11 @@ public class LuminexController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Assay List", PageFlowUtil.urlProvider(AssayUrls.class).getAssayListURL(getContainer()));
             root.addChild(_protocol.getName(), PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), _protocol));
             root.addChild("Single Point Control QC Report");
-
-            return root;
         }
     }
 
@@ -318,15 +312,13 @@ public class LuminexController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             setHelpTopic("luminexSinglePoint");
             root.addChild("Assay List", PageFlowUtil.urlProvider(AssayUrls.class).getAssayListURL(getContainer()));
             root.addChild(_form.getProtocol().getName(), PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), _form.getProtocol()));
             root.addChild("Levey-Jennings Reports", new ActionURL(LeveyJenningsMenuAction.class, getContainer()).addParameter("rowId", _form.getProtocol().getRowId()));
             root.addChild(_form.getControlName());
-
-            return root;
         }
     }
 
@@ -346,14 +338,12 @@ public class LuminexController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             setHelpTopic("trackLuminexAnalytes");
             root.addChild("Assay List", PageFlowUtil.urlProvider(AssayUrls.class).getAssayListURL(getContainer()));
             root.addChild(_form.getProtocol().getName(), PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), _form.getProtocol()));
             root.addChild("Levey-Jennings Reports");
-
-            return root;
         }
     }
 
@@ -414,10 +404,9 @@ public class LuminexController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Set Default Values");
-            return root;
         }
     }
 
@@ -586,10 +575,9 @@ public class LuminexController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Import Default Values");
-            return root;
         }
     }
 
@@ -720,10 +708,9 @@ public class LuminexController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Confirm Deletion");
-            return root;
         }
     }
 
@@ -941,13 +928,11 @@ public class LuminexController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Assay List", PageFlowUtil.urlProvider(AssayUrls.class).getAssayListURL(getContainer()));
             root.addChild(_protocol.getName(), PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), _protocol));
             root.addChild("Manage Guide Sets");
-
-            return root;
         }
     }
 }

--- a/microarray/src/org/labkey/microarray/controllers/FeatureAnnotationSetController.java
+++ b/microarray/src/org/labkey/microarray/controllers/FeatureAnnotationSetController.java
@@ -106,9 +106,9 @@ public class FeatureAnnotationSetController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Manage Feature Annotation Sets");
+            root.addChild("Manage Feature Annotation Sets");
         }
     }
 
@@ -150,7 +150,7 @@ public class FeatureAnnotationSetController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             throw new UnsupportedOperationException();
         }
@@ -262,13 +262,12 @@ public class FeatureAnnotationSetController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             setHelpTopic("featureAnnotationSets");
             ActionURL url = new ActionURL(ManageAction.class, getContainer());
             root.addChild("Feature Annotation Sets", url);
             root.addChild("Upload Annotation Set");
-            return root;
         }
     }
 
@@ -330,13 +329,12 @@ public class FeatureAnnotationSetController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             setHelpTopic("featureAnnotationSets");
             ActionURL url = new ActionURL(ManageAction.class, getContainer());
             root.addChild("Feature Annotation Sets", url);
             root.addChild("Feature Annotation Set");
-            return root;
         }
     }
 

--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -218,17 +218,16 @@ public class MS2Controller extends SpringActionController
         AdminConsole.addLink(SettingsLinkType.Management, "protein databases", MS2UrlsImpl.get().getShowProteinAdminUrl(), AdminOperationsPermission.class);
     }
 
-    private NavTree appendRootNavTrail(NavTree root, String title, PageConfig page, String helpTopic)
+    private void appendRootNavTrail(NavTree root, String title, PageConfig page, String helpTopic)
     {
         page.setHelpTopic(new HelpTopic(null == helpTopic ? "ms2" : helpTopic));
         root.addChild("MS2 Runs", getShowListURL(getContainer()));
         if (null != title)
             root.addChild(title);
-        return root;
     }
 
 
-    private NavTree appendRunNavTrail(NavTree root, MS2Run run, URLHelper runURL, String title, PageConfig page, String helpTopic)
+    private void appendRunNavTrail(NavTree root, MS2Run run, URLHelper runURL, String title, PageConfig page, String helpTopic)
     {
         appendRootNavTrail(root, null, page, helpTopic);
 
@@ -242,23 +241,21 @@ public class MS2Controller extends SpringActionController
 
         if (null != title)
             root.addChild(title);
-        return root;
     }
 
 
-    private NavTree appendAdminNavTrail(NavTree root, String adminPageTitle, ActionURL adminPageURL, String title, PageConfig page, String helpTopic)
+    private void addAdminNavTrail(NavTree root, String adminPageTitle, ActionURL adminPageURL, String title, PageConfig page, String helpTopic)
     {
         page.setHelpTopic(new HelpTopic(null == helpTopic ? "ms2" : helpTopic));
         root.addChild("Admin Console", PageFlowUtil.urlProvider(AdminUrls.class).getAdminConsoleURL());
         root.addChild(adminPageTitle, adminPageURL);
         root.addChild(title);
-        return root;
     }
 
 
-    private NavTree appendProteinAdminNavTrail(NavTree root, String title, PageConfig page, String helpTopic)
+    private void addProteinAdminNavTrail(NavTree root, String title, PageConfig page, String helpTopic)
     {
-        return appendAdminNavTrail(root, "Protein Database Admin", MS2UrlsImpl.get().getShowProteinAdminUrl(), title, page, helpTopic);
+        addAdminNavTrail(root, "Protein Database Admin", MS2UrlsImpl.get().getShowProteinAdminUrl(), title, page, helpTopic);
     }
 
 
@@ -312,9 +309,9 @@ public class MS2Controller extends SpringActionController
             return new VBox(searchView, gridView);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendRootNavTrail(root, "MS2 Runs", getPageConfig(), "ms2RunsList");
+            appendRootNavTrail(root, "MS2 Runs", getPageConfig(), "ms2RunsList");
         }
     }
 
@@ -441,14 +438,14 @@ public class MS2Controller extends SpringActionController
             return vBox;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             String pageTitle = (null != getPageConfig().getTitle() ? getPageConfig().getTitle() : "Run Summary");
 
             if (null != _run)
                 appendRunNavTrail(root, _run, null, null, getPageConfig(), "viewRuns");
 
-            return root.addChild(pageTitle);
+            root.addChild(pageTitle);
         }
     }
 
@@ -784,9 +781,9 @@ public class MS2Controller extends SpringActionController
             return form.getReturnURLHelper();
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendRunNavTrail(root, _run, _returnURL, "Rename Run", getPageConfig(), null);
+            appendRunNavTrail(root, _run, _returnURL, "Rename Run", getPageConfig(), null);
         }
     }
 
@@ -921,9 +918,8 @@ public class MS2Controller extends SpringActionController
             return result;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -965,11 +961,10 @@ public class MS2Controller extends SpringActionController
             return new GoView();
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             setTitle((GoLoader.isGoLoaded().booleanValue() ? "Reload" : "Load") + " GO Annotations");
             setHelpTopic(new HelpTopic("annotations"));
-            return null;  // TODO: Admin navtrail
         }
 
         public boolean handlePost(Object o, BindException errors) throws Exception
@@ -1040,11 +1035,10 @@ public class MS2Controller extends SpringActionController
             return GoLoader.getCurrentStatus(form.getMessage());
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             setTitle("GO Load Status");
             setHelpTopic(new HelpTopic("annotations"));
-            return null;
         }
     }
 
@@ -1121,11 +1115,11 @@ public class MS2Controller extends SpringActionController
             return new JspView<>("/org/labkey/ms2/peptideChart.jsp", bean);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             ActionURL runURL = MS2Controller.getShowRunURL(getUser(), getContainer(), _run.getRun());
 
-            return appendRunNavTrail(root, _run, runURL, "GO " + _goChartType + " Chart", getPageConfig(), "viewingGeneOntologyData");
+            appendRunNavTrail(root, _run, runURL, "GO " + _goChartType + " Chart", getPageConfig(), "viewingGeneOntologyData");
         }
     }
 
@@ -1158,9 +1152,8 @@ public class MS2Controller extends SpringActionController
             return peptideView.getPeptideViewForProteinGrouping(form.getProteinGroupingId(), form.getColumns());
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -1253,9 +1246,9 @@ public class MS2Controller extends SpringActionController
             return view;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendRunNavTrail(root, _run, _returnURL, "Customize Views", getPageConfig(), "viewRun");
+            appendRunNavTrail(root, _run, _returnURL, "Customize Views", getPageConfig(), "viewRun");
         }
 
         public boolean handlePost(ManageViewsForm form, BindException errors)
@@ -1398,9 +1391,9 @@ public class MS2Controller extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Compare Search Engine Protein Setup");
+            root.addChild("Compare Search Engine Protein Setup");
         }
     }
 
@@ -1455,10 +1448,10 @@ public class MS2Controller extends SpringActionController
             return new JspView<CompareOptionsBean>("/org/labkey/ms2/compare/compareProteinProphetQueryOptions.jsp", bean);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             setHelpTopic("compareProteinProphet");
-            return root.addChild("Compare ProteinProphet Options");
+            root.addChild("Compare ProteinProphet Options");
         }
     }
 
@@ -1497,9 +1490,9 @@ public class MS2Controller extends SpringActionController
             return new JspView<CompareOptionsBean>("/org/labkey/ms2/compare/comparePeptideQueryOptions.jsp", bean);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Compare Peptides Options");
+            root.addChild("Compare Peptides Options");
         }
     }
 
@@ -1612,10 +1605,9 @@ public class MS2Controller extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Disambiguate Protein");
-            return root;
         }
     }
 
@@ -1946,7 +1938,7 @@ public class MS2Controller extends SpringActionController
             }
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if (_form != null)
             {
@@ -1969,7 +1961,7 @@ public class MS2Controller extends SpringActionController
                 root.addChild("Setup Compare ProteinProphet", setupURL); // GET the setup view -- no use going through POST, since we don't have a run list
             }
             setHelpTopic("compareProteinProphet");
-            return root.addChild("Compare ProteinProphet");
+            root.addChild("Compare ProteinProphet");
         }
     }
 
@@ -2025,7 +2017,7 @@ public class MS2Controller extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if (_form != null)
             {
@@ -2041,9 +2033,10 @@ public class MS2Controller extends SpringActionController
                 root.addChild("Setup Compare Peptides", setupURL); // GET the setup view -- no use going through POST, since we don't have a run list
                 StringBuilder title = new StringBuilder("Compare Peptides: ");
                 _form.appendPeptideFilterDescription(title, getViewContext());
-                return root.addChild(title.toString());
+                root.addChild(title.toString());
+                return;
             }
-            return root.addChild("Compare Peptides");
+            root.addChild("Compare Peptides");
         }
     }
 
@@ -2086,9 +2079,9 @@ public class MS2Controller extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendRootNavTrail(root, "Export Runs", getPageConfig(), "exportRuns");
+            appendRootNavTrail(root, "Export Runs", getPageConfig(), "exportRuns");
         }
     }
 
@@ -2130,9 +2123,9 @@ public class MS2Controller extends SpringActionController
             return compareRuns(form.getRunList(), false, _title, form.getColumn(), errors);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendRootNavTrail(root, _title.toString(), getPageConfig(), "compareRuns");
+            appendRootNavTrail(root, _title.toString(), getPageConfig(), "compareRuns");
         }
     }
 
@@ -2332,9 +2325,9 @@ public class MS2Controller extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Spectra Count Options");
+            root.addChild("Spectra Count Options");
         }
     }
 
@@ -2407,9 +2400,9 @@ public class MS2Controller extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            root = appendRootNavTrail(root, null, getPageConfig(), "spectraCount");
+            appendRootNavTrail(root, null, getPageConfig(), "spectraCount");
             if (_form != null)
             {
                 ActionURL setupURL = new ActionURL(SpectraCountSetupAction.class, getContainer());
@@ -2434,7 +2427,6 @@ public class MS2Controller extends SpringActionController
                 _form.appendPeptideFilterDescription(title, getViewContext());
                 root.addChild(title.toString());
             }
-            return root;
         }
     }
 
@@ -2646,10 +2638,9 @@ public class MS2Controller extends SpringActionController
             return new JspView<>("/org/labkey/ms2/testFastaParsing.jsp", form);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            appendProteinAdminNavTrail(root, "Test FASTA header parsing", getPageConfig(), null);
-            return root;
+            addProteinAdminNavTrail(root, "Test FASTA header parsing", getPageConfig(), null);
         }
     }
 
@@ -2813,10 +2804,9 @@ public class MS2Controller extends SpringActionController
             return result;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             PageFlowUtil.urlProvider(AdminUrls.class).appendAdminNavTrail(root, "Protein Database Admin", null);
-            return root;
         }
     }
 
@@ -3121,12 +3111,11 @@ public class MS2Controller extends SpringActionController
             return result;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             String helpTopic = "proteinSearch";
             getPageConfig().setHelpTopic(new HelpTopic(helpTopic));
             root.addChild("Protein Search Results");
-            return root;
         }
     }
 
@@ -3460,9 +3449,8 @@ public class MS2Controller extends SpringActionController
             return result;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -3516,9 +3504,8 @@ public class MS2Controller extends SpringActionController
             return result;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -3583,10 +3570,9 @@ public class MS2Controller extends SpringActionController
             return result;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             PageFlowUtil.urlProvider(AdminUrls.class).appendAdminNavTrail(root, "MS2 Admin", null);
-            return root;
         }
     }
 
@@ -3686,9 +3672,9 @@ public class MS2Controller extends SpringActionController
             return gridView;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;  // TODO: admin navtrail
+            // TODO: admin navtrail
         }
     }
 
@@ -3759,9 +3745,9 @@ public class MS2Controller extends SpringActionController
             return form.getReturnURLHelper();
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return appendRunNavTrail(root, _run, _returnURL, "Save View", getPageConfig(), "viewRun");
+            appendRunNavTrail(root, _run, _returnURL, "Save View", getPageConfig(), "viewRun");
         }
     }
 
@@ -3854,9 +3840,8 @@ public class MS2Controller extends SpringActionController
             return null;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -3967,7 +3952,7 @@ public class MS2Controller extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if (getViewContext().getContainer().isRoot())
             {
@@ -3977,7 +3962,7 @@ public class MS2Controller extends SpringActionController
             {
                 root.addChild("Pipeline Settings", PageFlowUtil.urlProvider(PipelineUrls.class).urlSetup(getViewContext().getContainer()));
             }
-            return root.addChild("Mascot Server Configuration");
+            root.addChild("Mascot Server Configuration");
         }
     }
 
@@ -4051,9 +4036,9 @@ public class MS2Controller extends SpringActionController
             return new ProteinsView(currentURL, _run, form, Collections.singletonList(_protein), null, peptideQueryView);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild(getProteinTitle(_protein, true));
+            root.addChild(getProteinTitle(_protein, true));
         }
     }
 
@@ -4091,9 +4076,8 @@ public class MS2Controller extends SpringActionController
             return new VBox(summary, view);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -4156,9 +4140,8 @@ public class MS2Controller extends SpringActionController
             return new VBox(summaryView, view);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -4366,9 +4349,8 @@ public class MS2Controller extends SpringActionController
             return null;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -4511,9 +4493,8 @@ public class MS2Controller extends SpringActionController
             return null;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -4563,10 +4544,9 @@ public class MS2Controller extends SpringActionController
             return vBox;
         }
 
-        public NavTree appendNavTrail(NavTree root)
-    {
-        return null;
-    }
+        public void addNavTrail(NavTree root)
+        {
+        }
     }
 
     public static class PieSliceSectionForm
@@ -4636,9 +4616,9 @@ public class MS2Controller extends SpringActionController
             return vbox;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Pieslice Details for: " + _form.getSliceTitle());
+            root.addChild("Pieslice Details for: " + _form.getSliceTitle());
         }
     }
 
@@ -4785,11 +4765,10 @@ public class MS2Controller extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Admin Console", PageFlowUtil.urlProvider(AdminUrls.class).getAdminConsoleURL());
             root.addChild("Test Mascot Settings");
-            return root;
         }
     }
 
@@ -5477,10 +5456,9 @@ public class MS2Controller extends SpringActionController
             return MS2UrlsImpl.get().getShowProteinAdminUrl("Annotation load queued. Monitor its progress using the job list at the bottom of this page.");
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            appendProteinAdminNavTrail(root, "Load Protein Annotations", getPageConfig(), null);
-            return root;
+            addProteinAdminNavTrail(root, "Load Protein Annotations", getPageConfig(), null);
         }
     }
 
@@ -5611,10 +5589,9 @@ public class MS2Controller extends SpringActionController
             return new JspView<>("/org/labkey/ms2/annotLoadDetails.jsp", _insertion);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            appendProteinAdminNavTrail(root, _insertion.getFiletype() + " Annotation Insertion Details: " + _insertion.getFilename(), getPageConfig(), null);
-            return null;
+            addProteinAdminNavTrail(root, _insertion.getFiletype() + " Annotation Insertion Details: " + _insertion.getFilename(), getPageConfig(), null);
         }
     }
 
@@ -6025,9 +6002,9 @@ public class MS2Controller extends SpringActionController
             return url;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Edit Elution Profile");
+            root.addChild("Edit Elution Profile");
         }
     }
 
@@ -6170,13 +6147,11 @@ public class MS2Controller extends SpringActionController
             return result;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Peptide Search Results");
+            root.addChild("Peptide Search Results");
         }
     } //PepSearchAction
-
-
 
     public class CompareOptionsBean<Form extends PeptideFilteringComparisonForm>
     {
@@ -6253,9 +6228,9 @@ public class MS2Controller extends SpringActionController
             return PageFlowUtil.urlProvider(PipelineUrls.class).urlBegin(getContainer());
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Attach mspicture Files to Existing MS2 Runs");
+            root.addChild("Attach mspicture Files to Existing MS2 Runs");
         }
     }
 
@@ -6291,9 +6266,9 @@ public class MS2Controller extends SpringActionController
             return PageFlowUtil.urlProvider(PipelineUrls.class).urlBegin(getContainer());
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Load MS scan counts");
+            root.addChild("Load MS scan counts");
         }
     }
 

--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -2806,7 +2806,7 @@ public class MS2Controller extends SpringActionController
 
         public void addNavTrail(NavTree root)
         {
-            PageFlowUtil.urlProvider(AdminUrls.class).appendAdminNavTrail(root, "Protein Database Admin", null);
+            PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Protein Database Admin", null);
         }
     }
 
@@ -3572,7 +3572,7 @@ public class MS2Controller extends SpringActionController
 
         public void addNavTrail(NavTree root)
         {
-            PageFlowUtil.urlProvider(AdminUrls.class).appendAdminNavTrail(root, "MS2 Admin", null);
+            PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "MS2 Admin", null);
         }
     }
 

--- a/ms2/src/org/labkey/ms2/pipeline/PipelineController.java
+++ b/ms2/src/org/labkey/ms2/pipeline/PipelineController.java
@@ -605,10 +605,10 @@ public class PipelineController extends SpringActionController
             return errorString.toString();
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("File List", PageFlowUtil.urlProvider(PipelineUrls.class).urlBrowse(getContainer()));
-            return root.addChild("Search MS2 Data");
+            root.addChild("Search MS2 Data");
         }
     }
 
@@ -689,9 +689,9 @@ public class PipelineController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Configure FASTA Root");
+            root.addChild("Configure FASTA Root");
         }
     }
 
@@ -713,9 +713,9 @@ public class PipelineController extends SpringActionController
             return PipelineController.getHelpTopic("MS2-Pipeline/setTandemDefaults");
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Set X! Tandem Defaults");
+            root.addChild("Set X! Tandem Defaults");
         }
     }
 
@@ -737,9 +737,9 @@ public class PipelineController extends SpringActionController
             return PipelineController.getHelpTopic("MS2-Pipeline/setMascotDefaults");
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Set Mascot Defaults");
+            root.addChild("Set Mascot Defaults");
         }
     }
 
@@ -761,9 +761,9 @@ public class PipelineController extends SpringActionController
             return PipelineController.getHelpTopic("pipelineSequest");
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Set Sequest Defaults");
+            root.addChild("Set Sequest Defaults");
         }
     }
 
@@ -785,9 +785,9 @@ public class PipelineController extends SpringActionController
             return PipelineController.getHelpTopic("pipelineComet");
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Set Comet Defaults");
+            root.addChild("Set Comet Defaults");
         }
     }
 

--- a/ms2/src/org/labkey/ms2/protein/ProteinController.java
+++ b/ms2/src/org/labkey/ms2/protein/ProteinController.java
@@ -63,9 +63,9 @@ public class ProteinController extends SpringActionController
             return new CustomProteinListView(getViewContext(), true);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Custom Protein Lists");
+            root.addChild("Custom Protein Lists");
         }
     }
 
@@ -140,12 +140,11 @@ public class ProteinController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("MS2", MS2Controller.getBeginURL(getContainer()));
             root.addChild("Custom Protein Lists", getBeginURL(getContainer()));
             root.addChild("Custom Protein List: " + _setName);
-            return root;
         }
     }
 
@@ -355,12 +354,11 @@ public class ProteinController extends SpringActionController
             return getBeginURL(getContainer());
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("MS2", MS2Controller.getBeginURL(getContainer()));
             root.addChild("Custom Protein Lists", getBeginURL(getContainer()));
             root.addChild("Upload Custom Protein List");
-            return root;
         }
     }
 

--- a/nab/src/org/labkey/nab/NabAssayController.java
+++ b/nab/src/org/labkey/nab/NabAssayController.java
@@ -191,7 +191,7 @@ public class NabAssayController extends SpringActionController
             return HttpView.redirect(PageFlowUtil.urlProvider(AssayUrls.class).getAssayListURL(getContainer()));
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             throw new UnsupportedOperationException();
         }
@@ -233,7 +233,7 @@ public class NabAssayController extends SpringActionController
             return null;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             throw new UnsupportedOperationException("Not Yet Implemented");
         }
@@ -318,16 +318,14 @@ public class NabAssayController extends SpringActionController
             return _getNabAssayRun(run, fit, user);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if (null != _protocol)
             {
                 ActionURL runDataURL = PageFlowUtil.urlProvider(AssayUrls.class).getAssayResultsURL(getContainer(), _protocol, _runRowId);
                 root.addChild(_protocol.getName() + " Data", runDataURL);
                 root.addChild("Run " + _runRowId + " Details");
-                return root;
             }
-            return null;
         }
     }
 
@@ -442,7 +440,7 @@ public class NabAssayController extends SpringActionController
             throw new RedirectException(PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), run.getProtocol()));
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             throw new UnsupportedOperationException("Expected redirect did not occur.");
         }
@@ -488,7 +486,7 @@ public class NabAssayController extends SpringActionController
             return _getNabAssayRun(run, fit, user);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             throw new UnsupportedOperationException();
         }
@@ -813,12 +811,11 @@ public class NabAssayController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             ActionURL detailsURL = new ActionURL(DetailsAction.class, getContainer()).addParameter("rowId", _runId);
             root.addChild("Run " + _runId + " Details", detailsURL);
             root.addChild(_editMode ? "QC NAb Data" : "Excluded Data");
-            return root;
         }
     }
 

--- a/nab/src/org/labkey/nab/StudyNabGraphAction.java
+++ b/nab/src/org/labkey/nab/StudyNabGraphAction.java
@@ -97,7 +97,7 @@ public class StudyNabGraphAction extends SimpleViewAction<GraphSelectedForm>
         return null;
     }
 
-    public NavTree appendNavTrail(NavTree root)
+    public void addNavTrail(NavTree root)
     {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
#### Rationale
Adjust all the actions in commonAssays to implement `void addNavTrail()` instead of `NavTree appendNavTrail()`. See platform PR for more details.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1199

#### Changes
* Migrate all implementations and usages of `NavTree appendNavTrail()` to `void addNavTrail()`.
