### PR TITLE
Fix flow report

### DIFF
--- a/flow/resources/web/Flow/flowReport.js
+++ b/flow/resources/web/Flow/flowReport.js
@@ -42,7 +42,7 @@ function createSampleFilter(filterIdx, filter)
     return {
         xtype:'compositefield', filterIdx: filterIdx, fieldLabel: 'Sample Property', items: [
             {xtype:'hidden', name:'filter[' + filterIdx + '].type', value:'sample'},
-            {xtype:'combo', name:'filter[' + filterIdx + '].property', store:SampleSet.properties, value:filter.property},
+            {xtype:'combo', name:'filter[' + filterIdx + '].property', store:SampleType.properties, value:filter.property},
             {xtype:'textfield', name:'filter[' + filterIdx + '].value', value:filter.value},
             {xtype:'button', text:'Remove', handler: function () { removeFilter(filterIdx); } }
         ]


### PR DESCRIPTION
#### Rationale
statPicker.jsp was changed to set up SampleType.properties, but flowReport.js didn't get the memo

#### Related Pull Requests
https://github.com/LabKey/commonAssays/pull/195

#### Changes
* Update flowReport.js to use SampleType.properties
