### PR TITLE
Fix ViabilityTest

### DIFF
--- a/viability/webapp/viability/MultiValueInput.js
+++ b/viability/webapp/viability/MultiValueInput.js
@@ -59,9 +59,11 @@ var MultiValueInput = function (fieldId, initialValues)
             name: fieldId,
             editable: true,
             value: value,
+            enableKeyEvents: true,
             cls: "labkey-multi-value-input",
             listeners: {
-                'specialkey': function (f, e) {
+                keydown: function (f, e) {
+                    if (!e.isSpecialKey()) return;
                     var key = e.getKey();
                     if ((key == e.TAB || key == e.ENTER || key == e.DOWN) && !e.shiftKey)
                     {


### PR DESCRIPTION
#### Rationale
The `ViabilityTest` started failing recently due to the Guava Assay data input page failing to recognize tab to initiate a new element. After investigating, this was only occurring in FF on Linux/OSX and is the result of ExtJS 3 no longer being called with the `keypress` event when tabbing an input element. 

This PR switches the implementation of `MultiValueInput` to use the `keydown` event directly as is [recommended by MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/keypress_event).

#### Changes
* Use `keydown` event instead of `specialkey` when handling input for `MultiValueInput`.
