### PR TITLE
Issue 39667: Remove Raphael Renderer

### DIFF
--- a/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
+++ b/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
@@ -205,7 +205,6 @@ LABKEY.LeveyJenningsPlotHelper.renderPlot = function(config)
     else
         throw "You specified an invalid plotType! Check valid values in LABKEY.LeveyJenningsPlotHelper.PlotTypeMap.";
 
-    var renderType = Ext.isIE8 ? 'raphael' : 'd3';
     var title = config.controlName + ' ' + ytitle + ' for ' + config.analyte + ' - '
               + (config.isotype ? config.isotype : '[None]') + ' '
               + (config.conjugate ? config.conjugate : '[None]');
@@ -239,7 +238,6 @@ LABKEY.LeveyJenningsPlotHelper.renderPlot = function(config)
 
     var plot = LABKEY.vis.LeveyJenningsPlot({
         renderTo: config.renderDiv,
-        rendererType: renderType,
         width: 850,
         height: 300,
         data: plotData,
@@ -252,8 +250,6 @@ LABKEY.LeveyJenningsPlotHelper.renderPlot = function(config)
         }
     });
     plot.render();
-
-    return renderType;
 };
 
 // plotType: EC504PL, EC505PL, AUC, HighMFI


### PR DESCRIPTION
#### Rationale
The Raphael Renderer has been removed in the platform repo. This PR removes usages of it in LevyJenningsPlotHelpers.js

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1305

#### Changes
* Remove raphael setting from LevyJenningsPlotHelpers.js
