### PR TITLE
Discovered in testing issue 40735 - fix various MS2 nested grid problems

### DIFF
--- a/ms2/src/org/labkey/ms2/peptideview/QueryPeptideMS2RunView.java
+++ b/ms2/src/org/labkey/ms2/peptideview/QueryPeptideMS2RunView.java
@@ -24,6 +24,7 @@ import org.labkey.api.data.Filter;
 import org.labkey.api.data.NestableDataRegion;
 import org.labkey.api.data.NestableQueryView;
 import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.ShowRows;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.query.CustomView;
@@ -267,6 +268,11 @@ public class QueryPeptideMS2RunView extends AbstractMS2RunView
         {
             throw new RuntimeException(e);
         }
+
+        // Show all of the peptides with no offsets for this nested grid
+        settings.setOffset(0);
+        settings.setShowRows(ShowRows.ALL);
+
         PeptideQueryView view = new PeptideQueryView(schema, settings, true, false);
         DataRegion region = view.createDataRegion();
         if (!(region instanceof NestableDataRegion))

--- a/ms2/src/org/labkey/ms2/peptideview/QueryProteinGroupMS2RunView.java
+++ b/ms2/src/org/labkey/ms2/peptideview/QueryProteinGroupMS2RunView.java
@@ -22,6 +22,7 @@ import org.labkey.api.data.Filter;
 import org.labkey.api.data.NestableDataRegion;
 import org.labkey.api.data.NestableQueryView;
 import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.ShowRows;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.query.FieldKey;
@@ -74,6 +75,10 @@ public class QueryProteinGroupMS2RunView extends AbstractMS2RunView
         UserSchema schema = QueryService.get().getUserSchema(getUser(), getContainer(), MS2Schema.SCHEMA_NAME);
 
         QuerySettings settings = createQuerySettings(schema);
+
+        // Show all of the member proteins with no offsets for this nested grid
+        settings.setOffset(0);
+        settings.setShowRows(ShowRows.ALL);
 
         ProteinGroupQueryView peptideView = new ProteinGroupQueryView(schema, settings, expanded, forExport);
 
@@ -158,7 +163,7 @@ public class QueryProteinGroupMS2RunView extends AbstractMS2RunView
         {
             throw new RuntimeException(e);
         }
-        ProteinGroupQueryView peptideView = new ProteinGroupQueryView(schema, settings, true, true);
+        ProteinGroupQueryView peptideView = new ProteinGroupQueryView(schema, settings, true, false);
         NestableDataRegion rgn = (NestableDataRegion)peptideView.createDataRegion();
 
         DataRegion nestedRegion = rgn.getNestedRegion();


### PR DESCRIPTION
#### Changes
Fix problem where you don't get peptide or protein info when expanding nested grids on second page of results

Fix problem where you can't expand for protein group - protein info at all