### PR TITLE
Fb jsp print

### DIFF
--- a/flow/src/org/labkey/flow/controllers/editscript/uploadAnalysis.jsp
+++ b/flow/src/org/labkey/flow/controllers/editscript/uploadAnalysis.jsp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.labkey.api.util.HasHtmlString" %>
+<%@ page import="org.labkey.api.util.element.Input.InputBuilder" %>
 <%@ page import="org.labkey.flow.analysis.model.PopulationName" %>
 <%@ page import="org.labkey.flow.analysis.model.StatisticSet" %>
 <%@ page import="org.labkey.flow.controllers.editscript.ScriptController" %>
@@ -23,7 +23,7 @@
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.flow.controllers.editscript.ScriptController.UploadAnalysisPage" %>
 <%!
-    private HasHtmlString statOption(StatisticSet option)
+    private InputBuilder<?> statOption(StatisticSet option)
     {
         return input()
             .type("checkbox")

--- a/flow/src/org/labkey/flow/controllers/executescript/ImportAnalysisForm.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/ImportAnalysisForm.java
@@ -16,7 +16,6 @@
 package org.labkey.flow.controllers.executescript;
 
 import org.labkey.api.util.SafeToRenderEnum;
-import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.flow.analysis.model.Workspace;
 import org.labkey.flow.controllers.WorkspaceData;
 

--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -99,7 +99,6 @@ import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.SafeToRenderEnum;
-import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.util.URLHelper;

--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -91,10 +91,10 @@ import org.labkey.api.util.ContainerContext;
 import org.labkey.api.util.DOM;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.Formats;
-import org.labkey.api.util.HasHtmlString;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.JobRunner;
+import org.labkey.api.util.Link.LinkBuilder;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -479,7 +479,7 @@ public class MS2Controller extends SpringActionController
     public static class RunSummaryBean
     {
         public MS2Run run;
-        public HasHtmlString modHref;
+        public LinkBuilder modHref;
         public boolean writePermissions;
         public String quantAlgorithm;
     }
@@ -653,7 +653,7 @@ public class MS2Controller extends SpringActionController
     }
 
 
-    private HasHtmlString modificationHref(MS2Run run)
+    private LinkBuilder modificationHref(MS2Run run)
     {
         Map<String, String> fixed = new TreeMap<>();
         Map<String, String> var = new TreeMap<>();

--- a/ms2/src/org/labkey/ms2/MS2ExportType.java
+++ b/ms2/src/org/labkey/ms2/MS2ExportType.java
@@ -20,7 +20,6 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.ms2.peptideview.AbstractMS2RunView;

--- a/ms2/src/org/labkey/ms2/ShowPeptideContext.java
+++ b/ms2/src/org/labkey/ms2/ShowPeptideContext.java
@@ -19,8 +19,7 @@ package org.labkey.ms2;
 import org.labkey.api.data.Container;
 import org.labkey.api.ms2.MS2Urls;
 import org.labkey.api.security.User;
-import org.labkey.api.services.ServiceRegistry;
-import org.labkey.api.util.HasHtmlString;
+import org.labkey.api.util.Link.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 
@@ -40,10 +39,10 @@ public class ShowPeptideContext
     public ActionURL previousUrl;
     public ActionURL nextUrl;
     public ActionURL showGzUrl;
-    public HasHtmlString modificationHref;
+    public LinkBuilder modificationHref;
     public String pepSearchHref;
 
-    ShowPeptideContext(MS2Controller.DetailsForm form, MS2Run run, MS2Peptide peptide, ActionURL url, ActionURL previousUrl, ActionURL nextUrl, ActionURL showGzUrl, HasHtmlString modHref, Container container, User user)
+    ShowPeptideContext(MS2Controller.DetailsForm form, MS2Run run, MS2Peptide peptide, ActionURL url, ActionURL previousUrl, ActionURL nextUrl, ActionURL showGzUrl, LinkBuilder modHref, Container container, User user)
     {
         this.form = form;
         this.run = run;


### PR DESCRIPTION
#### Rationale
Eliminate unused `SimpleHasHtmlString` imports in preparation for its removal on platform. Stop assuming `HasHtmlString` is safe to render.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1548