### PR TITLE
NAb table fixes to use QueryForeignKey for RunData and DilutionData related columns

### DIFF
--- a/nab/src/org/labkey/nab/query/NabDilutionDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabDilutionDataTable.java
@@ -19,6 +19,7 @@ import org.labkey.api.assay.dilution.DilutionManager;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.query.QueryForeignKey;
 
 /**
  * Created by davebradlee on 7/10/15.
@@ -42,17 +43,20 @@ public class NabDilutionDataTable extends NabBaseTable
             String name = col.getName();
             if ("RunDataId".equalsIgnoreCase(name))
                 name = "RunData";
+
             var newCol = addWrapColumn(name, col);
             if (col.isHidden())
-            {
                 newCol.setHidden(col.isHidden());
-            }
+
             if ("MinDilution".equalsIgnoreCase(col.getName()))
             {
                 ColumnInfo maxCol = getRealTable().getColumn("MaxDilution");
                 if (null != maxCol)
                     addWrapColumn(maxCol.getName(), maxCol);
             }
+
+            if ("RunData".equalsIgnoreCase(name))
+                newCol.setFk(QueryForeignKey.from(schema, cf).to("Data", "RowId", "WellGroupName"));
         }
 
         addCondition(getRealTable().getColumn("ProtocolId"), protocol.getRowId());

--- a/nab/src/org/labkey/nab/query/NabWellDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabWellDataTable.java
@@ -33,6 +33,7 @@ import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
+import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.util.StringExpression;
 import org.labkey.nab.NabAssayProvider;
 
@@ -74,10 +75,14 @@ public class NabWellDataTable extends NabBaseTable
                 newCol = addOneBasedColumn(name, col);
             else
                 newCol = addWrapColumn(name, col);
+
             if (col.isHidden())
-            {
                 newCol.setHidden(col.isHidden());
-            }
+
+            if ("DilutionData".equalsIgnoreCase(name))
+                newCol.setFk(QueryForeignKey.from(schema, cf).to("DilutionData", "RowId", "WellGroupName"));
+            if ("RunData".equalsIgnoreCase(name))
+                newCol.setFk(QueryForeignKey.from(schema, cf).to("Data", "RowId", "WellGroupName"));
         }
 
         AssayProvider provider = AssayService.get().getProvider(_protocol);


### PR DESCRIPTION
#### Rationale
A couple of the FKs in the NAb assay schema tables were showing in the schema browser as "null.NAbSpecimen.RowId" and were also not allowing for all of the available calculated columns to be pulled into a custom view via that lookup. This was preventing a client scenario where they wanted to get the NAb assay DilutionData for all rows that were copied to a given study folder, but that "copied to study X" column could not be pulled into the DilutionData grid view.

Note: putting this into develop for now, TBD if this needs to be backported to another release.

#### Changes
* NabDilutionDataTable update to use QueryForeignKey for the RunData column lookup to the Data (i.e. NAbSpecimen) table
* NabWellDataTable update to use QueryForeignKey for the DilutionData and RunData column lookups
