### PR TITLE
Issue 40848: Adding Percent Neutralization Max and Percent Neutralization Initial Dilution to the NAb Assay results and copied-to-study dataset

### DIFF
--- a/nab/src/org/labkey/nab/NabDataHandler.java
+++ b/nab/src/org/labkey/nab/NabDataHandler.java
@@ -23,6 +23,7 @@ import org.labkey.api.assay.dilution.DilutionAssayRun;
 import org.labkey.api.assay.dilution.DilutionDataHandler;
 import org.labkey.api.assay.dilution.DilutionSummary;
 import org.labkey.api.assay.nab.NabSpecimen;
+import org.labkey.api.assay.nab.query.NAbSpecimenTable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.statistics.StatsService;
@@ -389,5 +390,13 @@ public abstract class NabDataHandler extends DilutionDataHandler
         }
 
         return new Pair<>(row, col);
+    }
+
+    @Override
+    public boolean isValidDataProperty(String propertyName)
+    {
+        return super.isValidDataProperty(propertyName) ||
+            NAbSpecimenTable.PERCENT_NEUT_MAX_PROP.equals(propertyName) ||
+            NAbSpecimenTable.PERCENT_NEUT_INIT_DILUTION_PROP.equals(propertyName);
     }
 }

--- a/nab/src/org/labkey/nab/query/NabRunDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabRunDataTable.java
@@ -111,6 +111,7 @@ public class NabRunDataTable extends NabBaseTable
     public Collection<PropertyDescriptor> getExistingDataProperties(ExpProtocol protocol)
     {
         List<PropertyDescriptor> pds = NabProviderSchema.getExistingDataProperties(protocol, _schema.getCutoffValues());
+        pds.addAll(_nabSpecimenTable.getAdditionalDataProperties(protocol));
 
         pds.sort(Comparator.comparing(PropertyDescriptor::getName));
         return pds;
@@ -341,9 +342,13 @@ public class NabRunDataTable extends NabBaseTable
                 {
                     // Column is in NabSpecimen
                     FieldKey key = FieldKey.fromString(legalName);
-                    visibleColumns.add(key);
                     if (null == getColumn(key))
-                        addWrapColumn(_rootTable.getColumn(key));
+                    {
+                        ColumnInfo col = _rootTable.getColumn(key);
+                        addWrapColumn(col);
+                        if (!col.isHidden())
+                            visibleColumns.add(key);
+                    }
                 }
                 else
                 {

--- a/nab/src/org/labkey/nab/query/NabRunDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabRunDataTable.java
@@ -338,17 +338,15 @@ public class NabRunDataTable extends NabBaseTable
             if (!hiddenCols.contains(lookupCol.getName()))
             {
                 String legalName = ColumnInfo.legalNameFromName(lookupCol.getName());
-                if (null != _rootTable.getColumn(legalName))
+                ColumnInfo col = _rootTable.getColumn(legalName);
+                if (null != col)
                 {
                     // Column is in NabSpecimen
                     FieldKey key = FieldKey.fromString(legalName);
+                    if (!col.isHidden())
+                        visibleColumns.add(key);
                     if (null == getColumn(key))
-                    {
-                        ColumnInfo col = _rootTable.getColumn(key);
-                        addWrapColumn(col);
-                        if (!col.isHidden())
-                            visibleColumns.add(key);
-                    }
+                        addWrapColumn(_rootTable.getColumn(key));
                 }
                 else
                 {


### PR DESCRIPTION
#### Rationale
See info from issue [40848](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40848) and related support ticket [40640](https://www.labkey.org/Atlas/support%20tickets/issues-details.view?issueId=40640). A lab using the LabKey NAb assay tool requested that two new values be calculated and added to the NAb assay results grid. These values were simple calculations off of the DilutionData values we already stored for the NAb assay runs.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1382

#### Changes
* add ExprColumn for two calculated values to the NAbSpecimenTable
* expose the new calculated columns in the NabRunDataTable, but don't add them to the default view
* override isValidDataProperty() in NAbDataHandler so that it considers the two new column names valid
