### PR TITLE
Issue 40503: Luminex Levey-Jennings fix for cross container display/query of single point control calc and QC flag data

### DIFF
--- a/luminex/src/org/labkey/luminex/query/LuminexDataTable.java
+++ b/luminex/src/org/labkey/luminex/query/LuminexDataTable.java
@@ -326,10 +326,6 @@ public class LuminexDataTable extends FilteredTable<LuminexProtocolSchema> imple
         SQLFragment protocolIDFilter = new SQLFragment("ProtocolID = ?");
         protocolIDFilter.add(_userSchema.getProtocol().getRowId());
         addCondition(protocolIDFilter, FieldKey.fromParts("ProtocolID"));
-
-        SQLFragment containerFilter = new SQLFragment("Container = ?");
-        containerFilter.add(_userSchema.getContainer().getId());
-        addCondition(containerFilter, FieldKey.fromParts("Container"));
     }
 
     private SQLFragment getExclusionsUnionSQL()


### PR DESCRIPTION
#### Rationale
Issue [40503](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40503): the Luminex assay Levey-Jennings report was developed so that it would show any data uploaded to the given assay design for any container that has access to the assay design. It looks like there was a regression (possible during some of the containerFilter migration work) so that the single point control report would only show data for the given container (i.e. only those runs in the given container but not results for other runs uploaded to the same assay designer in different containers). 

NOTE: this change/fix has already been applied to trunk/develop for 20.7 (https://github.com/LabKey/commonAssays/pull/177). This PR is to backport that fix to the clients current LK Server version.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1256

#### Changes
* LuminexDataTable change to remove the extra container filter query param now that containerFilter support has been added since the original dev

