### PR TITLE
Issue 41014: fix flagging of flow FCSAnalysis wells

### DIFF
--- a/flow/src/org/labkey/flow/data/FlowObject.java
+++ b/flow/src/org/labkey/flow/data/FlowObject.java
@@ -61,6 +61,7 @@ abstract public class FlowObject<T extends ExpObject> implements Comparable<Obje
         _expObject = expObject;
     }
 
+    @Override
     public T getExpObject()
     {
         return _expObject;

--- a/flow/src/org/labkey/flow/view/setComment.jsp
+++ b/flow/src/org/labkey/flow/view/setComment.jsp
@@ -115,7 +115,7 @@ LABKEY.requiresExt3(function() {
                         'line-height': "18px",
                         display: "block",
                         visibility: "hidden",
-                        background: "transparent url(<%=contextPath%>/_.gif) no-repeat 0 2px"
+                        background: "transparent url(<%=h(contextPath)%>/_.gif) no-repeat 0 2px"
                     }
                 });
                 this.alignStatusIcon();
@@ -125,11 +125,11 @@ LABKEY.requiresExt3(function() {
             switch (status)
             {
                 case 'loading':
-                    this.statusEl.setStyle("background-image", "url(<%=contextPath%>/<%=PageFlowUtil.extJsRoot()%>/resources/images/default/grid/loading.gif)");
+                    this.statusEl.setStyle("background-image", "url(<%=h(contextPath)%>/<%=PageFlowUtil.extJsRoot()%>/resources/images/default/grid/loading.gif)");
                     this.statusEl.setStyle("color", "silver");
                     break;
                 case 'success':
-                    this.statusEl.setStyle("background-image", "url(<%=contextPath%>/<%=PageFlowUtil.extJsRoot()%>/resources/images/default/tree/drop-yes.gif)");
+                    this.statusEl.setStyle("background-image", "url(<%=h(contextPath)%>/<%=PageFlowUtil.extJsRoot()%>/resources/images/default/tree/drop-yes.gif)");
                     this.statusEl.setStyle("color", "green");
                     if (!this.delayHide)
                     {
@@ -138,7 +138,7 @@ LABKEY.requiresExt3(function() {
                     this.delayHide.delay(4000);
                     break;
                 case 'error':
-                    this.statusEl.setStyle("background-image", "url(<%=contextPath%>/<%=PageFlowUtil.extJsRoot()%>/resources/images/default/form/exclamation.gif)")
+                    this.statusEl.setStyle("background-image", "url(<%=h(contextPath)%>/<%=PageFlowUtil.extJsRoot()%>/resources/images/default/form/exclamation.gif)")
                     this.statusEl.setStyle("color", "red");
                     break;
             }

--- a/flow/src/org/labkey/flow/view/setGraphSize.jsp
+++ b/flow/src/org/labkey/flow/view/setGraphSize.jsp
@@ -142,7 +142,7 @@
 <%
 for (Map.Entry<String, String> entry : sizes.entrySet()) { %>
     <div class="labkey-graph-size">
-        [<a class="<%=entry.getKey().equals(graphSize) ? "labkey-selected-link" : ""%>" name="graphSize<%=entry.getKey()%>" onclick="setGraphSize(<%=entry.getKey()%>)"><%=h(entry.getValue())%></a>]
+        [<a class="<%=h(entry.getKey().equals(graphSize) ? "labkey-selected-link" : "")%>" name="graphSize<%=h(entry.getKey())%>" onclick="setGraphSize(<%=h(entry.getKey())%>)"><%=h(entry.getValue())%></a>]
     </div>
 <% } %>
 <img id="updateGraphSize" height="1" width="1" src="<%=getWebappURL("_.gif")%>">


### PR DESCRIPTION
#### Rationale
Flagging flow wells broke after flow objects were refactored to implement Identifiable.

The SetFlagAction uses ExperimentService.findObjectFromLSID() to resolve Identifiable objects using LsidManager.getObject(lsid) and expects the result to implement ExpObject.  After refactoring flow objects to implement Identifiable, FlowFCSAnalysis objects are now found before the underlying ExpData object.  The fix is to teach Identifiable how to get a corresponding ExpObject which the SetFlag action can use to set the comment.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1434
* https://github.com/LabKey/commonAssays/pull/145
* https://github.com/LabKey/platform/pull/1000

#### Changes
- add Identifiable.getExpObject() for attaching flag comment
- also fix some unencoded strings
