### PR TITLE
Issue 40840: flow: support for sub-populations of boolean populations

### DIFF
--- a/flow/enginesrc/org/labkey/flow/analysis/model/PCWorkspace.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/PCWorkspace.java
@@ -232,6 +232,15 @@ public class PCWorkspace extends FlowJoWorkspace
 
         readStats(subset, elBoolNode, results, analysis, sampleId, warnOnMissingStats);
 
+        // recurse
+        for (Element elSubpopulations : getElementsByTagName(elBoolNode, "Subpopulations"))
+        {
+            List<Population> subpops = readSubpopulations(elSubpopulations, subset, analysis, results, sampleId, warnOnMissingStats);
+            for (Population pop : subpops)
+                ret.addPopulation(pop);
+        }
+
+
         return ret;
     }
 
@@ -284,6 +293,7 @@ public class PCWorkspace extends FlowJoWorkspace
 
         readStats(subset, elPopulation, results, analysis, sampleId, warnOnMissingStats);
 
+        // recurse
         for (Element elSubpopulations : getElementsByTagName(elPopulation, "Subpopulations"))
         {
             List<Population> subpops = readSubpopulations(elSubpopulations, subset, analysis, results, sampleId, warnOnMissingStats);


### PR DESCRIPTION
#### Rationale
- Mac FlowJo workspaces supported sub-populations of booleans, but we didn't support them in .wsp workspaces.
- automated tests will be added to trunk due to the flow sample data move from svn to testAutomation repository
