### PR TITLE
Item 7353: LuminexTest update to remove unused PropertiesEditor test class

### DIFF
--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -28,7 +28,6 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.components.PropertiesEditor;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.components.html.Checkbox;
@@ -57,7 +56,6 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.labkey.test.components.PropertiesEditor.PropertiesEditor;
 
 @BaseWebDriverTest.ClassTimeout(minutes = 40)
 public abstract class LuminexTest extends BaseWebDriverTest
@@ -565,13 +563,6 @@ public abstract class LuminexTest extends BaseWebDriverTest
     public void goToTestAssayHome()
     {
         goToTestAssayHome(TEST_ASSAY_LUM);
-    }
-
-    private void setFormat(String where, int index, String formatStr)
-    {
-        PropertiesEditor propertiesEditor = PropertiesEditor(getDriver()).withTitleContaining(where).find();
-        propertiesEditor.selectField(index);
-        propertiesEditor.fieldProperties().selectFormatTab().setPropertyFormat(formatStr);
     }
 
     public void importLuminexRunPageTwo(String name, String isotype, String conjugate, String stndCurveFitInput,


### PR DESCRIPTION
#### Rationale
With the GWT PropertiesEditor gone, it is time to also remove the PropertiesEditor test class. The only remaining items in use from the PropertiesEditor test class were three public enums. Those have been moved to the FieldDefinition test class as part of the testAutomation PR changes.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/341
* https://github.com/LabKey/platform/pull/1213
* https://github.com/LabKey/compliance/pull/85

#### Changes
* LuminexTest update to remove unused PropertiesEditor test class
