### PR TITLE
Skip mock mascot test if devtools module is missing

### DIFF
--- a/ms2/src/org/labkey/ms2/pipeline/mascot/MascotClientImpl.java
+++ b/ms2/src/org/labkey/ms2/pipeline/mascot/MascotClientImpl.java
@@ -27,12 +27,14 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.ms2.SearchClient;
 import org.labkey.api.pipeline.ParamParser;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobService;
+import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.view.ActionURL;
 import org.labkey.ms2.pipeline.AbstractMS2SearchProtocolFactory;
@@ -1523,6 +1525,11 @@ public class MascotClientImpl implements SearchClient
         @Test
         public void testMockMascotServer() throws IOException
         {
+            if (!AppProps.getInstance().isDevMode())
+            {
+                Assume.assumeNotNull("Mock mascot server requires DeveloperTools module. Skipping test in production mode.",
+                        ModuleLoader.getInstance().getModule("DeveloperTools"));
+            }
             MascotClientImpl client = new MascotClientImpl(ActionURL.getBaseServerURL() + "/mockmascot/cgi/", _log);
             String version = client.getMascotVersion().trim();
             Assert.assertEquals("Hello - Server: LabKey MockMascotServer 1.0", version);


### PR DESCRIPTION
#### Rationale
DeveloperTools module might not be present on production servers. This change allows us to run more tests on remote servers, which tend to be running in production mode.

#### Changes
* Skip mock mascot test in production mode if the `devtools` modules isn't present.
