### PR TITLE
Replace remaining uses of LinkTag with LinkBuilder

### DIFF
--- a/flow/src/org/labkey/flow/controllers/attribute/summary.jsp
+++ b/flow/src/org/labkey/flow/controllers/attribute/summary.jsp
@@ -15,14 +15,13 @@
  * limitations under the License.
  */
 %>
-<%@ page import="java.util.Map" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.flow.controllers.attribute.AttributeController" %>
+<%@ page import="org.labkey.flow.data.AttributeType" %>
 <%@ page import="org.labkey.flow.persist.FlowManager" %>
 <%@ page import="org.labkey.flow.persist.FlowManager.FlowEntry" %>
-<%@ page import="org.labkey.flow.data.AttributeType" %>
 <%@ page import="java.util.Collection" %>
-<%@ page import="org.labkey.flow.controllers.attribute.AttributeController" %>
-<%@ page import="org.labkey.flow.persist.AttributeCache" %>
+<%@ page import="java.util.Map" %>
 <%@ page extends="org.labkey.api.jsp.FormPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -66,7 +65,7 @@
             <% } %>
         </td>
         <td>
-            <labkey:link href='<%=editURL.clone().addParameter(AttributeController.Param.rowId, primary._rowId)%>' text="edit"/>
+            <%=link("edit").href(editURL.clone().addParameter(AttributeController.Param.rowId, primary._rowId))%>
             <%--<% if (totalCount == 0) { %>--%>
             <%--<labkey:link href='<%=deleteURL.clone().addParameter(AttributeController.Param.rowId, primary._rowId)%>' text="delete"/>--%>
             <%--<% } %>--%>
@@ -89,7 +88,7 @@
             <% } %>
         </td>
         <td>
-            <labkey:link href='<%=editURL.clone().addParameter(AttributeController.Param.rowId, alias._rowId)%>' text="edit"/>
+            <%=link("edit").href(editURL.clone().addParameter(AttributeController.Param.rowId, alias._rowId))%>
             <%--<labkey:link href='<%=deleteURL.clone().addParameter(AttributeController.Param.rowId, alias._rowId)%>' text="delete"/>--%>
             <%--<labkey:link href='<%=makePrimaryURL.clone().addParameter(AttributeController.Param.rowId, alias._rowId)%>' text="make primary"/>--%>
         </td>
@@ -101,7 +100,7 @@
         <td style="padding-left: 1.5em;">
         </td>
         <td>
-            <labkey:link href='<%=aliasURL.clone().addParameter(AttributeController.Param.rowId, primary._rowId)%>' text="create alias"/>
+            <%=link("create alias").href(aliasURL.clone().addParameter(AttributeController.Param.rowId, primary._rowId))%>
         </td>
         <td>&nbsp;</td>
     </tr>

--- a/flow/src/org/labkey/flow/controllers/editscript/showCompensationCalculation.jsp
+++ b/flow/src/org/labkey/flow/controllers/editscript/showCompensationCalculation.jsp
@@ -15,16 +15,12 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.apache.commons.lang3.StringUtils" %>
 <%@ page import="org.fhcrc.cpas.flow.script.xml.CompensationCalculationDef" %>
-<%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.flow.controllers.editscript.ScriptController" %>
 <%@ page import="org.labkey.flow.controllers.executescript.AnalysisScriptController" %>
 <%@ page import="org.labkey.flow.data.FlowProtocolStep" %>
 <%@ page extends="org.labkey.flow.controllers.editscript.CompensationCalculationPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
-
-
 <labkey:errors/>
 <%  CompensationCalculationDef calc = compensationCalculationDef();
     if (calc != null)
@@ -62,9 +58,9 @@
     <br/>
     <p>
         This compensation calculation may be edited in a number of ways:<br>
-        <labkey:link text="Upload a FlowJo workspace" href="<%=form.urlFor(ScriptController.UploadCompensationCalculationAction.class)%>" /><br>
-        <labkey:link text="Switch keywords or gates" href="<%=form.urlFor(ScriptController.ChooseCompensationRunAction.class)%>" /><br>
-        <labkey:link href="<%=form.getFlowScript().urlFor(ScriptController.EditGateTreeAction.class, FlowProtocolStep.calculateCompensation)%>" text="Rename gates" /><br>
-        <labkey:link href="<%=form.urlFor(AnalysisScriptController.BeginAction.class)%>" text="Script main page" />
+        <%=link("Upload a FlowJo workspace").href(form.urlFor(ScriptController.UploadCompensationCalculationAction.class))%><br>
+        <%=link("Switch keywords or gates").href(form.urlFor(ScriptController.ChooseCompensationRunAction.class))%><br>
+        <%=link("Rename gates").href(form.getFlowScript().urlFor(ScriptController.EditGateTreeAction.class, FlowProtocolStep.calculateCompensation))%><br>
+        <%=link("Script main page").href(form.urlFor(AnalysisScriptController.BeginAction.class))%>
     </p>
 <% } %>

--- a/flow/src/org/labkey/flow/controllers/executescript/showScript.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/showScript.jsp
@@ -69,7 +69,7 @@ The analysis section describes which gates in the analysis, as well as the stati
 <% if (script.getRunCount() > 0) {
     boolean showRuns = FlowPreference.showRuns.getBooleanValue(request);
     if (showRuns) {
-        %><labkey:link href='<%=url.clone().replaceParameter("showRuns", "0")%>' text="Hide Runs"/><br/><%
+        %><%=link("Hide Runs").href(url.clone().replaceParameter("showRuns", "0"))%><br/><%
 
         BindException errors = new NullSafeBindException(new Object(), "fake");
         FlowSchema schema = new FlowSchema(context);
@@ -88,7 +88,7 @@ The analysis section describes which gates in the analysis, as well as the stati
         view.getSettings().getBaseFilter().addCondition(FieldKey.fromParts("AnalysisScript", "RowId"), script.getScriptId(), CompareType.EQUAL);
         include(view, out);
     } else {
-        %><labkey:link href='<%=url.clone().replaceParameter("showRuns", "1")%>' text="Show Runs"/><%
+        %><%=link("Show Runs").href(url.clone().replaceParameter("showRuns", "1"))%><%
     }
 } %>
 </div>

--- a/flow/src/org/labkey/flow/controllers/protocol/showProtocol.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/showProtocol.jsp
@@ -23,8 +23,9 @@
 <%@ page import="org.labkey.flow.data.FlowProtocol" %>
 <%@ page extends="org.labkey.api.jsp.FormPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
-<% ProtocolForm form = (ProtocolForm) __form;
-   FlowProtocol protocol = form.getProtocol();
+<%
+    ProtocolForm form = (ProtocolForm) __form;
+    FlowProtocol protocol = form.getProtocol();
 %>
 <p>
     The Flow Protocol describes sample information and metadata about the experiment.
@@ -33,36 +34,36 @@
     Upload sample information and match samples with FCSFiles.<br>
     <% if (protocol.getSampleType() == null) { %>
         No samples have been uploaded in this folder.<br>
-        <labkey:link href="<%=protocol.urlCreateSampleType()%>" text="Create new sample type" /><br>
+        <%=link("Create new sample type").href(protocol.urlCreateSampleType())%><br>
     <% } else { %>
-        <labkey:link href="<%=protocol.getSampleType().detailsURL()%>" text="Show sample type"/><br>
-        <labkey:link href="<%=protocol.urlShowSamples()%>" text="Show samples joined to FCS Files" /><br>
-        <labkey:link href="<%=protocol.urlUploadSamples()%>" text="Upload more samples from a spreadsheet" /><br>
+        <%=link("Show sample type").href(protocol.getSampleType().detailsURL())%><br>
+        <%=link("Show samples joined to FCS Files").href(protocol.urlShowSamples())%><br>
+        <%=link("Upload more samples from a spreadsheet").href(protocol.urlUploadSamples())%><br>
         <% if (protocol.getSampleTypeJoinFields().size() != 0) { %>
-            <labkey:link href="<%=protocol.urlFor(JoinSampleTypeAction.class)%>" text="Modify sample join fields" /><br>
+            <%=link("Modify sample join fields").href(protocol.urlFor(JoinSampleTypeAction.class))%><br>
         <% } else { %>
-            <labkey:link href="<%=protocol.urlFor(JoinSampleTypeAction.class)%>" text="Join samples to FCS File Data" /><br>
+            <%=link("Join samples to FCS File Data").href(protocol.urlFor(JoinSampleTypeAction.class))%><br>
         <% } %>
     <% } %>
 </p>
 <p><b>FCS Analysis Display Names</b><br>
     When you analyze an FCS file, the FCS analysis can be given a name composed from keyword values from the FCS file.<br>
-    <labkey:link href="<%=protocol.urlFor(ProtocolController.EditFCSAnalysisNameAction.class)%>" text="Change FCS Analyses Names" />
+    <%=link("Change FCS Analyses Names").href(protocol.urlFor(ProtocolController.EditFCSAnalysisNameAction.class))%>
 </p>
 <p><b>FCS Analysis Filter</b><br>
     You can choose to only analyze FCS files where the keywords match certain criteria.<br>
-    <labkey:link href="<%=protocol.urlFor(ProtocolController.EditFCSAnalysisFilterAction.class)%>" text="Edit FCS Analysis Filter" />
+    <%=link("Edit FCS Analysis Filter").href(protocol.urlFor(ProtocolController.EditFCSAnalysisFilterAction.class))%>
 </p>
 <p><b>Metadata</b><br>
     Identify participant visit/date columns and
     columns used to subtract background from stimulated wells.<br>
-    <labkey:link href="<%=protocol.urlFor(ProtocolController.EditICSMetadataAction.class)%>" text="Edit Metadata" />
+    <%=link("Edit Metadata").href(protocol.urlFor(ProtocolController.EditICSMetadataAction.class))%>
 </p>
 <p><b>Manage Names and Aliases</b><br>
     Create and remove names and aliases for Keywords, Statistics, and Graphs.<br>
-    <labkey:link href='<%=protocol.urlFor(AttributeController.CaseSensitivityAction.class).addReturnURL(getActionURL())%>' text="Case sensitivity"/><br/>
-    <labkey:link href='<%=protocol.urlFor(AttributeController.DeleteUnusedAction.class).addReturnURL(getActionURL())%>' text="Delete Unused"/><br/>
-    <labkey:link href='<%=protocol.urlFor(AttributeController.SummaryAction.class).addParameter(AttributeController.Param.type, AttributeType.keyword.name())%>' text="Manage Keywords"/><br/>
-    <labkey:link href='<%=protocol.urlFor(AttributeController.SummaryAction.class).addParameter(AttributeController.Param.type, AttributeType.statistic.name())%>' text="Manage Statistics"/><br/>
-    <labkey:link href='<%=protocol.urlFor(AttributeController.SummaryAction.class).addParameter(AttributeController.Param.type, AttributeType.graph.name())%>' text="Manage Graphs"/><br/>
+    <%=link("Case sensitivity").href(protocol.urlFor(AttributeController.CaseSensitivityAction.class).addReturnURL(getActionURL()))%><br/>
+    <%=link("Delete Unused").href(protocol.urlFor(AttributeController.DeleteUnusedAction.class).addReturnURL(getActionURL()))%><br/>
+    <%=link("Manage Keywords").href(protocol.urlFor(AttributeController.SummaryAction.class).addParameter(AttributeController.Param.type, AttributeType.keyword.name()))%><br/>
+    <%=link("Manage Statistics").href(protocol.urlFor(AttributeController.SummaryAction.class).addParameter(AttributeController.Param.type, AttributeType.statistic.name()))%><br/>
+    <%=link("Manage Graphs").href(protocol.urlFor(AttributeController.SummaryAction.class).addParameter(AttributeController.Param.type, AttributeType.graph.name()))%><br/>
 </p>

--- a/flow/src/org/labkey/flow/controllers/protocol/showSamples2.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/showSamples2.jsp
@@ -93,14 +93,14 @@
 
 <% if (st == null) { %>
     No samples have been imported in this folder.<br>
-    <labkey:link href="<%=protocol.urlCreateSampleType()%>" text="Create sample type" /><br>
+    <%=link("Create sample type").href(protocol.urlCreateSampleType())%><br>
 <% } else { %>
 <p>
 There are <a href="<%=h(st.detailsURL())%>"><%=sampleCount%> sample descriptions</a> in this folder.<br>
 
 <% if (protocol.getSampleTypeJoinFields().size() == 0) { %>
 <p>
-    <labkey:link href="<%=protocol.urlFor(JoinSampleTypeAction.class)%>" text="Join samples to FCS File Data" /><br>
+    <%=link("Join samples to FCS File Data").href(protocol.urlFor(JoinSampleTypeAction.class))%><br>
     No sample join fields have been defined yet.  The samples are linked to the FCS files using keywords.  When new samples are added or FCS files are loaded, new links will be created.
 <% } else { %>
 
@@ -213,12 +213,12 @@ There are <a href="<%=h(st.detailsURL())%>"><%=sampleCount%> sample descriptions
     </table>
 
     <p>
-        <labkey:link href="<%=st.detailsURL()%>" text="Show sample type"/><br>
-        <labkey:link href="<%=protocol.urlUploadSamples()%>" text="Upload more samples from a spreadsheet" /><br>
+        <%=link("Show sample type").href(st.detailsURL())%>"/><br>
+        <%=link("Upload more samples from a spreadsheet").href(protocol.urlUploadSamples())%><br>
         <% if (protocol.getSampleTypeJoinFields().size() != 0) { %>
-        <labkey:link href="<%=protocol.urlFor(JoinSampleTypeAction.class)%>" text="Modify sample join fields" /><br>
+        <%=link("Modify sample join fields").href(protocol.urlFor(JoinSampleTypeAction.class))%><br>
         <% } else { %>
-        <labkey:link href="<%=protocol.urlFor(JoinSampleTypeAction.class)%>" text="Join samples to FCS File Data" /><br>
+        <%=link("Join samples to FCS File Data").href(protocol.urlFor(JoinSampleTypeAction.class))%><br>
         <% } %>
     </p>
     <% } %>

--- a/flow/src/org/labkey/flow/controllers/run/download.jsp
+++ b/flow/src/org/labkey/flow/controllers/run/download.jsp
@@ -48,7 +48,7 @@
         %>
         </ul>
         <br>
-        <labkey:link href="<%=model.run.urlFor(RunController.DownloadAction.class).addParameter(\"skipMissing\", true)%>" text="Download FCS Files anyway?" />
+        <%=link("Download FCS Files anyway?").href(model.run.urlFor(RunController.DownloadAction.class).addParameter("skipMissing", true))%>
         </p>
 
         <p>

--- a/flow/src/org/labkey/flow/reports/editPositivityReport.jsp
+++ b/flow/src/org/labkey/flow/reports/editPositivityReport.jsp
@@ -71,7 +71,7 @@
   The positivity report requires metadata describing the sample and background information
   of the flow experiment before it can be run.
   <br>
-  <labkey:link href="<%=editICSMetadataURL%>" text="Edit Metadata" />
+  <%=link("Edit Metadata").href(editICSMetadataURL)%>
   </p>
 <% } %>
 


### PR DESCRIPTION
#### Rationale
`LinkTag` is going away.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1395

#### Changes
* Replace remaining uses of LinkTag with LinkBuilder