### PR TITLE
Issue 41224: support duplicate sample names in FlowJo workspace

### DIFF
--- a/flow/enginesrc/org/labkey/flow/Main.java
+++ b/flow/enginesrc/org/labkey/flow/Main.java
@@ -199,7 +199,7 @@ public class Main
                     List<Workspace.SampleInfo> samples = new ArrayList<>(sampleIDs.size());
                     for (String sampleId : sampleIDs)
                     {
-                        Workspace.SampleInfo sample = workspace.getSample(sampleId);
+                        Workspace.SampleInfo sample = workspace.getSampleById(sampleId);
                         samples.add(sample);
                     }
                     String indent = "  ";

--- a/flow/enginesrc/org/labkey/flow/analysis/model/BaseWorkspace.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/BaseWorkspace.java
@@ -99,7 +99,7 @@ public abstract class BaseWorkspace<S extends ISampleInfo> implements IWorkspace
     @Override
     public List<S> getSamples()
     {
-        return new ArrayList<>(_sampleInfos.values());
+        return List.copyOf(_sampleInfos.values());
     }
 
     /**

--- a/flow/enginesrc/org/labkey/flow/analysis/model/BaseWorkspace.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/BaseWorkspace.java
@@ -15,30 +15,37 @@
  */
 package org.labkey.flow.analysis.model;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.collections.CaseInsensitiveTreeSet;
 import org.labkey.flow.persist.AttributeSet;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
-public abstract class BaseWorkspace implements IWorkspace, Serializable
+import static java.util.Collections.unmodifiableList;
+
+public abstract class BaseWorkspace<S extends ISampleInfo> implements IWorkspace, Serializable
 {
     protected String _name = null;
     protected String _path = null;
 
-    protected List<String> _warnings = new LinkedList<>();
+    protected final List<String> _warnings = new LinkedList<>();
 
-    protected Set<String> _keywords = new CaseInsensitiveTreeSet();
-    protected Map<String, ParameterInfo> _parameters = new CaseInsensitiveMapWrapper<>(new LinkedHashMap<>());
+    protected final Set<String> _keywords = new CaseInsensitiveTreeSet();
+    protected final Map<String, ParameterInfo> _parameters = new CaseInsensitiveMapWrapper<>(new LinkedHashMap<>());
     // sample id -> analysis results
-    protected Map<String, AttributeSet> _sampleAnalysisResults = new LinkedHashMap<>();
+    protected final Map<String, AttributeSet> _sampleAnalysisResults = new LinkedHashMap<>();
+
+    // sample id -> SampleInfo
+    protected final Map<String, S> _sampleInfos = new CaseInsensitiveMapWrapper<>(new LinkedHashMap<>());
+    // sample id -> SampleInfo
+    protected final Map<String, S> _deletedInfos = new CaseInsensitiveMapWrapper<>(new LinkedHashMap<>());
+    // sample label -> list of sample id
+    protected final Map<String, List<String>> _sampleLabelToIds = new CaseInsensitiveMapWrapper<>(new LinkedHashMap<>());
+    // list of sample labels associated with different sample id
+    protected final List<String> _duplicateSampleLabels = new ArrayList<>();
 
 
     @Override
@@ -82,6 +89,94 @@ public abstract class BaseWorkspace implements IWorkspace, Serializable
     public AttributeSet getSampleAnalysisResults(ISampleInfo sample)
     {
         return _sampleAnalysisResults.get(sample.getSampleId());
+    }
+
+    public int getSampleCount()
+    {
+        return _sampleInfos.size();
+    }
+
+    @Override
+    public List<S> getSamples()
+    {
+        return new ArrayList<>(_sampleInfos.values());
+    }
+
+    /**
+     * Get all samples in the workspace, including samples that are no longer referenced by any group.
+     * Usually using .getSamples() is preferred.
+     * After deleting samples from a FlowJo workspace, the workspace may retain the sample info and just
+     * remove it from the "All Samples" group.
+     */
+    public List<S> getSamplesComplete()
+    {
+        return List.copyOf(_sampleInfos.values());
+    }
+
+    /**
+     * Get all sample IDs in the workspace, including samples that are no longer referenced by any group.
+     */
+    protected List<String> getSampleIdsComplete()
+    {
+        return List.copyOf(_sampleInfos.keySet());
+    }
+
+    /**
+     * Get SampleInfo by workspace sample ID.
+     */
+    @Override
+    public S getSampleById(String sampleId)
+    {
+        S sample = _sampleInfos.get(sampleId);
+        assert sample == null || !sample.isDeleted();
+        return sample;
+    }
+
+    /**
+     * Get SampleInfos by workspace label (typically the FCS filename, $FIL keyword)
+     */
+    @NotNull
+    @Override
+    public List<S> getSampleByLabel(String label)
+    {
+        List<String> ids = _sampleLabelToIds.get(label);
+        if (ids == null)
+            return Collections.emptyList();
+        return ids.stream().map(id -> _sampleInfos.get(id)).collect(Collectors.toList());
+    }
+
+    public S getDeletedSampleById(String sampleId)
+    {
+        S sample = _deletedInfos.get(sampleId);
+        assert sample == null || sample.isDeleted();
+        return sample;
+    }
+
+    @NotNull
+    @Override
+    public List<String> getDuplicateSampleLabels()
+    {
+        return unmodifiableList(_duplicateSampleLabels);
+    }
+
+    // Add the sample and check for duplicates sample IDs
+    protected void addSample(S sampleInfo)
+    {
+        S existing;
+        if (sampleInfo.isDeleted())
+            existing = _deletedInfos.put(sampleInfo.getSampleId(), sampleInfo);
+        else
+            existing = _sampleInfos.put(sampleInfo.getSampleId(), sampleInfo);
+        if (existing != null)
+            throw new FlowException("Sample '" + sampleInfo + "' and '" + existing + "' have the same sample id");
+
+        if (!sampleInfo.isDeleted())
+        {
+            var sampleIds = _sampleLabelToIds.computeIfAbsent(sampleInfo.getLabel(), label -> new ArrayList<>());
+            sampleIds.add(sampleInfo.getSampleId());
+            if (sampleIds.size() == 2)
+                _duplicateSampleLabels.add(sampleInfo.getLabel());
+        }
     }
 
 }

--- a/flow/enginesrc/org/labkey/flow/analysis/model/ISampleInfo.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/ISampleInfo.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.flow.analysis.model;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.flow.persist.AttributeSet;
 
@@ -33,51 +34,48 @@ public interface ISampleInfo
 
     /**
      * Internal sample id used by the workspace or analysis archive.
-     * Not a stable identifier.
-     * @return
+     * Not a stable identifier across imports.
      */
+    @NotNull
     public String getSampleId();
 
     /**
      * The sample name (usually the same as the $FIL keyword, but may be renamed in the workspace.)
-     * @return
+     * The sample name may be null.
      */
+    @Nullable
     public String getSampleName();
 
     /**
      * The $FIL keyword value.
-     * @return
      */
+    @Nullable
     public String getFilename();
 
     /**
      * Get human readable display name (may be sample name, $FIL, or sample id).
-     * @return
      */
+    @NotNull
     public String getLabel();
 
     /**
      * A case-insensitive map of keyword names to values.
-     * @return
      */
     public Map<String, String> getKeywords();
 
     /**
      * The analysis definition which may be null for an analysis archive.
-     * @return
      */
     @Nullable
     public Analysis getAnalysis();
 
     /**
      * The calculated statistics and graphs.
-     * @return
      */
     public AttributeSet getAnalysisResults();
 
     /**
      * The compensation matrix used for analysis.
-     * @return
      */
     public CompensationMatrix getCompensationMatrix();
 }

--- a/flow/enginesrc/org/labkey/flow/analysis/model/IWorkspace.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/IWorkspace.java
@@ -15,7 +15,8 @@
  */
 package org.labkey.flow.analysis.model;
 
-import org.labkey.api.data.Container;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.flow.persist.AttributeSet;
 
 import java.util.List;
@@ -38,44 +39,50 @@ public interface IWorkspace
 
     /**
      * Warnings generated during loading of the workspace.
-     * @return
      */
     List<String> getWarnings();
 
     /**
      * Get union of all keywords found in all samples.
-     * @return
      */
     Set<String> getKeywords();
 
     /**
      * Get a list of all parameter names.
-     * @return
      */
     List<String> getParameterNames();
 
     List<ParameterInfo> getParameters();
 
     /**
-     * Get all internal sample ids.
-     * @return
+     * Get all internal sample ids.  Each id is guaranteed to be unique.
      */
     List<String> getSampleIds();
 
     /**
-     * Get all sample labels.
-     * @return
+     * Get all sample labels.  More than one sample may have the same label.
      */
     List<String> getSampleLabels();
 
     List<? extends ISampleInfo> getSamples();
 
     /**
-     * Get sample by either sample id or label.
-     * @param sampleIdOrLabel
-     * @return
+     * Get SampleInfo by workspace sample ID.
      */
-    ISampleInfo getSample(String sampleIdOrLabel);
+    @Nullable
+    ISampleInfo getSampleById(String sampleId);
+
+    /**
+     * Get SampleInfos by sample label (typically the FCS filename, $FIL keyword)
+     */
+    @NotNull
+    List<? extends ISampleInfo> getSampleByLabel(String label);
+
+    /**
+     * List of duplicate sample lables (FCS filenames) found in the workspace that have distinct IDs.
+     */
+    @NotNull
+    List<String> getDuplicateSampleLabels();
 
     /**
      * @return true if the workspace has an analysis definition
@@ -90,4 +97,10 @@ public interface IWorkspace
 
     List<CompensationMatrix> getCompensationMatrices();
 
+    /**
+     * Create backwards compatibility aliases for boolean populations.
+     */
+    default void createBooleanAliases()
+    {
+    }
 }

--- a/flow/enginesrc/org/labkey/flow/analysis/model/MacWorkspace.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/MacWorkspace.java
@@ -458,8 +458,8 @@ public class MacWorkspace extends FlowJoWorkspace
 
     protected SampleInfo readSample(Element elSample)
     {
-        SampleInfo ret = new SampleInfo();
-        ret._sampleId = elSample.getAttribute("sampleID");
+        String id = elSample.getAttribute("sampleID");
+        SampleInfo ret = new SampleInfo(id, null);
         if (elSample.hasAttribute("compensationID"))
         {
             ret._compensationId = elSample.getAttribute("compensationID");
@@ -469,7 +469,7 @@ public class MacWorkspace extends FlowJoWorkspace
             readKeywords(ret, elFCSHeader);
         }
         readParameterInfo(elSample);
-        _sampleInfos.put(ret._sampleId, ret);
+        addSample(ret);
         return ret;
     }
 

--- a/flow/enginesrc/org/labkey/flow/analysis/model/PCWorkspace.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/PCWorkspace.java
@@ -44,25 +44,22 @@ public class PCWorkspace extends FlowJoWorkspace
 
     protected SampleInfo readSample(Element elSample)
     {
-        SampleInfo sampleInfo = new SampleInfo();
+        Element elSampleNode = getElementByTagName(elSample, "SampleNode");
+        String sampleName = elSampleNode.getAttribute("name");
+        String sampleId = elSampleNode.getAttribute("sampleID");
+        boolean deleted = readSampleDeletedFlag(elSampleNode);
+        SampleInfo sampleInfo = new SampleInfo(sampleId, sampleName, deleted);
+
         for (Element elKeywords : getElementsByTagName(elSample, "Keywords"))
         {
             readKeywords(sampleInfo, elKeywords);
         }
         readParameterInfo(sampleInfo);
 
-        Element elSampleNode = getElementByTagName(elSample, "SampleNode");
-        sampleInfo._sampleName = elSampleNode.getAttribute("name");
-        sampleInfo._sampleId = elSampleNode.getAttribute("sampleID");
-        sampleInfo._deleted = readSampleDeletedFlag(elSampleNode);
-
         readSampleCompensation(sampleInfo, elSample);
         readSampleTransformations(sampleInfo, elSample);
 
-        if (sampleInfo._deleted)
-            _deletedInfos.put(sampleInfo.getSampleId(), sampleInfo);
-        else
-            _sampleInfos.put(sampleInfo.getSampleId(), sampleInfo);
+        addSample(sampleInfo);
         return sampleInfo;
     }
 

--- a/flow/enginesrc/org/labkey/flow/analysis/model/SampleIdMap.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/SampleIdMap.java
@@ -48,9 +48,9 @@ public class SampleIdMap<V>
         };
     }
 
-    private Map<String, V> _idToDataMap;
-    private Map<String, String> _idToNameMap;
-    private CaseInsensitiveArrayListValuedMap<String> _nameToIdMap;
+    private final Map<String, V> _idToDataMap;
+    private final Map<String, String> _idToNameMap;
+    private final CaseInsensitiveArrayListValuedMap<String> _nameToIdMap;
 
     public SampleIdMap()
     {

--- a/flow/enginesrc/org/labkey/flow/analysis/model/SampleInfoBase.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/SampleInfoBase.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.flow.analysis.model;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveTreeMap;
 
 import java.io.Serializable;
@@ -27,10 +29,22 @@ import java.util.Map;
  */
 public abstract class SampleInfoBase implements ISampleInfo, Serializable
 {
-    protected Map<String, String> _keywords = new CaseInsensitiveTreeMap<>();
-    protected String _sampleId;
-    protected String _sampleName;
-    protected boolean _deleted = false;
+    protected final Map<String, String> _keywords = new CaseInsensitiveTreeMap<>();
+    protected final @NotNull String _sampleId;
+    protected final @Nullable String _sampleName;
+    protected final boolean _deleted;
+
+    protected SampleInfoBase(@NotNull String sampleId, @Nullable String sampleName)
+    {
+        this(sampleId, sampleName, false);
+    }
+
+    protected SampleInfoBase(@NotNull String sampleId, @Nullable String sampleName, boolean deleted)
+    {
+        this._sampleId = sampleId;
+        this._sampleName = sampleName;
+        this._deleted = deleted;
+    }
 
     @Override
     public boolean isDeleted()
@@ -45,19 +59,19 @@ public abstract class SampleInfoBase implements ISampleInfo, Serializable
     }
 
     @Override
-    public String getSampleName()
+    public @Nullable String getSampleName()
     {
         return _sampleName;
     }
 
     @Override
-    public String getFilename()
+    public @Nullable String getFilename()
     {
         return getKeywords().get("$FIL");
     }
 
     @Override
-    public String getLabel()
+    public @NotNull String getLabel()
     {
         String ret = _sampleName;
         if (ret == null || ret.length() == 0)
@@ -72,6 +86,16 @@ public abstract class SampleInfoBase implements ISampleInfo, Serializable
     public Map<String, String> getKeywords()
     {
         return Collections.unmodifiableMap(_keywords);
+    }
+
+    public void putKeyword(String keywordName, String keywordValue)
+    {
+        _keywords.put(keywordName, keywordValue);
+    }
+
+    public void putAllKeywords(Map<String, String> keywords)
+    {
+        _keywords.putAll(keywords);
     }
 
     public String toString()

--- a/flow/enginesrc/org/labkey/flow/analysis/web/PlotTests.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/web/PlotTests.java
@@ -89,7 +89,12 @@ public class PlotTests extends Assert
 
     private Map<String, GraphSpec> generatePlots(File outDir, Workspace workspace, File fcsFile) throws Exception
     {
-        Workspace.SampleInfo sample = workspace.getSample(fcsFile.getName());
+        List<? extends Workspace.SampleInfo> samples = workspace.getSampleByLabel(fcsFile.getName());
+        if (samples.size() > 1)
+            throw new RuntimeException("Found duplicate samples for '" + fcsFile.getName() + "'");
+        if (samples.isEmpty())
+            throw new RuntimeException("No sample found for '" + fcsFile.getName() + "'");
+        Workspace.SampleInfo sample = samples.get(0);
         Analysis analysis = workspace.getSampleAnalysis(sample);
         CompensationMatrix comp = sample.getCompensationMatrix();
 

--- a/flow/enginesrc/org/labkey/flow/analysis/web/ScriptAnalyzer.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/web/ScriptAnalyzer.java
@@ -418,7 +418,15 @@ public class ScriptAnalyzer
         }
         else if (sampleId != null)
         {
-            Workspace.SampleInfo sample = workspace.getSample(sampleId);
+            Workspace.SampleInfo sample = workspace.getSampleById(sampleId);
+            if (sample == null)
+            {
+                List<? extends Workspace.SampleInfo> samples = workspace.getSampleByLabel(sampleId);
+                if (samples.size() > 1)
+                    throw new RuntimeException("Found duplicate samples for '" + sampleId + "'");
+                if (!samples.isEmpty())
+                    sample = samples.get(0);
+            }
             if (sample == null)
                 throw new RuntimeException("Cannot find sample '" + sampleId + "'");
 

--- a/flow/enginesrc/org/labkey/flow/util/KeywordUtil.java
+++ b/flow/enginesrc/org/labkey/flow/util/KeywordUtil.java
@@ -58,6 +58,9 @@ public class KeywordUtil
             "BD\\$.*|" +
             "CST .*|" +
             "SPILL|" +
+            "\\$SPILLOVER|" +
+            "COMP|" +
+            "\\$COMP|" +
             "\\$DFC\\d+TO\\d+|" +
             "APPLY COMPENSATION|" +
             "CREATOR|" +

--- a/flow/enginesrc/org/labkey/flow/util/KeywordUtil.java
+++ b/flow/enginesrc/org/labkey/flow/util/KeywordUtil.java
@@ -59,7 +59,6 @@ public class KeywordUtil
             "CST .*|" +
             "SPILL|" +
             "\\$SPILLOVER|" +
-            "COMP|" +
             "\\$COMP|" +
             "\\$DFC\\d+TO\\d+|" +
             "APPLY COMPENSATION|" +

--- a/flow/src/org/labkey/flow/controllers/WorkspaceData.java
+++ b/flow/src/org/labkey/flow/controllers/WorkspaceData.java
@@ -16,8 +16,8 @@
 
 package org.labkey.flow.controllers;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.Container;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
@@ -55,12 +55,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.labkey.api.action.SpringActionController.ERROR_MSG;
 
 public class WorkspaceData implements Serializable
 {
-    static final private Logger _log = LogManager.getLogger(WorkspaceData.class);
+    private static final Logger _log = LogManager.getLogger(WorkspaceData.class);
+    private static final boolean CREATE_BOOLEAN_ALIASES = true;
 
     String path;
     String name;
@@ -220,6 +222,9 @@ public class WorkspaceData implements Serializable
                 }
 
                 _object = readWorkspace(file, path);
+
+                if (CREATE_BOOLEAN_ALIASES)
+                    _object.createBooleanAliases();
 
                 FlowProtocol protocol = FlowProtocol.ensureForContainer(user,  container);
                 validateKeywordCasing(container, errors, protocol.isCaseSensitiveKeywords());

--- a/flow/src/org/labkey/flow/controllers/WorkspaceData.java
+++ b/flow/src/org/labkey/flow/controllers/WorkspaceData.java
@@ -62,7 +62,6 @@ import static org.labkey.api.action.SpringActionController.ERROR_MSG;
 public class WorkspaceData implements Serializable
 {
     private static final Logger _log = LogManager.getLogger(WorkspaceData.class);
-    private static final boolean CREATE_BOOLEAN_ALIASES = true;
 
     String path;
     String name;
@@ -222,9 +221,6 @@ public class WorkspaceData implements Serializable
                 }
 
                 _object = readWorkspace(file, path);
-
-                if (CREATE_BOOLEAN_ALIASES)
-                    _object.createBooleanAliases();
 
                 FlowProtocol protocol = FlowProtocol.ensureForContainer(user,  container);
                 validateKeywordCasing(container, errors, protocol.isCaseSensitiveKeywords());

--- a/flow/src/org/labkey/flow/controllers/compensation/CompensationController.java
+++ b/flow/src/org/labkey/flow/controllers/compensation/CompensationController.java
@@ -135,7 +135,7 @@ public class CompensationController extends BaseFlowController
             AttributeSetHelper.prepareForSave(name, attrs, getContainer(), true);
             try (DbScope.Transaction transaction = svc.ensureTransaction())
             {
-                _flowComp = FlowCompensationMatrix.create(getUser(), getContainer(), form.ff_compensationMatrixName, attrs);
+                _flowComp = FlowCompensationMatrix.create(getUser(), getContainer(), form.ff_compensationMatrixName, attrs, null);
                 transaction.commit();
             }
             return true;

--- a/flow/src/org/labkey/flow/controllers/executescript/ImportAnalysisForm.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/ImportAnalysisForm.java
@@ -18,12 +18,10 @@ package org.labkey.flow.controllers.executescript;
 import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.flow.analysis.model.Workspace;
 import org.labkey.flow.controllers.WorkspaceData;
-import org.labkey.flow.data.FlowRun;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * User: kevink
@@ -45,9 +43,8 @@ public class ImportAnalysisForm
     private final SelectedSamples selectedSamples = new SelectedSamples();
 
     private int step = AnalysisScriptController.ImportAnalysisStep.SELECT_ANALYSIS.getNumber();
-    private SelectFCSFileOption selectFCSFilesOption = SelectFCSFileOption.None;
-    private Map<FlowRun, String> existingKeywordRuns = null;
-    private int existingKeywordRunId;
+    private SelectFCSFileOption selectFCSFilesOption = null;
+    private boolean keywordRunsExist = false;
     private String importGroupNames = Workspace.ALL_SAMPLES;
     private boolean resolving = false;
     private AnalysisEngine selectAnalysisEngine = null;
@@ -111,20 +108,14 @@ public class ImportAnalysisForm
     }
 
     // not a POSTed parameter - For rending the SELECT_FCSFILES step
-    public void setExistingKeywordRuns(Map<FlowRun, String> keywordRuns)
+    public boolean getKeywordRunsExist()
     {
-        this.existingKeywordRuns = keywordRuns;
+        return keywordRunsExist;
     }
 
-    // not a POSTed parameter
-    public Map<FlowRun, String> getExistingKeywordRuns()
+    protected void setKeywordRunsExist(boolean keywordRunsExist)
     {
-        return existingKeywordRuns;
-    }
-
-    public int getExistingKeywordRunId()
-    {
-        return existingKeywordRunId;
+        this.keywordRunsExist = keywordRunsExist;
     }
 
     public AnalysisEngine getSelectAnalysisEngine()
@@ -150,11 +141,6 @@ public class ImportAnalysisForm
     public void setImportGroupNames(String importGroupNames)
     {
         this.importGroupNames = importGroupNames;
-    }
-
-    public void setExistingKeywordRunId(int existingKeywordRunId)
-    {
-        this.existingKeywordRunId = existingKeywordRunId;
     }
 
     public boolean isCreateAnalysis()

--- a/flow/src/org/labkey/flow/controllers/executescript/SamplesConfirmGridView.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/SamplesConfirmGridView.java
@@ -237,6 +237,10 @@ public class SamplesConfirmGridView extends GridView
             dr.addDisplayColumn(dc);
         }
 
+        // Add SampleId column
+        dc = new SimpleDisplayColumn("${" + SAMPLE_ID_FIELD_KEY.getName() + "}");
+        dc.setCaption("ID");
+        dr.addDisplayColumn(dc);
 
         // Add SampleName column
         dc = new SimpleDisplayColumn("${" + SAMPLE_NAME_FIELD_KEY.getName() + "}");

--- a/flow/src/org/labkey/flow/controllers/executescript/importAnalysisChooseAnalysis.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/importAnalysisChooseAnalysis.jsp
@@ -46,7 +46,6 @@
 %>
 
 <input type="hidden" name="selectFCSFilesOption" id="selectFCSFilesOption" value="<%=form.getSelectFCSFilesOption()%>">
-<input type="hidden" name="existingKeywordRunId" id="existingKeywordRunId" value="<%=h(form.getExistingKeywordRunId())%>">
 <% if (form.getKeywordDir() != null) for (String keywordDir : form.getKeywordDir()) { %>
 <input type="hidden" name="keywordDir" value="<%=h(keywordDir)%>">
 <% } %>
@@ -80,11 +79,6 @@
                 if (keywordDir != null)
                     keywordDirs.add(keywordDir);
             }
-        }
-        else if (form.getExistingKeywordRunId() > 0)
-        {
-            FlowRun keywordsRun = FlowRun.fromRunId(form.getExistingKeywordRunId());
-            keywordDirs.add(new File(keywordsRun.getPath()));
         }
         else if (form.getSelectedSamples().getRows() != null && !form.getSelectedSamples().getRows().isEmpty())
         {
@@ -163,7 +157,7 @@ those results must be put into different analysis folders.
                 <input type="radio" id="chooseExistingAnalysis" name="createAnalysis" value="false" checked>
             </td>
             <td>
-                Choose an analysis folder to put the results into:<br>
+                <label for="chooseExistingAnalysis">Choose an analysis folder to put the results into:</label><br>
                 <select name="existingAnalysisId" onfocus="document.forms.importAnalysis.chooseExistingAnalysis.checked = true;">
                     <%
                         FlowExperiment recentAnalysis = FlowExperiment.getMostRecentAnalysis(container);
@@ -194,7 +188,7 @@ those results must be put into different analysis folders.
                 <input type="radio" id="chooseNewAnalysis" name="createAnalysis" value="true">
             </td>
             <td>
-                Create a new analysis folder:<br>
+                <label for="chooseNewAnalysis">Create a new analysis folder:</label><br>
                 <input type="text" name="newAnalysisName" value="<%=h(newAnalysisName)%>" onfocus="document.forms.importAnalysis.chooseNewAnalysis.checked = true;">
                 <br><br>
             </td>

--- a/flow/src/org/labkey/flow/controllers/executescript/importAnalysisConfirm.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/importAnalysisConfirm.jsp
@@ -73,7 +73,6 @@
 %>
 
 <input type="hidden" name="selectFCSFilesOption" id="selectFCSFilesOption" value="<%=form.getSelectFCSFilesOption()%>">
-<input type="hidden" name="existingKeywordRunId" id="existingKeywordRunId" value="<%=h(form.getExistingKeywordRunId())%>">
 <% if (form.getKeywordDir() != null) for (String keywordDir : form.getKeywordDir()) { %>
 <input type="hidden" name="keywordDir" value="<%=h(keywordDir)%>">
 <% } %>
@@ -133,19 +132,7 @@
     </li>
 
     <%
-        FlowRun keywordRun = FlowRun.fromRunId(form.getExistingKeywordRunId());
-        if (keywordRun != null) {
-            String keywordRunPath = pipeRoot.relativePath(new File(keywordRun.getPath()));
-    %>
-    <li style="padding-bottom:0.5em;">
-        <b>Existing FCS File run:</b>
-        <a href="<%=keywordRun.urlShow().addParameter(QueryParam.queryName, FlowTableType.FCSFiles.toString())%>" target="_blank" title="Show FCS File run in a new window"><%=h(keywordRun.getName())%></a>
-    </li>
-    <li style="padding-bottom:0.5em;">
-        <b>FCS File Path:</b> <%=h(keywordRunPath)%>
-    </li>
-    <%
-    } else if (form.isResolving() && !form.getSelectedSamples().getRows().isEmpty()) {
+    if (form.isResolving() && !form.getSelectedSamples().getRows().isEmpty()) {
     %>
     <li style="padding-bottom:0.5em;">
         <b>Existing FCS files:</b>

--- a/flow/src/org/labkey/flow/controllers/executescript/importAnalysisReviewSamples.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/importAnalysisReviewSamples.jsp
@@ -55,7 +55,7 @@
             Map<String, String[]> groupSamples = new TreeMap<>();
             for (String sampleID : group.getSampleIds())
             {
-                Workspace.SampleInfo sampleInfo = w.getSample(sampleID);
+                Workspace.SampleInfo sampleInfo = w.getSampleById(sampleID);
                 if (sampleInfo != null)
                     groupSamples.put(sampleInfo.getLabel(), new String[] { sampleInfo.getSampleId(), sampleInfo.getLabel() });
             }
@@ -88,7 +88,6 @@
 %>
 
 <input type="hidden" name="selectFCSFilesOption" id="selectFCSFilesOption" value="<%=form.getSelectFCSFilesOption()%>">
-<input type="hidden" name="existingKeywordRunId" id="existingKeywordRunId" value="<%=h(form.getExistingKeywordRunId())%>">
 <% if (form.getKeywordDir() != null) for (String keywordDir : form.getKeywordDir()) { %>
 <input type="hidden" name="keywordDir" value="<%=h(keywordDir)%>">
 <% } %>

--- a/flow/src/org/labkey/flow/controllers/executescript/importAnalysisSelectFCSFiles.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/importAnalysisSelectFCSFiles.jsp
@@ -33,7 +33,7 @@
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     ImportAnalysisForm form = (ImportAnalysisForm)getModelBean();
-    Map<FlowRun, String> keywordRuns = form.getExistingKeywordRuns();
+    boolean keywordRunsExist = form.getKeywordRunsExist();
     Container container = getContainer();
     PipelineService pipeService = PipelineService.get();
     PipeRoot pipeRoot = pipeService.findPipelineRoot(container);
@@ -58,13 +58,6 @@
     }
 %>
 <script type="text/javascript">
-    function clearExistingRunIdCombo()
-    {
-        var combo = document.forms.importAnalysis.existingKeywordRunId;
-        if (combo && combo.tagName.toLowerCase() === "select")
-            combo.selectedIndex = 0;
-    }
-
     function clearFileBrowserSelection(selectedValue)
     {
         if (fileBrowser && fileBrowser.rendered)
@@ -77,7 +70,6 @@
 
     function clearSelections(selectedValue)
     {
-        //clearExistingRunIdCombo();
         clearFileBrowserSelection(selectedValue);
         return true;
     }
@@ -122,12 +114,12 @@
 <input type="radio" name="selectFCSFilesOption"
        id="<%=ImportAnalysisForm.SelectFCSFileOption.Previous%>" value="<%=ImportAnalysisForm.SelectFCSFileOption.Previous%>"
         <%=checked(Objects.equals(form.getSelectFCSFilesOption(), ImportAnalysisForm.SelectFCSFileOption.Previous))%>
-        <%=disabled(keywordRuns == null || keywordRuns.isEmpty())%>
+        <%=disabled(!keywordRunsExist)%>
        onclick="clearSelections(this.value);" />
 <label for="<%=ImportAnalysisForm.SelectFCSFileOption.Previous%>">
-    <div style="display:inline-block; <%=text(keywordRuns == null || keywordRuns.isEmpty() ? "color:silver;" : "")%>">Previously imported FCS files.</div>
+    <div style="display:inline-block; <%=text(!keywordRunsExist ? "color:silver;" : "")%>">Previously imported FCS files.</div>
 </label>
-<div style="padding-left: 2em; padding-bottom: 1em; <%=text(keywordRuns == null || keywordRuns.isEmpty() ? "color:silver;" : "")%>">
+<div style="padding-left: 2em; padding-bottom: 1em; <%=text(!keywordRunsExist ? "color:silver;" : "")%>">
     <%=h(FlowModule.getLongProductName())%> will attempt to match the samples in the <%=h(workspace.getKindName())%> with previously imported FCS files.
 </div>
 
@@ -165,10 +157,8 @@
             Ext.get(inputId).dom.value=path;
             if (path)
             {
-                clearExistingRunIdCombo();
                 document.getElementById("<%=ImportAnalysisForm.SelectFCSFileOption.Browse%>").checked = true;
             }
-            // setTitle...
         }
 
         function renderFileBrowser()

--- a/flow/src/org/labkey/flow/data/FlowCompensationMatrix.java
+++ b/flow/src/org/labkey/flow/data/FlowCompensationMatrix.java
@@ -16,6 +16,8 @@
 
 package org.labkey.flow.data;
 
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.exp.api.ExpData;
@@ -71,7 +73,7 @@ public class FlowCompensationMatrix extends FlowDataObject implements Serializab
         return ret;
     }
 
-    static public FlowCompensationMatrix create(User user, Container container, String name, AttributeSet attrs) throws Exception
+    static public FlowCompensationMatrix create(User user, Container container, String name, AttributeSet attrs, @Nullable Logger log) throws Exception
     {
         ExperimentService svc = ExperimentService.get();
 
@@ -89,7 +91,7 @@ public class FlowCompensationMatrix extends FlowDataObject implements Serializab
             }
             data.setDataFileURI(new File(FlowSettings.getWorkingDirectory(), "compensation." + FlowDataHandler.EXT_DATA).toURI());
             data.save(user);
-            AttributeSetHelper.doSave(attrs, user, data);
+            AttributeSetHelper.doSave(attrs, user, data, log);
             flowComp = (FlowCompensationMatrix) FlowDataObject.fromData(data);
             transaction.commit();
             return flowComp;

--- a/flow/src/org/labkey/flow/data/FlowFCSFile.java
+++ b/flow/src/org/labkey/flow/data/FlowFCSFile.java
@@ -31,6 +31,20 @@ import java.util.ListIterator;
 
 public class FlowFCSFile extends FlowWell
 {
+    // Represents an FCS file selected by the user for import that has no corresponding FCS file imported in the database.
+    // This can happen when there are no FCS files to be imported or when a directory of FCS files will be imported at the same time as the workspace.
+    // Unfortuantely, since we use Jackson serialization to save/restore the job state, we can't check UNMAPPED for object equality
+    // and instead rely on the <code>isUnresolved</code> method to check for a null ExpData.
+    public static final FlowFCSFile UNMAPPED = new FlowFCSFile();
+    static {
+        UNMAPPED.setEntityId("UNMAPPED");
+    }
+
+    public final boolean isUnmapped()
+    {
+        return null == getData() && "UNMAPPED".equals(getEntityId());
+    }
+
     // For serialization
     protected FlowFCSFile() {}
 

--- a/flow/src/org/labkey/flow/data/FlowRunWorkspace.java
+++ b/flow/src/org/labkey/flow/data/FlowRunWorkspace.java
@@ -50,12 +50,10 @@ public class FlowRunWorkspace extends Workspace
         for (FlowFCSFile well : run.getFCSFiles())
         {
             String key = Integer.toString(well.getWellId());
-            SampleInfo info = new SampleInfo();
-            info.setSampleName(well.getName());
-            info.setSampleId(key);
+            SampleInfo info = new SampleInfo(key, well.getName());
             FCSKeywordData fcs = FCSAnalyzer.get().readAllKeywords(FlowAnalyzer.getFCSRef(well));
             info.putAllKeywords(fcs.getAllKeywords());
-            _sampleInfos.put(info.getSampleId(), info);
+            addSample(info);
             _sampleAnalyses.put(info.getSampleId(), analysis);
             Map<String,String> params = FlowAnalyzer.getParameters(well, null);
             for (String param : params.keySet())

--- a/flow/src/org/labkey/flow/script/AbstractExternalAnalysisJob.java
+++ b/flow/src/org/labkey/flow/script/AbstractExternalAnalysisJob.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
 import org.fhcrc.cpas.flow.script.xml.ScriptDocument;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SimpleFilter;
@@ -35,10 +36,14 @@ import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
+import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.flow.analysis.model.Analysis;
 import org.labkey.flow.analysis.model.CompensationMatrix;
+import org.labkey.flow.analysis.model.FlowException;
+import org.labkey.flow.analysis.model.ISampleInfo;
+import org.labkey.flow.analysis.model.IWorkspace;
 import org.labkey.flow.analysis.model.SampleIdMap;
 import org.labkey.flow.controllers.executescript.AnalysisEngine;
 import org.labkey.flow.data.FlowCompensationMatrix;
@@ -60,10 +65,12 @@ import org.labkey.flow.persist.FlowManager;
 import org.labkey.flow.persist.InputRole;
 import org.labkey.flow.persist.ObjectType;
 import org.labkey.flow.util.KeywordUtil;
+import org.labkey.flow.util.SampleUtil;
 
 import java.io.File;
 import java.net.URI;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -71,6 +78,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * User: kevink
@@ -84,8 +92,9 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
     private final File _runFilePathRoot;
     // Directories of FCS files to be imported.
     private final List<File> _keywordDirs;
-    // Map workspace sample label -> FlowFCSFile (or null if we aren't resolving previously imported FCS files)
-    private Map<String, FlowFCSFile> _selectedFCSFiles;
+    // Map workspace sample ID -> FlowFCSFile (or FlowFCSFile.UNMAPPED if we aren't resolving previously imported FCS files)
+    private SampleIdMap<FlowFCSFile> _selectedFCSFiles;
+    private List<FlowFCSFile> _newFlowWells;
 //    private final List<String> _importGroupNames;
     private final Container _targetStudy;
     private final boolean _failOnError;
@@ -120,7 +129,7 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
             File originalImportedFile,
             File runFilePathRoot,
             List<File> keywordDirs,
-            Map<String, FlowFCSFile> selectedFCSFiles,
+            SampleIdMap<FlowFCSFile> selectedFCSFiles,
             //List<String> importGroupNames,
             Container targetStudy,
             boolean failOnError)
@@ -178,9 +187,88 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
         return _originalImportedFile;
     }
 
-    public Map<String,FlowFCSFile> getSelectedFCSFiles()
+    public SampleIdMap<FlowFCSFile> getSelectedFCSFiles()
     {
         return _selectedFCSFiles;
+    }
+
+    // The list of FCSFile that have been imported in this job just before importing the workspace analysis
+    public List<FlowFCSFile> getNewlyImportedFCSFiles()
+    {
+        return _newFlowWells;
+    }
+
+    /**
+     * Resolve the newly imported FCS files against the selected FCS files that have
+     * not been resolved yet.  The keywords in the workspace are used to match against
+     * the importedFCSFiles.
+     */
+    public static SampleIdMap<FlowFCSFile> resolveSelectedFCSFiles(IWorkspace workspace, SampleIdMap<FlowFCSFile> selectedFCSFiles, List<FlowFCSFile> importedFCSFiles)
+    {
+        // Don't bother resolving anything if no FCS files were imported as a part of this job
+        if (importedFCSFiles == null || importedFCSFiles.isEmpty())
+            return selectedFCSFiles;
+
+        // check if we need to resolve anything
+        boolean needsResolving = selectedFCSFiles.isEmpty() || selectedFCSFiles.values().stream().anyMatch(FlowFCSFile::isUnmapped);
+        if (!needsResolving)
+            return selectedFCSFiles;
+
+        // resolved the newly imported FCS files against the keywords in the workspace
+        var resolved = SampleUtil.resolveSamples(workspace.getSamples(), importedFCSFiles);
+        if (resolved.isEmpty())
+            return selectedFCSFiles;
+
+        SampleIdMap<FlowFCSFile> ret = new SampleIdMap<>();
+        if (selectedFCSFiles.isEmpty())
+        {
+            // select all samples from the workspace
+            for (ISampleInfo sample : resolved.keySet())
+            {
+                var pair = resolved.get(sample);
+                collectResolved(ret, sample, pair);
+            }
+        }
+        else
+        {
+            for (String id : selectedFCSFiles.idSet())
+            {
+                ISampleInfo sample = workspace.getSampleById(id);
+                if (sample == null)
+                    throw new FlowException("Selected sample '" + id + "' not found in workspace");
+
+                FlowFCSFile file = selectedFCSFiles.getById(id);
+                if (file.isUnmapped())
+                {
+                    // use the matched fcs file
+                    var pair = resolved.get(sample);
+                    collectResolved(ret, sample, pair);
+                }
+                else
+                {
+                    // use the selected information from the user
+                    ret.put(sample, file);
+                }
+            }
+        }
+
+        return ret;
+    }
+
+    private static void collectResolved(SampleIdMap<FlowFCSFile> map, ISampleInfo sample, Pair<FlowFCSFile, List<FlowFCSFile>> match)
+    {
+        if (match.first != null)
+        {
+            // perfect match
+            map.put(sample, match.first);
+        }
+        else
+        {
+            StringBuilder sb = new StringBuilder("Failed to find FCS file matching selected sample '" + sample + "' from imported FCS files");
+            if (!match.second.isEmpty())
+                sb.append("\npartial matching FCS files: ").append(match.second.stream().map(FlowFCSFile::toString).collect(Collectors.joining(", ")));
+            throw new FlowException(sb.toString());
+        }
     }
 
     public Container getTargetStudy()
@@ -209,10 +297,9 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
                 List<FlowRun> runs = KeywordsTask.importFlowRuns(this, _protocol, getKeywordDirectories(), getTargetStudy());
 
                 // Consider the newly imported files as the resolved FCSFiles, but don't add any new selectedFCSFiles unless there are no selected files.
-                // NOTE: Duplicate samples are ignored.
                 if (_selectedFCSFiles == null)
-                    _selectedFCSFiles = new HashMap<>();
-                boolean addNewFCSFiles = _selectedFCSFiles.isEmpty();
+                    _selectedFCSFiles = new SampleIdMap<>();
+                List<FlowFCSFile> newWells = new ArrayList<>();
                 for (FlowRun run : runs)
                 {
                     for (FlowWell well : run.getWells())
@@ -221,15 +308,12 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
                         {
                             FlowFCSFile file = (FlowFCSFile)well;
                             if (file.isOriginalFCSFile())
-                            {
-                                // Only add newly imported FCS Files if there are no selected FCS Files or the selected FCS File isn't resolved yet.
-                                String wellName = well.getName();
-                                if (addNewFCSFiles || (_selectedFCSFiles.containsKey(wellName) && _selectedFCSFiles.get(wellName) == null))
-                                    _selectedFCSFiles.put(wellName, (FlowFCSFile)well);
-                            }
+                                newWells.add(file);
                         }
                     }
                 }
+
+                _newFlowWells = newWells;
             }
 
             if (!hasErrors())
@@ -289,7 +373,7 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
     protected FlowRun saveAnalysis(User user, Container container, FlowExperiment experiment,
                                    String analysisName, File externalAnalysisFile, File originalImportedFile,
                                    File runFilePathRoot,
-                                   Map<String, FlowFCSFile> selectedFCSFiles,
+                                   SampleIdMap<FlowFCSFile> selectedFCSFiles,
                                    SampleIdMap<AttributeSet> keywordsMap,
                                    SampleIdMap<CompensationMatrix> sampleCompMatrixMap,
                                    SampleIdMap<AttributeSet> resultsMap,
@@ -362,11 +446,11 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
                 String sampleLabel = sampleNames.iterator().next();
 
                 iSample++;
-                FlowFCSFile resolvedFCSFile = null;
+                FlowFCSFile resolvedFCSFile = FlowFCSFile.UNMAPPED;
                 if (selectedFCSFiles != null)
                 {
-                    resolvedFCSFile = selectedFCSFiles.get(sampleLabel);
-                    assert resolvedFCSFile == null || resolvedFCSFile.isOriginalFCSFile();
+                    resolvedFCSFile = selectedFCSFiles.getById(sampleId);
+                    assert resolvedFCSFile != null && (resolvedFCSFile.isUnmapped() || resolvedFCSFile.isOriginalFCSFile());
                 }
 
                 // Create a 'fake' FCSFile if there is no resolved original FCSFile, or the extra keywords are not a subset of the resolved FCSFile's keywords:
@@ -375,7 +459,7 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
                 // - If there is an 'original' FCSFile and there are additional extra keywords, the 'original' FCSFile is a DataInput of the 'fake' FCSFile (which in turn is a DatInput of the FCSAnalysis.)
                 FlowFCSFile flowFCSFile = resolvedFCSFile;
                 AttributeSet keywordAttrs = keywordsMap.getById(sampleId);
-                if (resolvedFCSFile == null || (keywordAttrs != null && !isSubset(keywordAttrs.getKeywords(), resolvedFCSFile.getKeywords())))
+                if (resolvedFCSFile.isUnmapped() || (keywordAttrs != null && !isSubset(keywordAttrs.getKeywords(), resolvedFCSFile.getKeywords())))
                 {
                     flowFCSFile = createFakeFCSFile(user, container,
                             resolvedFCSFile,
@@ -400,7 +484,7 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
                 AttributeSet compAttrs = entry.getValue();
                 assert compAttrs.getType() == ObjectType.compensationMatrix;
 
-                FlowCompensationMatrix flowComp = FlowCompensationMatrix.create(user, container, null, compAttrs);
+                FlowCompensationMatrix flowComp = FlowCompensationMatrix.create(user, container, null, compAttrs, getLogger());
                 ExpProtocolApplication paComp = run.addProtocolApplication(user, FlowProtocolStep.calculateCompensation.getAction(protocol), ExpProtocol.ApplicationType.ProtocolApplication, FlowProtocolStep.calculateCompensation.getName());
                 paComp.addDataInput(user, externalAnalysisData, InputRole.Workspace.toString());
                 flowComp.getData().setSourceApplication(paComp);
@@ -453,7 +537,7 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
 
                     addStatus("Saving FCSAnalysis " + iAnalysis + "/" + totAnalysis + ":" + fcsAnalysis.getName());
                     fcsAnalysis.save(user);
-                    AttributeSetHelper.doSave(results, user, fcsAnalysis);
+                    AttributeSetHelper.doSave(results, user, fcsAnalysis, getLogger());
 
                     Analysis analysis = analysisMap.getById(sampleId);
                     if (analysis != null)
@@ -540,7 +624,7 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
 
     // Create a 'fake' FCSFile for the import.
     private FlowFCSFile createFakeFCSFile(User user, Container container,
-                                   FlowFCSFile resolvedFCSFile,
+                                   @NotNull FlowFCSFile resolvedFCSFile,
                                    AttributeSet keywordAttrs,
                                    URI dataFileURI,
                                    ExpRun run,
@@ -557,7 +641,7 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
         paSample.addDataInput(user, externalAnalysisData, InputRole.Workspace.toString());
 
         // Attach the real original FCSFile as an input to the fake well
-        if (resolvedFCSFile != null)
+        if (!resolvedFCSFile.isUnmapped())
         {
             assert resolvedFCSFile.isOriginalFCSFile() : "Original FlowFCSFile is not original: " + (resolvedFCSFile.getData() != null ? resolvedFCSFile.getData().getDataFileUrl() : "<no ExpData>");
             if (resolvedFCSFile.getData() != null)
@@ -578,7 +662,7 @@ public abstract class AbstractExternalAnalysisJob extends FlowExperimentJob
         if (keywordAttrs == null)
             keywordAttrs = new AttributeSet(ObjectType.fcsKeywords, null);
         assert keywordAttrs.getType() == ObjectType.fcsKeywords;
-        AttributeSetHelper.doSave(keywordAttrs, user, fcsFile);
+        AttributeSetHelper.doSave(keywordAttrs, user, fcsFile, getLogger());
 
         // Attach the experiment sample to the fake FCSFile generated from the workspace.
         SampleKey sampleKey = flowProtocol.makeSampleKey(run.getName(), fcsFile.getName(), keywordAttrs);

--- a/flow/src/org/labkey/flow/script/WorkspaceJob.java
+++ b/flow/src/org/labkey/flow/script/WorkspaceJob.java
@@ -285,7 +285,7 @@ public class WorkspaceJob extends AbstractExternalAnalysisJob
                 return true;
 
             iSample++;
-            String description = "sample " + iSample + "/" + sampleIDs.size() + ": " + sample.getLabel();
+            String description = "sample " + iSample + "/" + sampleIDs.size() + ": " + sample.toString();
             addStatus("Preparing " + description);
 
             AttributeSet attrs = new AttributeSet(ObjectType.fcsKeywords, null);

--- a/flow/src/org/labkey/flow/script/WorkspaceJob.java
+++ b/flow/src/org/labkey/flow/script/WorkspaceJob.java
@@ -105,7 +105,7 @@ public class WorkspaceJob extends AbstractExternalAnalysisJob
                         File originalImportedFile,
                         File runFilePathRoot,
                         List<File> keywordDirs,
-                        Map<String, FlowFCSFile> selectedFCSFiles,
+                        SampleIdMap<FlowFCSFile> selectedFCSFiles,
                         //List<String> importGroupNames,
                         Container targetStudy,
                         boolean failOnError)
@@ -151,9 +151,11 @@ public class WorkspaceJob extends AbstractExternalAnalysisJob
         {
             Workspace workspace = (Workspace)ois.readObject();
 
+            SampleIdMap<FlowFCSFile> selectedFCSFiles = resolveSelectedFCSFiles(workspace, getSelectedFCSFiles(), getNewlyImportedFCSFiles());
+
             return createExperimentRun(getUser(), getContainer(), workspace,
                     getExperiment(), _workspaceName, _workspaceFile, getOriginalImportedFile(),
-                    getRunFilePathRoot(), getSelectedFCSFiles(),
+                    getRunFilePathRoot(), selectedFCSFiles,
                     isFailOnError());
         }
     }
@@ -161,7 +163,7 @@ public class WorkspaceJob extends AbstractExternalAnalysisJob
     private FlowRun createExperimentRun(User user, Container container,
                                         Workspace workspace, FlowExperiment experiment,
                                         String workspaceName, File workspaceFile, File originalImportedFile,
-                                        File runFilePathRoot, Map<String, FlowFCSFile> resolvedFCSFiles,
+                                        File runFilePathRoot, SampleIdMap<FlowFCSFile> resolvedFCSFiles,
                                         boolean failOnError) throws Exception
     {
         SampleIdMap<AttributeSet> keywordsMap = new SampleIdMap<>();
@@ -211,7 +213,7 @@ public class WorkspaceJob extends AbstractExternalAnalysisJob
             List<String> filteredSampleIDs = new ArrayList<>(sampleIDs.size());
             for (String sampleID : sampleIDs)
             {
-                Workspace.SampleInfo sampleInfo = workspace.getSample(sampleID);
+                Workspace.SampleInfo sampleInfo = workspace.getSampleById(sampleID);
                 if (matchesFilter(fcsFilesTable, analysisFilter, sampleInfo.getLabel(), sampleInfo.getKeywords()))
                 {
                     filteredSampleIDs.add(sampleID);
@@ -229,7 +231,7 @@ public class WorkspaceJob extends AbstractExternalAnalysisJob
         }
     }
 
-    private List<String> getSampleIDs(Workspace workspace, Map<String, FlowFCSFile> selectedFCSFile)
+    private List<String> getSampleIDs(Workspace workspace, SampleIdMap<FlowFCSFile> selectedFCSFile)
     {
         List<String> sampleIDs;
         if (selectedFCSFile == null || selectedFCSFile.isEmpty())
@@ -239,10 +241,9 @@ public class WorkspaceJob extends AbstractExternalAnalysisJob
         else
         {
             sampleIDs = new ArrayList<>(workspace.getSampleCount());
-            for (Map.Entry<String, FlowFCSFile> entry : selectedFCSFile.entrySet())
+            for (String id : selectedFCSFile.idSet())
             {
-                String sampleLabel = entry.getKey();
-                Workspace.SampleInfo sample = workspace.getSample(sampleLabel);
+                Workspace.SampleInfo sample = workspace.getSampleById(id);
                 if (sample != null)
                     sampleIDs.add(sample.getSampleId());
             }
@@ -255,7 +256,7 @@ public class WorkspaceJob extends AbstractExternalAnalysisJob
     private boolean extractAnalysis(Container container,
                                     Workspace workspace,
                                     File runFilePathRoot,
-                                    Map<String, FlowFCSFile> selectedFCSFiles,
+                                    SampleIdMap<FlowFCSFile> selectedFCSFiles,
                                     //List<String> importGroupNames,
                                     boolean failOnError,
                                     SampleIdMap<AttributeSet> keywordsMap,
@@ -276,7 +277,7 @@ public class WorkspaceJob extends AbstractExternalAnalysisJob
         int iSample = 0;
         for (String sampleID : sampleIDs)
         {
-            Workspace.SampleInfo sample = workspace.getSample(sampleID);
+            Workspace.SampleInfo sample = workspace.getSampleById(sampleID);
 
             allSampleIds.add(sampleID);
             sampleIdToNameMap.put(sampleID, sample.getLabel());
@@ -294,10 +295,8 @@ public class WorkspaceJob extends AbstractExternalAnalysisJob
             File file = null;
             if (selectedFCSFiles != null)
             {
-                FlowFCSFile resolvedFCSFile = selectedFCSFiles.get(sampleID);
-                if (resolvedFCSFile == null)
-                    resolvedFCSFile = selectedFCSFiles.get(sample.getLabel());
-                if (resolvedFCSFile != null)
+                FlowFCSFile resolvedFCSFile = selectedFCSFiles.getById(sampleID);
+                if (!resolvedFCSFile.isUnmapped())
                 {
                     uri = resolvedFCSFile.getFCSURI();
                     if (uri != null)

--- a/flow/src/org/labkey/flow/util/SampleUtil.java
+++ b/flow/src/org/labkey/flow/util/SampleUtil.java
@@ -34,9 +34,10 @@ import java.util.Objects;
  */
 public class SampleUtil
 {
-    private static final String[] KEYWORDS = new String[] { "$FIL", "GUID", "$TOT", "$PAR", "$DATE", "$ETIM", "EXPORT TIME" };
-    private static final int MAX_MATCHES = KEYWORDS.length+1;
-    private static final int MIN_MATCHES = 2;
+    private static final String[] KEYWORDS = new String[] { "$FIL", "GUID", "$TOT", "$PAR", "$DATE", "$ETIM", "EXPORT TIME", "$ENDDATA" };
+    // max possible score: 2 points for each keyword (and one more for the file name itself)
+    private static final int MAX_MATCHES = 2 * (KEYWORDS.length+1);
+    private static final int MIN_MATCHES = 4;
 
     private static class FlowFCSFileList extends ArrayList<FlowFCSFile>
     {
@@ -51,8 +52,16 @@ public class SampleUtil
         assert a.length == b.length;
         int dist = -1;
         for (int i = 0, len = a.length; i < len; i++)
+        {
             if (Objects.equals(a[i], b[i]))
-                dist++;
+            {
+                // give non-null values more weight
+                if (a[i] != null)
+                    dist += 2;
+                else
+                    dist += 1;
+            }
+        }
 
         return dist;
     }


### PR DESCRIPTION
#### [Issue 41224](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41224): support duplicate sample names in FlowJo workspace

The flow import process supports duplicate samples for external analysis archives but not for FlowJo workspaces.  This change consolidates sample handling in the workspace data model to ensure unique sample IDs but allow duplicate sample labels across all format types.

The FCS file resolve step in the import wizard switched from using a simple Map of sample label to the resolved FCS file to a SampleIdMap to guarantee unique sample ID values.  The import wizard supports selecting FCS files from the workspace for import that aren't resolved in two cases: (1) when not resolving against any FCS files, (2) importing a directory of FCS files at the same time as the workspace is imported.  In the latter case, the newly imported FCS files will be matched against the samples in the workspace by keyword values.  A marker FlowFCSFile.UNMATCHED value is used to represent the selected but unresolved samples that will be imported.

#### [Issue 41225](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41225): flow: import failure for duplicate aliased statistics

It is possible to have two boolean populations defined that result in the same alias. When importing the workspace, the boolean population's count statistic will have an alias created that represents the boolean expression. If two boolean populations have the same boolean expression aliases, they will all become aliases of each other. For example, the count statistic of boolean population "Foo" that represents A or B will have an alias created "(A|B):Count" for "Foo:Count". If a second population "Bar" also represents A or B, it will have the same alias "(A|B):Count" and will become aliases of "Foo:Count" as well.

When importing the statistics, we insert the stat value using the preferred statistic name ("Foo:Count" in our example) and enforce a single statistic definition for each flow well.  This change detects duplicate statistics and will print a warning to the job log file if the statistic values are identical or throw an error if they are not.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/441
