### PR TITLE
Update tests for new sampledata locations

### DIFF
--- a/flow/enginesrc/org/labkey/flow/analysis/model/FlowJoWorkspace.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/FlowJoWorkspace.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.settings.AppProps;
+import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.VersionNumber;
 import org.labkey.flow.analysis.web.FCSAnalyzer;
 import org.labkey.flow.analysis.web.GraphSpec;
@@ -735,17 +735,9 @@ abstract public class FlowJoWorkspace extends Workspace
 
     public static class LoadTests extends Assert
     {
-        private File projectRoot()
-        {
-            String projectRootPath =  AppProps.getInstance().getProjectRoot();
-            if (projectRootPath == null)
-                projectRootPath = System.getProperty("user.dir") + "/..";
-            return new File(projectRootPath);
-        }
-
         private Workspace loadWorkspace(String path) throws Exception
         {
-            File file = new File(projectRoot(), "sampledata/" + path);
+            File file = JunitUtil.getSampleData(null, path);
             return Workspace.readWorkspace(file.getName(), path, new FileInputStream(file));
         }
 

--- a/luminex/src/org/labkey/luminex/LuminexExcelParser.java
+++ b/luminex/src/org/labkey/luminex/LuminexExcelParser.java
@@ -34,6 +34,7 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.PropertyService;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.reader.ExcelFactory;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.JunitUtil;
@@ -842,7 +843,7 @@ public class LuminexExcelParser
 
         private LuminexExcelParser createParser(String fileName) throws IOException
         {
-            File luminexDir = JunitUtil.getSampleData(null, "Luminex");
+            File luminexDir = JunitUtil.getSampleData(ModuleLoader.getInstance().getModule(LuminexModule.class), "luminex");
             assertTrue("Couldn't find " + luminexDir, null != luminexDir && luminexDir.isDirectory());
 
             Domain dummyDomain = PropertyService.get().createDomain(ContainerManager.getRoot(), "fakeURI", "dummyDomain");

--- a/ms2/src/org/labkey/ms2/pipeline/sequest/SequestParamsBuilder.java
+++ b/ms2/src/org/labkey/ms2/pipeline/sequest/SequestParamsBuilder.java
@@ -22,10 +22,12 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.ParamParser;
 import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.ms2.MS2Module;
 import org.labkey.ms2.pipeline.AbstractMS2SearchTask;
 import org.labkey.ms2.pipeline.MS2PipelineManager;
 import org.labkey.ms2.pipeline.client.ParameterNames;
@@ -1052,7 +1054,7 @@ public abstract class SequestParamsBuilder
         public void setUp() throws Exception
         {
             ip = PipelineJobService.get().createParamParser();
-            root = JunitUtil.getSampleData(null, "xarfiles/ms2pipe/databases");
+            root = JunitUtil.getSampleData(ModuleLoader.getInstance().getModule(MS2Module.class), "xarfiles/ms2pipe/databases");
             dbPath = root.getCanonicalPath();
             spb = createParamsBuilder();
         }

--- a/ms2/src/org/labkey/ms2/reader/RandomAccessJrapMzxmlIterator.java
+++ b/ms2/src/org/labkey/ms2/reader/RandomAccessJrapMzxmlIterator.java
@@ -18,9 +18,11 @@ package org.labkey.ms2.reader;
 import org.apache.xmlbeans.GDuration;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.massSpecDataFileType;
+import org.labkey.ms2.MS2Module;
 import org.systemsbiology.jrap.MSXMLParser;
 import org.systemsbiology.jrap.Scan;
 import org.systemsbiology.jrap.ScanHeader;
@@ -169,8 +171,8 @@ public class RandomAccessJrapMzxmlIterator extends RandomAccessMzxmlIterator
         public void testMzxml() throws IOException
         {
             massSpecDataFileType FT_MZXML = new massSpecDataFileType();
-            File mzxml2File = JunitUtil.getSampleData(null, "mzxml/test_nocompression.mzXML");
-            File mzxml3File = JunitUtil.getSampleData(null, "mzxml/test_zlibcompression.mzXML");
+            File mzxml2File = JunitUtil.getSampleData(ModuleLoader.getInstance().getModule(MS2Module.class), "mzxml/test_nocompression.mzXML");
+            File mzxml3File = JunitUtil.getSampleData(ModuleLoader.getInstance().getModule(MS2Module.class), "mzxml/test_zlibcompression.mzXML");
             assertTrue(FT_MZXML.isType(mzxml2File));
             assertTrue(FT_MZXML.isType(mzxml3File));
             try

--- a/nab/src/org/labkey/nab/PlateParserTests.java
+++ b/nab/src/org/labkey/nab/PlateParserTests.java
@@ -19,8 +19,9 @@ import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.exp.ExperimentException;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
 
@@ -119,8 +120,8 @@ public class PlateParserTests
     {
         for (Pair<String, String> test : singlePlateTests)
         {
-            File nabFile = JunitUtil.getSampleData(null, test.first);
-            File expectedFile = JunitUtil.getSampleData(null, test.second);
+            File nabFile = JunitUtil.getSampleData(ModuleLoader.getInstance().getModule(NabModule.class), test.first);
+            File expectedFile = JunitUtil.getSampleData(ModuleLoader.getInstance().getModule(NabModule.class), test.second);
 
             final double[][] expected = parseExpected(expectedFile);
             PlateTemplate template = template(nabFile.getName(), expected.length, expected[0].length);

--- a/nab/src/org/labkey/nab/PlateParserTests.java
+++ b/nab/src/org/labkey/nab/PlateParserTests.java
@@ -21,7 +21,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.exp.ExperimentException;
-import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
 
@@ -120,8 +119,8 @@ public class PlateParserTests
     {
         for (Pair<String, String> test : singlePlateTests)
         {
-            File nabFile = JunitUtil.getSampleData(ModuleLoader.getInstance().getModule(NabModule.class), test.first);
-            File expectedFile = JunitUtil.getSampleData(ModuleLoader.getInstance().getModule(NabModule.class), test.second);
+            File nabFile = JunitUtil.getSampleData(null, test.first);
+            File expectedFile = JunitUtil.getSampleData(null, test.second);
 
             final double[][] expected = parseExpected(expectedFile);
             PlateTemplate template = template(nabFile.getName(), expected.length, expected[0].length);


### PR DESCRIPTION
#### Rationale
`/sampledata` has been deleted from SVN. Most of it has moved to individual modules or the `testAutomation` repository.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1316

#### Changes
* Update sample data references
