### PR TITLE
fix intermittent FlowDuplicateSamplesTest failure

### DIFF
--- a/flow/src/org/labkey/flow/controllers/BaseFlowController.java
+++ b/flow/src/org/labkey/flow/controllers/BaseFlowController.java
@@ -83,7 +83,7 @@ public abstract class BaseFlowController extends SpringActionController
             PipelineService service = PipelineService.get();
             service.queueJob(job);
 
-            ActionURL forward = job.getStatusHref().clone();
+            ActionURL forward = job.urlStatus();
             putParam(forward, FlowParam.redirect, 1);
             return forward;
         }

--- a/flow/src/org/labkey/flow/script/FlowJob.java
+++ b/flow/src/org/labkey/flow/script/FlowJob.java
@@ -178,28 +178,15 @@ public abstract class FlowJob extends PipelineJob
     @Override
     public ActionURL getStatusHref()
     {
-        ActionURL ret = urlRedirect();
-        if (ret != null)
-            return ret;
-
-        ret = urlStatus();
-        if (ret != null)
-            return ret;
-
-        return null;
-    }
-
-    public ActionURL urlRedirect()
-    {
-        if (!isComplete())
-            return null;
         if (hasErrors())
             return null;
         return urlData();
     }
 
+    /** Link to imported data once job has completed */
     public abstract ActionURL urlData();
 
+    /** Link to pipeline status details */
     public ActionURL urlStatus()
     {
         if (_statusHref == null)

--- a/flow/src/org/labkey/flow/script/FlowJob.java
+++ b/flow/src/org/labkey/flow/script/FlowJob.java
@@ -108,19 +108,6 @@ public abstract class FlowJob extends PipelineJob
     }
 
 
-    public int getElapsedTime()
-    {
-        Date start = _start;
-        if (start == null)
-            return 0;
-        Date end = _end;
-        if (end == null)
-        {
-            end = new Date();
-        }
-        return (int) (end.getTime() - start.getTime());
-    }
-
     synchronized public void addStatus(String status)
     {
         info(status);
@@ -136,11 +123,6 @@ public abstract class FlowJob extends PipelineJob
     {
         super.error(message, t);
         setStatus(TaskStatus.error);
-    }
-
-    public boolean isComplete()
-    {
-        return _end != null;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Fix intermittent test failure in FlowDuplicateSamplesTest.  For questionable historical reasons, the flow import job would use the pipeline details URL as it's status URL while running and switch to a URL for the imported data once completed successfully. With the switch to the new pipeline status details page, that behavior is no longer needed.  However, it was possible the job would report it's URL as the pipeline status URL even if the job was completed successfully due to a race.

#### Changes
- don't use pipeline status URL as the job's status url