### PR TITLE
Finalize JSP print() work

### DIFF
--- a/elisa/src/org/labkey/elisa/view/runDetailsView.jsp
+++ b/elisa/src/org/labkey/elisa/view/runDetailsView.jsp
@@ -78,24 +78,24 @@
             runTableName    : <%=q(form.getRunTableName())%>,
             runId           : <%=form.getRunId()%>,
             dataRegionName  : <%=q(form.getDataRegionName())%>,
-            baseUrl         : <%=q(baseUrl.getLocalURIString())%>
+            baseUrl         : <%=q(baseUrl)%>
         });
 
         Ext4.create('LABKEY.ext4.GenericChartPanel', {
             renderTo        : <%=q(renderId)%>,
             height          : 500,
             padding         : '20px 0',
-            schemaName      : <%=q(form.getSchemaName() != null ? form.getSchemaName() : null) %>,
-            queryName       : <%=q(form.getQueryName() != null ? form.getQueryName() : null) %>,
+            schemaName      : <%=q(form.getSchemaName())%>,
+            queryName       : <%=q(form.getQueryName())%>,
             dataRegionName  : <%=q(form.getDataRegionName())%>,
             renderType      : <%=q(form.getRenderType())%>,
-            baseUrl         : <%=q(baseUrl.getLocalURIString())%>,
+            baseUrl         : <%=q(baseUrl)%>,
             allowShare      : <%=c.hasPermission(user, ShareReportPermission.class)%>,
             isDeveloper     : <%=user.isBrowserDev()%>,
             hideSave        : <%=user.isGuest()%>,
             hideViewData    : true,
-            autoColumnYName  : <%=q(form.getAutoColumnYName() != null ? form.getAutoColumnYName() : null)%>,
-            autoColumnXName  : <%=q(form.getAutoColumnXName() != null ? form.getAutoColumnXName() : null)%>,
+            autoColumnYName  : <%=q(form.getAutoColumnYName())%>,
+            autoColumnXName  : <%=q(form.getAutoColumnXName())%>,
             defaultNumberFormat: eval(<%=q(numberFormatFn)%>),
             allowEditMode   : <%=!user.isGuest() && c.hasPermission(user, UpdatePermission.class)%>,
             curveFit        : {type : 'linear', min: 0, max: 100, points: 5, params : <%=text(jsonMapper.writeValueAsString(form.getFitParams()))%>},

--- a/flow/src/org/labkey/flow/controllers/editscript/EditScriptForm.java
+++ b/flow/src/org/labkey/flow/controllers/editscript/EditScriptForm.java
@@ -53,8 +53,8 @@ import java.util.Map;
 
 public class EditScriptForm extends FlowObjectForm<FlowScript>
 {
-    static private Logger _log = LogManager.getLogger(EditScriptForm.class);
-    private static int MAX_WELLS_TO_POLL = 15;
+    private static final Logger _log = LogManager.getLogger(EditScriptForm.class);
+    private static final int MAX_WELLS_TO_POLL = 15;
 
     public ScriptDocument analysisDocument;
     public FlowProtocolStep step;
@@ -233,7 +233,7 @@ public class EditScriptForm extends FlowObjectForm<FlowScript>
         catch (Throwable t)
         {
             _log.error("Error", t);
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
         }
     }
 

--- a/flow/src/org/labkey/flow/controllers/editscript/ScriptController.java
+++ b/flow/src/org/labkey/flow/controllers/editscript/ScriptController.java
@@ -17,8 +17,8 @@
 package org.labkey.flow.controllers.editscript;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.xmlbeans.XmlCursor;
 import org.apache.xmlbeans.XmlObject;
 import org.fhcrc.cpas.flow.script.xml.AnalysisDef;
@@ -97,8 +97,7 @@ import java.util.StringTokenizer;
  */
 public class ScriptController extends BaseFlowController
 {
-    private static Logger _log = LogManager.getLogger(ScriptController.class);
-
+    private static final Logger _log = LogManager.getLogger(ScriptController.class);
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(ScriptController.class);
 
     public ScriptController()
@@ -434,9 +433,9 @@ public class ScriptController extends BaseFlowController
             return form.getFlowScript();
         }
 
-        public String formAction(Class<? extends Controller> actionClass)
+        public ActionURL formAction(Class<? extends Controller> actionClass)
         {
-            return form.urlFor(actionClass).toString();
+            return form.urlFor(actionClass);
         }
     }
 

--- a/flow/src/org/labkey/flow/controllers/editscript/copy.jsp
+++ b/flow/src/org/labkey/flow/controllers/editscript/copy.jsp
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.labkey.flow.data.FlowProtocolStep"%>
-<%@ page import="org.labkey.flow.controllers.editscript.ScriptController"%>
-<%@ page import="org.labkey.flow.controllers.editscript.CopyProtocolForm" %>
+<%@ page import="org.labkey.flow.controllers.editscript.CopyProtocolForm"%>
+<%@ page import="org.labkey.flow.controllers.editscript.ScriptController.CopyAction"%>
+<%@ page import="org.labkey.flow.data.FlowProtocolStep" %>
 <%@ page extends="org.labkey.flow.controllers.editscript.ScriptController.Page" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <% CopyProtocolForm form = (CopyProtocolForm) this.form; %>
 <labkey:errors/>
-<labkey:form action="<%=formAction(ScriptController.CopyAction.class)%>" method="POST">
+<labkey:form action="<%=formAction(CopyAction.class)%>" method="POST">
     <p>
         What do you want to call the new script?<br>
         <input type="text" name="name" value="<%=h(form.name)%>">

--- a/flow/src/org/labkey/flow/controllers/editscript/editAnalysis.jsp
+++ b/flow/src/org/labkey/flow/controllers/editscript/editAnalysis.jsp
@@ -18,15 +18,15 @@
 <%@ page import="org.labkey.flow.analysis.web.StatisticSpec" %>
 <%@ page import="org.labkey.flow.analysis.web.SubsetSpec"%>
 <%@ page import="org.labkey.flow.controllers.editscript.AnalysisForm" %>
-<%@ page import="org.labkey.flow.controllers.editscript.ScriptController" %>
+<%@ page import="org.labkey.flow.controllers.editscript.ScriptController.EditAnalysisAction" %>
 <%@ page import="java.util.Collection" %>
 <%@ page import="java.util.Map" %>
 <%@ page extends="org.labkey.flow.controllers.editscript.ScriptController.Page" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
-<% AnalysisForm bean = (AnalysisForm) form; %>
-<%Map<String, String> params = form.getParameters();
+<%
+    AnalysisForm bean = (AnalysisForm) form;
+    Map<String, String> params = form.getParameters();
     Collection<SubsetSpec> subsets = form.getFlowScript().getSubsets();
-
 %>
 <labkey:errors/>
 <script>
@@ -146,7 +146,7 @@
     }
 </script>
 
-<labkey:form method="post" action="<%=formAction(ScriptController.EditAnalysisAction.class)%>">
+<labkey:form method="post" action="<%=formAction(EditAnalysisAction.class)%>">
     <p>
         <b>Statistics</b><br>
         Which statistics do you want to calculate? Enter one statistic per line.<br>

--- a/flow/src/org/labkey/flow/controllers/editscript/editCompensationCalculation.jsp
+++ b/flow/src/org/labkey/flow/controllers/editscript/editCompensationCalculation.jsp
@@ -17,7 +17,7 @@
 %>
 <%@ page import="org.labkey.api.query.FieldKey" %>
 <%@ page import="org.labkey.flow.analysis.model.AutoCompensationScript" %>
-<%@ page import="org.labkey.flow.controllers.editscript.ScriptController" %>
+<%@ page import="org.labkey.flow.controllers.editscript.ScriptController.EditCompensationCalculationAction" %>
 <%@ page import="java.util.List"%>
 <%@ page import="java.util.Map"%>
 <%@ page import="java.util.TreeMap" %>
@@ -102,7 +102,7 @@ var KV = {}; // KEYWORD->VALUE->SUBSET
 var keywordValueSubsetListMap = KV; 
 </script>
 
-<labkey:form method="POST" action="<%=formAction(ScriptController.EditCompensationCalculationAction.class)%>">
+<labkey:form method="POST" action="<%=formAction(EditCompensationCalculationAction.class)%>">
 
 <% if (hasAutoCompScripts) { %>
         <labkey:panel title="Choose AutoCompensation script">

--- a/flow/src/org/labkey/flow/controllers/editscript/editGateTree.jsp
+++ b/flow/src/org/labkey/flow/controllers/editscript/editGateTree.jsp
@@ -19,7 +19,7 @@
 <%@ page import="org.labkey.api.util.HtmlString"%>
 <%@ page import="org.labkey.flow.analysis.web.SubsetSpec"%>
 <%@ page import="org.labkey.flow.controllers.editscript.EditGateTreeForm" %>
-<%@ page import="org.labkey.flow.controllers.editscript.ScriptController" %>
+<%@ page import="org.labkey.flow.controllers.editscript.ScriptController.EditGateTreeAction" %>
 <%@ page extends="org.labkey.flow.controllers.editscript.ScriptController.Page" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 
@@ -34,7 +34,7 @@
 <p>
     Use this page to rename populations.  To delete a population, delete its name.<br>
 </p>
-<labkey:form action="<%=formAction(ScriptController.EditGateTreeAction.class)%>" method="POST">
+<labkey:form action="<%=formAction(EditGateTreeAction.class)%>" method="POST">
 <table class="lk-fields-table">
     <%
         for (int i = 0; i < form.populationNames.length; i ++)

--- a/flow/src/org/labkey/flow/controllers/editscript/editScript.jsp
+++ b/flow/src/org/labkey/flow/controllers/editscript/editScript.jsp
@@ -17,7 +17,7 @@
 %>
 <%@ page import="org.labkey.api.util.PageFlowUtil"%>
 <%@ page import="org.labkey.flow.ScriptParser"%>
-<%@ page import="org.labkey.flow.controllers.editscript.ScriptController"%>
+<%@ page import="org.labkey.flow.controllers.editscript.ScriptController.EditScriptAction"%>
 <%@ page import="org.labkey.flow.data.FlowScript" %>
 <%@ page extends="org.labkey.flow.controllers.editscript.ScriptController.EditPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -25,7 +25,7 @@
     FlowScript script = getScript();
     ScriptParser.Error error = scriptParseError;
 %>
-<labkey:form method="POST" action="<%=formAction(ScriptController.EditScriptAction.class)%>">
+<labkey:form method="POST" action="<%=formAction(EditScriptAction.class)%>">
 <% if (error != null) { %>
 <p class="labkey-error"><%=unsafe(PageFlowUtil.filter(error.getMessage(), true).replaceAll("\\n", "<br>"))%></p>
 <% if (error.getLine() != 0) { %>

--- a/flow/src/org/labkey/flow/controllers/editscript/uploadAnalysis.jsp
+++ b/flow/src/org/labkey/flow/controllers/editscript/uploadAnalysis.jsp
@@ -18,7 +18,7 @@
 <%@ page import="org.labkey.api.util.element.Input.InputBuilder" %>
 <%@ page import="org.labkey.flow.analysis.model.PopulationName" %>
 <%@ page import="org.labkey.flow.analysis.model.StatisticSet" %>
-<%@ page import="org.labkey.flow.controllers.editscript.ScriptController" %>
+<%@ page import="org.labkey.flow.controllers.editscript.ScriptController.UploadAnalysisAction" %>
 <%@ page import="java.util.Map" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.flow.controllers.editscript.ScriptController.UploadAnalysisPage" %>
@@ -33,7 +33,7 @@
     }
 %>
 <labkey:errors/>
-<labkey:form method="POST" action="<%=formAction(ScriptController.UploadAnalysisAction.class)%>" enctype="multipart/form-data">
+<labkey:form method="POST" action="<%=formAction(UploadAnalysisAction.class)%>" enctype="multipart/form-data">
     <% if (form._workspaceObject != null)
     { %>
     <input type="hidden" name="token" value="<%=h(form.getToken())%>">

--- a/flow/src/org/labkey/flow/controllers/editscript/uploadCompensationCalculation.jsp
+++ b/flow/src/org/labkey/flow/controllers/editscript/uploadCompensationCalculation.jsp
@@ -16,12 +16,11 @@
  */
 %>
 <%@ page import="org.labkey.flow.FlowModule" %>
-<%@ page import="org.labkey.flow.controllers.editscript.ScriptController" %>
+<%@ page import="org.labkey.flow.controllers.editscript.ScriptController.EditCompensationCalculationAction" %>
 <%@ page extends="org.labkey.flow.controllers.editscript.CompensationCalculationPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <labkey:errors />
-<labkey:form method="POST" action="<%=formAction(ScriptController.EditCompensationCalculationAction.class)%>"
-      enctype="multipart/form-data">
+<labkey:form method="POST" action="<%=formAction(EditCompensationCalculationAction.class)%>" enctype="multipart/form-data">
     <p>
         The compensation calculation tells <%=h(FlowModule.getLongProductName())%> how
         to identify the compensation controls in an experiment run, and what gates

--- a/flow/src/org/labkey/flow/controllers/executescript/chooseAnalysisName.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/chooseAnalysisName.jsp
@@ -19,10 +19,10 @@
 <%@ page import="org.labkey.api.data.Container"%>
 <%@ page import="org.labkey.api.data.DataRegion" %>
 <%@ page import="org.labkey.api.data.DataRegionSelection" %>
-<%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
-<%@ page import="org.labkey.flow.controllers.executescript.AnalysisScriptController" %>
+<%@ page import="org.labkey.flow.controllers.executescript.AnalysisScriptController.AnalyzeSelectedRunsAction" %>
+<%@ page import="org.labkey.flow.controllers.executescript.AnalysisScriptController.ChooseRunsToAnalyzeAction" %>
 <%@ page import="org.labkey.flow.controllers.executescript.ChooseRunsToAnalyzeForm" %>
 <%@ page import="org.labkey.flow.data.FlowExperiment" %>
 <%@ page import="java.util.HashSet" %>
@@ -35,7 +35,7 @@
     Container c = getContainer();
 %>
 <labkey:errors/>
-<labkey:form method="POST" action="<%=buildURL(AnalysisScriptController.AnalyzeSelectedRunsAction.class)%>">
+<labkey:form method="POST" action="<%=urlFor(AnalyzeSelectedRunsAction.class)%>">
     <p>What do you want to call the new analysis folder?<br>
         <% String name = form.ff_analysisName;
             if (StringUtils.isEmpty(name))
@@ -59,8 +59,8 @@
         <input type="text" name="ff_analysisName" value="<%=h(name)%>">
     </p>
 
-    <labkey:button text="Analyze runs" action="<%=new ActionURL(AnalysisScriptController.AnalyzeSelectedRunsAction.class, c)%>"/>
-    <labkey:button text="Go back" action="<%=new ActionURL(AnalysisScriptController.ChooseRunsToAnalyzeAction.class, c)%>"/>
+    <labkey:button text="Analyze runs" action="<%=urlFor(AnalyzeSelectedRunsAction.class)%>"/>
+    <labkey:button text="Go back" action="<%=urlFor(ChooseRunsToAnalyzeAction.class)%>"/>
     <% for (int runid : form.getSelectedRunIds()) { %>
     <input type="hidden" name="<%=h(DataRegion.SELECT_CHECKBOX_NAME)%>" value="<%=runid%>">
     <% } %>

--- a/flow/src/org/labkey/flow/controllers/executescript/importAnalysisChooseAnalysis.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/importAnalysisChooseAnalysis.jsp
@@ -171,7 +171,7 @@ those results must be put into different analysis folders.
                         {
                             String disabledReason = disabledAnalyses.get(analysis.getExperimentId());
                     %>
-                    <option value="<%=h(analysis.getExperimentId())%>"
+                    <option value="<%=analysis.getExperimentId()%>"
                             <%=selected(disabledReason == null && analysis.getExperimentId() == selectedId)%>
                             <%=text(disabledReason != null ? "disabled=\"disabled\" title=\"" + h(disabledReason) + "\"":"")%>>
                         <%=h(analysis.getName())%>

--- a/flow/src/org/labkey/flow/controllers/executescript/importAnalysisConfirm.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/importAnalysisConfirm.jsp
@@ -93,7 +93,7 @@
 <% if (form.isCreateAnalysis()) { %>
 <input type="hidden" name="newAnalysisName" id="newAnalysisName" value="<%=h(form.getNewAnalysisName())%>">
 <% } else { %>
-<input type="hidden" name="existingAnalysisId" id="existingAnalysisId" value="<%=h(form.getExistingAnalysisId())%>">
+<input type="hidden" name="existingAnalysisId" id="existingAnalysisId" value="<%=form.getExistingAnalysisId()%>">
 <% } %>
 
 <input type="hidden" name="targetStudy" id="targetStudy" value="<%=h(form.getTargetStudy())%>">
@@ -149,7 +149,7 @@
             ActionURL url = schema.urlFor(QueryAction.executeQuery, FlowTableType.FCSFiles);
             filter.applyToURL(url, QueryView.DATAREGIONNAME_DEFAULT);
         %>
-        <a href="<%=h(url)%>" target="_blank" title="Show FCS files"><%=h(rowIds.size())%> FCS files</a>
+        <a href="<%=h(url)%>" target="_blank" title="Show FCS files"><%=rowIds.size()%> FCS files</a>
     </li>
     <%
     } else {

--- a/flow/src/org/labkey/flow/controllers/well/bulkUpdate.jsp
+++ b/flow/src/org/labkey/flow/controllers/well/bulkUpdate.jsp
@@ -20,7 +20,8 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.ViewContext" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
-<%@ page import="org.labkey.flow.controllers.well.WellController" %>
+<%@ page import="org.labkey.flow.controllers.well.WellController.BulkUpdateKeywordsAction" %>
+<%@ page import="org.labkey.flow.controllers.well.WellController.UpdateKeywordsForm" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
@@ -31,7 +32,7 @@
     }
 %>
 <%
-    WellController.UpdateKeywordsForm form = (WellController.UpdateKeywordsForm)HttpView.currentModel();
+    UpdateKeywordsForm form = (UpdateKeywordsForm)HttpView.currentModel();
     ViewContext context = getViewContext();
 %>
 <span style="color:green;"><%=h(form.message)%></span><br>
@@ -57,7 +58,7 @@ function keywordCombo_onSelect()
 function form_onSubmit()
 {
     var form = updateFormPanel.getForm();
-    form.getEl().dom.action=<%=q(buildURL(WellController.BulkUpdateKeywordsAction.class))%>;
+    form.getEl().dom.action=<%=q(urlFor(BulkUpdateKeywordsAction.class))%>;
     form.getEl().dom.submit();
 }
 
@@ -112,7 +113,7 @@ Ext.onReady(function(){
                 ]
             } <%}}%>
         ],
-        buttons:[{text: 'Update', type:'submit', handler:function() {updateFormPanel.getForm().submit({url:<%=q(buildURL(WellController.BulkUpdateKeywordsAction.class))%>})}}]
+        buttons:[{text: 'Update', type:'submit', handler:function() {updateFormPanel.getForm().submit({url:<%=q(urlFor(BulkUpdateKeywordsAction.class))%>})}}]
     });
 
     keywordCombo.on('select', keywordCombo_onSelect);

--- a/flow/src/org/labkey/flow/controllers/well/editWell.jsp
+++ b/flow/src/org/labkey/flow/controllers/well/editWell.jsp
@@ -63,7 +63,7 @@
                     for (FlowWell flowWell : wells)
                     {%>
                 <%=h(prefix + flowWell.getName())%>
-                <input type="hidden" name="ff_fileRowId" value="<%=h(flowWell.getRowId())%>">
+                <input type="hidden" name="ff_fileRowId" value="<%=flowWell.getRowId()%>">
                 <% prefix = ", ";
                 }%>
             </td>
@@ -76,7 +76,7 @@
         <tr>
             <td>Well Name:</td>
             <td><input type="text" name="ff_name" value="<%=h(form.ff_name)%>">
-                <input type="hidden" name="ff_fileRowId" value="<%=h(wells.get(0).getRowId())%>"></td>
+                <input type="hidden" name="ff_fileRowId" value="<%=wells.get(0).getRowId()%>"></td>
         </tr>
         <tr>
             <td>Comment:</td>

--- a/flow/src/org/labkey/flow/reports/editPositivityReport.jsp
+++ b/flow/src/org/labkey/flow/reports/editPositivityReport.jsp
@@ -156,7 +156,7 @@ function Form_onDelete()
        url = new ActionURL(ReportsController.BeginAction.class, c);
    }
    %>
-   window.location = <%=q(url.getLocalURIString())%>;
+   window.location = <%=q(url)%>;
 }
 
 Ext.onReady(function() {

--- a/flow/src/org/labkey/flow/reports/editPositivityReport.jsp
+++ b/flow/src/org/labkey/flow/reports/editPositivityReport.jsp
@@ -22,8 +22,9 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
-<%@ page import="org.labkey.flow.controllers.ReportsController" %>
-<%@ page import="org.labkey.flow.controllers.protocol.ProtocolController" %>
+<%@ page import="org.labkey.flow.controllers.ReportsController.BeginAction" %>
+<%@ page import="org.labkey.flow.controllers.ReportsController.DeleteAction" %>
+<%@ page import="org.labkey.flow.controllers.protocol.ProtocolController.EditICSMetadataAction" %>
 <%@ page import="org.labkey.flow.data.FlowProtocol" %>
 <%@ page import="org.labkey.flow.data.ICSMetadata" %>
 <%@ page import="org.labkey.flow.reports.FilterFlowReport" %>
@@ -49,8 +50,8 @@
     ReportDescriptor d = report.getDescriptor();
     String reportId = d.getReportId() == null ? null : d.getReportId().toString();
 
-    String retURL = returnURL == null ? buildURL(ReportsController.BeginAction.class) : returnURL.getLocalURIString();
-    String canURL = cancelURL == null ? retURL : cancelURL.getLocalURIString();
+    ActionURL retURL = returnURL == null ? urlFor(BeginAction.class) : returnURL;
+    ActionURL canURL = cancelURL == null ? retURL : cancelURL;
 
     FlowProtocol protocol = FlowProtocol.getForContainer(c);
     ICSMetadata metadata = protocol == null ? null : protocol.getICSMetadata();
@@ -59,7 +60,7 @@
     ActionURL editICSMetadataURL = null;
     if (protocol != null)
     {
-        editICSMetadataURL = protocol.urlFor(ProtocolController.EditICSMetadataAction.class);
+        editICSMetadataURL = protocol.urlFor(EditICSMetadataAction.class);
         editICSMetadataURL.addParameter(ActionURL.Param.returnUrl, currentURL.toString());
     }
 %>
@@ -143,7 +144,7 @@ function Form_onDelete()
    ActionURL url = null;
    if (d.getReportId() != null)
    {
-       url = new ActionURL(ReportsController.DeleteAction.class, c).addParameter("reportId", report.getReportId().toString());
+       url = urlFor(DeleteAction.class).addParameter("reportId", report.getReportId().toString());
        if (returnURL != null)
            url.addReturnURL(returnURL);
    }
@@ -153,7 +154,7 @@ function Form_onDelete()
    }
    else
    {
-       url = new ActionURL(ReportsController.BeginAction.class, c);
+       url = urlFor(BeginAction.class);
    }
    %>
    window.location = <%=q(url)%>;

--- a/flow/src/org/labkey/flow/reports/editQCReport.jsp
+++ b/flow/src/org/labkey/flow/reports/editQCReport.jsp
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.reports.report.ReportDescriptor" %>
 <%@ page import="org.labkey.api.util.Tuple3" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
-<%@ page import="org.labkey.flow.controllers.ReportsController" %>
+<%@ page import="org.labkey.flow.controllers.ReportsController.BeginAction" %>
+<%@ page import="org.labkey.flow.controllers.ReportsController.DeleteAction" %>
 <%@ page import="org.labkey.flow.reports.FilterFlowReport" %>
 <%@ page import="org.labkey.flow.reports.StatPickerView" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
@@ -35,8 +35,6 @@
     }
 %>
 <%
-    Container c = getContainer();
-
     Tuple3<FilterFlowReport, ActionURL, ActionURL> bean = (Tuple3<FilterFlowReport, ActionURL, ActionURL>) HttpView.currentModel();
     FilterFlowReport report = bean.first;
     ActionURL returnURL = bean.second;
@@ -44,8 +42,8 @@
     ReportDescriptor d = report.getDescriptor();
     String reportId = d.getReportId() == null ? null : d.getReportId().toString();
 
-    String retURL = returnURL == null ? buildURL(ReportsController.BeginAction.class) : returnURL.getLocalURIString();
-    String canURL = cancelURL == null ? retURL : cancelURL.getLocalURIString();
+    ActionURL retURL = returnURL == null ? urlFor(BeginAction.class) : returnURL;
+    ActionURL canURL = cancelURL == null ? retURL : cancelURL;
 %>
 <style type="text/css">
     .x-form-item {
@@ -114,7 +112,7 @@ function Form_onDelete()
    ActionURL url = null;
    if (d.getReportId() != null)
    {
-       url = new ActionURL(ReportsController.DeleteAction.class, c).addParameter("reportId", report.getReportId().toString());
+       url = urlFor(DeleteAction.class).addParameter("reportId", report.getReportId().toString());
        if (returnURL != null)
            url.addReturnURL(returnURL);
    }
@@ -124,7 +122,7 @@ function Form_onDelete()
    }
    else
    {
-       url = new ActionURL(ReportsController.BeginAction.class, c);
+       url = urlFor(BeginAction.class);
    }
    %>
    window.location = <%=q(url)%>;

--- a/flow/src/org/labkey/flow/reports/editQCReport.jsp
+++ b/flow/src/org/labkey/flow/reports/editQCReport.jsp
@@ -127,7 +127,7 @@ function Form_onDelete()
        url = new ActionURL(ReportsController.BeginAction.class, c);
    }
    %>
-   window.location = <%=q(url.getLocalURIString())%>;
+   window.location = <%=q(url)%>;
 }
 
 Ext.onReady(function() {

--- a/flow/src/org/labkey/flow/webparts/FlowOverview.java
+++ b/flow/src/org/labkey/flow/webparts/FlowOverview.java
@@ -329,7 +329,7 @@ public class FlowOverview extends Overview
                 statusHTML.append("<br>");
             }
             ActionURL urlFlowComp = FlowTableType.CompensationMatrices.urlFor(getUser(), getContainer(), QueryAction.executeQuery);
-            statusHTML.append("There are <a href=\"").append(h(urlFlowComp.getLocalURIString())).append("\">").append(_compensationMatrixCount).append(" compensation matrices</a>.");
+            statusHTML.append("There are <a href=\"").append(h(urlFlowComp)).append("\">").append(_compensationMatrixCount).append(" compensation matrices</a>.");
             if (_compensationRunCount != 0)
             {
                 ActionURL urlShowRuns = new ActionURL(RunController.ShowRunsAction.class, getContainer()).addParameter("query.CompensationControlCount~neq", 0);

--- a/luminex/src/org/labkey/luminex/view/guideSetConfirmDelete.jsp
+++ b/luminex/src/org/labkey/luminex/view/guideSetConfirmDelete.jsp
@@ -56,7 +56,7 @@
 
     <ul>
         <% for (LuminexController.GuideSetsDeleteBean.GuideSet gs : guideSets) { %>
-            <li><a href="#" tabindex="-1" onclick="createGuideSetWindow('<%=h(bean.getProtocol().getRowId())%>','<%=h(gs.getGuideSetId())%>', false)">Guide Set <%= h(gs.getGuideSetId()) %>: <%= h(gs.getComment()) %></a></li>
+            <li><a href="#" tabindex="-1" onclick="createGuideSetWindow('<%=bean.getProtocol().getRowId()%>','<%=gs.getGuideSetId()%>', false)">Guide Set <%=gs.getGuideSetId()%>: <%= h(gs.getComment()) %></a></li>
             <br>
             Type: <% if (gs.isValueBased()) {%>Value-based<%} else {%>Run-based<%}%>
             <br><br>
@@ -114,7 +114,7 @@
         <% } if (successUrl != null) { %>
             <input type="hidden" name="<%=ActionURL.Param.successUrl%>" value="<%= h(successUrl) %>"/>
         <% } if (bean.getProtocol() != null) { %>
-            <input type="hidden" name="rowId" value="<%= h(bean.getProtocol().getRowId()) %>"/>
+            <input type="hidden" name="rowId" value="<%=bean.getProtocol().getRowId()%>"/>
         <% } %>
         <input type="hidden" name="forceDelete" value="true"/>
         <%= button("Confirm Delete").submit(true) %>

--- a/ms2/src/org/labkey/ms2/PepSearchModel.java
+++ b/ms2/src/org/labkey/ms2/PepSearchModel.java
@@ -17,6 +17,7 @@ package org.labkey.ms2;
 
 import org.labkey.api.data.Container;
 import org.labkey.api.view.ActionURL;
+import org.labkey.ms2.MS2Controller.PepSearchAction;
 
 /**
  * Model for the PepSearchView.jsp
@@ -27,7 +28,7 @@ import org.labkey.api.view.ActionURL;
  */
 public class PepSearchModel
 {
-    private String _resultsUri;
+    private final ActionURL _resultsUri;
     private String _pepSeq = null;
     private boolean _exact = false;
     private boolean _subfolders = false;
@@ -36,7 +37,7 @@ public class PepSearchModel
 
     public PepSearchModel(Container container)
     {
-        _resultsUri = new ActionURL(MS2Controller.PepSearchAction.class, container).getLocalURIString();
+        _resultsUri = new ActionURL(PepSearchAction.class, container);
     }
 
     public PepSearchModel(Container container, String pepSeq, boolean exact, boolean includeSubfolders, String runIds)
@@ -48,7 +49,7 @@ public class PepSearchModel
         _runIds = runIds;
     }
 
-    public String getResultsUri()
+    public ActionURL getResultsUri()
     {
         return _resultsUri;
     }

--- a/ms2/src/org/labkey/ms2/annotLoadDetails.jsp
+++ b/ms2/src/org/labkey/ms2/annotLoadDetails.jsp
@@ -32,18 +32,18 @@
    <td align='left' class="labkey-form-label">Completed</td><td align='right'><%=insertion.getCompletionDate() == null ? h("Not complete") : formatDateTime(insertion.getCompletionDate())%></td><td align='right'><%=formatDateTime(insertion.getChangeDate())%></td>
 </tr>
 <tr>
-   <td align='left' class="labkey-form-label">Records</td><td align='right'><%=h(insertion.getRecordsProcessed())%></td><td align='right'><%=h(insertion.getMrmSize())%></td>
+   <td align='left' class="labkey-form-label">Records</td><td align='right'><%=insertion.getRecordsProcessed()%></td><td align='right'><%=h(insertion.getMrmSize())%></td>
 </tr>
 <tr>
-   <td align='left' class="labkey-form-label">Organisms</td><td align='right'><%=h(insertion.getOrganismsAdded())%></td><td align='right'><%=h(insertion.getMrmOrganismsAdded())%></td>
+   <td align='left' class="labkey-form-label">Organisms</td><td align='right'><%=insertion.getOrganismsAdded()%></td><td align='right'><%=h(insertion.getMrmOrganismsAdded())%></td>
 </tr>
 <tr>
-   <td align='left' class="labkey-form-label">Sequences</td><td align='right'><%=h(insertion.getSequencesAdded())%></td><td align='right'><%=h(insertion.getMrmSequencesAdded())%></td>
+   <td align='left' class="labkey-form-label">Sequences</td><td align='right'><%=insertion.getSequencesAdded()%></td><td align='right'><%=h(insertion.getMrmSequencesAdded())%></td>
 </tr>
 <tr>
-   <td align='left' class="labkey-form-label">Identifiers</td><td align='right'><%=h(insertion.getIdentifiersAdded())%></td><td align='right'><%=h(insertion.getMrmIdentifiersAdded())%></td>
+   <td align='left' class="labkey-form-label">Identifiers</td><td align='right'><%=insertion.getIdentifiersAdded()%></td><td align='right'><%=h(insertion.getMrmIdentifiersAdded())%></td>
 </tr>
 <tr>
-   <td align='left' class="labkey-form-label">Annotations</td><td align='right'><%=h(insertion.getAnnotationsAdded())%></td><td align='right'><%=h(insertion.getMrmAnnotationsAdded())%></td>
+   <td align='left' class="labkey-form-label">Annotations</td><td align='right'><%=insertion.getAnnotationsAdded()%></td><td align='right'><%=h(insertion.getMrmAnnotationsAdded())%></td>
 </tr>
 </table>

--- a/ms2/src/org/labkey/ms2/decoySummary.jsp
+++ b/ms2/src/org/labkey/ms2/decoySummary.jsp
@@ -94,7 +94,7 @@
             <td style="text-align:right;"><%=h(pVal)%></td>
             <td style="padding-left: 1em"></td>
             <td class="labkey-form-label">Ion Threshold</td>
-            <td style="text-align:right" id="ionThresholdValue"><%=h(bean.getScoreThreshold())%></td>
+            <td style="text-align:right" id="ionThresholdValue"><%=bean.getScoreThreshold()%></td>
         </tr>
         <tr>
             <td class="labkey-form-label">In Target</td>

--- a/ms2/src/org/labkey/ms2/editElution.jsp
+++ b/ms2/src/org/labkey/ms2/editElution.jsp
@@ -43,11 +43,11 @@
            </tr>
            <tr>
                <td class="labkey-form-label">Charge</td>
-               <td>+<%=h(p.getCharge())%></td>
+               <td>+<%=p.getCharge()%></td>
            </tr>
            <tr>
                <td class="labkey-form-label">Scan</td>
-               <td>+<%=h(p.getScan())%></td>
+               <td>+<%=p.getScan()%></td>
            </tr>
            <tr>
                <td class="labkey-form-label">Light to heavy ratio</td>

--- a/ms2/src/org/labkey/ms2/insertAnnots.jsp
+++ b/ms2/src/org/labkey/ms2/insertAnnots.jsp
@@ -18,6 +18,7 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.ms2.MS2Controller" %>
+<%@ page import="org.labkey.ms2.MS2Controller.InsertAnnotsAction" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
@@ -26,7 +27,7 @@
 %>
 <labkey:errors />
 <br>
-<labkey:form method="post" action="<%=h(buildURL(MS2Controller.InsertAnnotsAction.class))%>" enctype="multipart/form-data">
+<labkey:form method="post" action="<%=urlFor(InsertAnnotsAction.class)%>" enctype="multipart/form-data">
 <table class="lk-fields-table">
     <tr>
       <td class="labkey-form-label">Full file path</td>

--- a/ms2/src/org/labkey/ms2/loadGoAutomatic.jsp
+++ b/ms2/src/org/labkey/ms2/loadGoAutomatic.jsp
@@ -16,7 +16,8 @@
  */
 %>
 <%@ page import="org.apache.commons.lang3.SystemUtils" %>
-<%@ page import="org.labkey.ms2.MS2Controller" %>
+<%@ page import="org.labkey.ms2.MS2Controller.LoadGoAction" %>
+<%@ page import="org.labkey.ms2.MS2Controller.MS2UrlsImpl" %>
 <%@ page import="org.labkey.ms2.protein.tools.GoLoader" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
@@ -25,7 +26,7 @@
 %>
 <table><tr><td>
 You are about to <%=h(loaded ? "reload" : "load")%> the latest Gene Ontology (GO) annotation files into your
-LabKey database.  If you click "Continue" your LabKey Server will automatically:
+LabKey database. If you click "Continue", this server will automatically:
 
 <ul>
     <li>Download the latest GO annotation files from ftp.geneontology.org</li><%
@@ -55,8 +56,8 @@ switch to the "Manual" tab and follow the instructions there.</span> For more in
 <% } %>
 
 If you wish to proceed, click the "Continue" button. Otherwise click "Cancel".<br><br>
-<labkey:form action="<%=buildURL(MS2Controller.LoadGoAction.class)%>" method="post">
+<labkey:form action="<%=urlFor(LoadGoAction.class)%>" method="post">
     <%= button("Continue").submit(true) %>
-    <%= button("Cancel").href(MS2Controller.MS2UrlsImpl.get().getShowProteinAdminUrl()) %>
+    <%= button("Cancel").href(MS2UrlsImpl.get().getShowProteinAdminUrl()) %>
 </labkey:form>
 </td></tr></table>

--- a/ms2/src/org/labkey/ms2/mascotConfig.jsp
+++ b/ms2/src/org/labkey/ms2/mascotConfig.jsp
@@ -20,7 +20,8 @@
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.util.HelpTopic" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
-<%@ page import="org.labkey.ms2.MS2Controller" %>
+<%@ page import="org.labkey.ms2.MS2Controller.MascotConfigAction" %>
+<%@ page import="org.labkey.ms2.MS2Controller.MascotTestAction" %>
 <%@ page import="org.labkey.ms2.pipeline.mascot.MascotConfig" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
@@ -68,7 +69,7 @@
                 <td colspan="2">
                     Configuration is currently being inherited from <%= h(mascotConfig.getContainer().isRoot() ? "the site-level" : mascotConfig.getContainer().getPath())%>.
                     Saving will override the inherited configuration.<br/>
-                    <%= link("edit inherited settings", new ActionURL(MS2Controller.MascotConfigAction.class, mascotConfig.getContainer()))%>
+                    <%= link("edit inherited settings", new ActionURL(MascotConfigAction.class, mascotConfig.getContainer()))%>
                 </td>
             </tr>
         <% } %>
@@ -106,7 +107,7 @@
     <% } %>
 </labkey:form>
 
-<labkey:form name="mascottest" action="mascotTest.view" enctype="multipart/form-data" method="post" target='_new' >
+<labkey:form name="mascottest" action="<%=urlFor(MascotTestAction.class)%>" enctype="multipart/form-data" method="post" target='_new' >
     <input type="hidden" name="mascotServer" value="" />
     <input type="hidden" name="mascotUserAccount" value="" />
     <input type="hidden" name="mascotUserPassword" value="" />

--- a/ms2/src/org/labkey/ms2/ms2Admin.jsp
+++ b/ms2/src/org/labkey/ms2/ms2Admin.jsp
@@ -75,7 +75,7 @@
     else
     { %>
 <labkey:form method="post" action="<%=new ActionURL(MS2Controller.PurgeRunsAction.class, ContainerManager.getRoot())%>">
-<table class="labkey-data-region"><tr><td>Currently set to purge all MS2 runs deleted <input name="days" value="<%=bean.days%>" size="2"> days ago or before&nbsp;<%= button("Update").submit(true).onClick("this.form.action=" + q(buildURL(MS2Controller.ShowMS2AdminAction.class)) + ";") %></td></tr>
+<table class="labkey-data-region"><tr><td>Currently set to purge all MS2 runs deleted <input name="days" value="<%=bean.days%>" size="2"> days ago or before&nbsp;<%= button("Update").submit(true).onClick("this.form.action=" + q(urlFor(MS2Controller.ShowMS2AdminAction.class)) + ";") %></td></tr>
 <tr><td><%= button("Purge Deleted MS2 Runs").submit(true) %></td></tr></table></labkey:form><%
     }
 %>

--- a/ms2/src/org/labkey/ms2/peptideChart.jsp
+++ b/ms2/src/org/labkey/ms2/peptideChart.jsp
@@ -19,6 +19,7 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.ms2.MS2Controller" %>
+<%@ page import="org.labkey.ms2.MS2Controller.PeptideChartsAction" %>
 <%@ page import="org.labkey.ms2.protein.tools.ProteinDictionaryHelpers.GoTypes" %>
 <%@ page import="java.util.Map" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -31,7 +32,7 @@
 <% } %>
 
 <% if (bean.foundData) { %>
-    <labkey:form name="chartForm" action="<%=buildURL(MS2Controller.PeptideChartsAction.class)%>">
+    <labkey:form name="chartForm" action="<%=urlFor(PeptideChartsAction.class)%>">
     <%=bean.imageMap%>
     <table align="left">
     <tr>

--- a/ms2/src/org/labkey/ms2/protein/uploadCustomProteinAnnotations.jsp
+++ b/ms2/src/org/labkey/ms2/protein/uploadCustomProteinAnnotations.jsp
@@ -19,7 +19,8 @@
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.ms2.protein.CustomAnnotationType" %>
-<%@ page import="org.labkey.ms2.protein.ProteinController" %>
+<%@ page import="org.labkey.ms2.protein.ProteinController.UploadAnnotationsForm" %>
+<%@ page import="org.labkey.ms2.protein.ProteinController.UploadCustomProteinAnnotations" %>
 <%@ page extends="org.labkey.api.jsp.JspBase"%>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -31,13 +32,13 @@
 %>
 
 <%
-    JspView<ProteinController.UploadAnnotationsForm> me = (JspView<ProteinController.UploadAnnotationsForm>) HttpView.currentView();
-    ProteinController.UploadAnnotationsForm bean = me.getModelBean();
+    JspView<UploadAnnotationsForm> me = (JspView<UploadAnnotationsForm>) HttpView.currentView();
+    UploadAnnotationsForm bean = me.getModelBean();
 %>
 
 <labkey:errors/>
 
-<labkey:form action="uploadCustomProteinAnnotations.post" name="proteinListForm" method="POST">
+<labkey:form action="<%=urlFor(UploadCustomProteinAnnotations.class)%>" name="proteinListForm" method="POST">
     <table>
         <tr>
             <td colspan="2">

--- a/ms2/src/org/labkey/ms2/proteinDisambiguation.jsp
+++ b/ms2/src/org/labkey/ms2/proteinDisambiguation.jsp
@@ -109,7 +109,7 @@
     %>
 
     <div>
-        <input type=checkbox name=targetSeqIds value="<%= h(protein.getSeqId())%>" checked>
+        <input type=checkbox name=targetSeqIds value="<%=protein.getSeqId()%>" checked>
 
         <span id="<%= h(divId) %>"></span>
         <span><a href="<%= h(proteinUrl) %>"><%= h(protein.getBestName())%></a></span>

--- a/ms2/src/org/labkey/ms2/renameRun.jsp
+++ b/ms2/src/org/labkey/ms2/renameRun.jsp
@@ -17,13 +17,14 @@
 %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
-<%@ page import="org.labkey.ms2.MS2Controller" %>
+<%@ page import="org.labkey.ms2.MS2Controller.RenameBean" %>
+<%@ page import="org.labkey.ms2.MS2Controller.RenameRunAction" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    MS2Controller.RenameBean bean = ((JspView<MS2Controller.RenameBean>) HttpView.currentView()).getModelBean();
+    RenameBean bean = ((JspView<RenameBean>) HttpView.currentView()).getModelBean();
 %>
-<labkey:form action="<%=buildURL(MS2Controller.RenameRunAction.class)%>" method="post">
+<labkey:form action="<%=urlFor(RenameRunAction.class)%>" method="post">
 <%=generateReturnUrlFormField(bean.returnURL)%>
 <input type="hidden" name="run" value="<%=bean.run.getRun()%>"/>
 <table class="lk-fields-table">

--- a/ms2/src/org/labkey/ms2/runSummary.jsp
+++ b/ms2/src/org/labkey/ms2/runSummary.jsp
@@ -77,17 +77,17 @@ if (null != bean.quantAlgorithm)
 
         if (null != run.getParamsFileName() && null != run.getPath())
         { %>
-            <%=link("Show " + run.getParamsFileName()).href(buildURL(MS2Controller.ShowParamsFileAction.class) + "run=" + run.getRun()).id("paramFileLink").target("paramFile")%><%
+            <%=link("Show " + run.getParamsFileName()).href(urlFor(MS2Controller.ShowParamsFileAction.class) + "run=" + run.getRun()).id("paramFileLink").target("paramFile")%><%
         }
 
         if (run.getHasPeptideProphet())
         { %>
-            <%=link("Show Peptide Prophet Details").href(buildURL(MS2Controller.ShowPeptideProphetDetailsAction.class) + "run=" + run.getRun()).id("peptideProphetDetailsLink").target("peptideProphetSummary")%><%
+            <%=link("Show Peptide Prophet Details").href(urlFor(MS2Controller.ShowPeptideProphetDetailsAction.class) + "run=" + run.getRun()).id("peptideProphetDetailsLink").target("peptideProphetSummary")%><%
         }
 
         if (run.hasProteinProphet())
         { %>
-            <%=link("Show Protein Prophet Details").href(buildURL(MS2Controller.ShowProteinProphetDetailsAction.class) + "run=" + run.getRun()).id("proteinProphetDetailsLink").target("proteinProphetSummary")%><%
+            <%=link("Show Protein Prophet Details").href(urlFor(MS2Controller.ShowProteinProphetDetailsAction.class) + "run=" + run.getRun()).id("proteinProphetDetailsLink").target("proteinProphetSummary")%><%
         } %>
         </div>
     </td></tr>

--- a/ms2/src/org/labkey/ms2/saveView.jsp
+++ b/ms2/src/org/labkey/ms2/saveView.jsp
@@ -17,13 +17,14 @@
 %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
-<%@ page import="org.labkey.ms2.MS2Controller" %>
+<%@ page import="org.labkey.ms2.MS2Controller.SaveViewAction" %>
+<%@ page import="org.labkey.ms2.MS2Controller.SaveViewBean" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    MS2Controller.SaveViewBean bean = ((JspView<MS2Controller.SaveViewBean>) HttpView.currentView()).getModelBean();
+    SaveViewBean bean = ((JspView<SaveViewBean>) HttpView.currentView()).getModelBean();
 %>
-<labkey:form method="post" action="<%=buildURL(MS2Controller.SaveViewAction.class)%>" className="labkey-data-region">
+<labkey:form method="post" action="<%=urlFor(SaveViewAction.class)%>" className="labkey-data-region">
     <table class="lk-fields-table">
         <tr>
             <td>Name:</td>

--- a/nab/src/org/labkey/nab/view/nabQC.jsp
+++ b/nab/src/org/labkey/nab/view/nabQC.jsp
@@ -70,7 +70,7 @@
             renderTo    : 'nabQCDiv',
             edit        : <%=bean.isEdit()%>,
             runId       : <%=bean.getRunId()%>,
-            returnUrl   : <%=q(bean.getReturnUrl(getContainer()).getLocalURIString())%>,
+            returnUrl   : <%=q(bean.getReturnUrl(getContainer()))%>,
             runName     : <%=q(assay.getRunName())%>,
             runProperties : <%=text(jsonMapper.writeValueAsString(runProperties))%>,
             controlProperties : <%=text(jsonMapper.writeValueAsString(controlProperties))%>


### PR DESCRIPTION
#### Rationale
Miscellaneous cleanup now that `print(String)` and unsafe `print(Object)` invocations have been removed from all JSP files.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1549

#### Changes
* Use `JspBase.q(URLHelper)`
* Stop calling `h()` on primitives like int, long, et al
* Remove pointless ternary operators (x != null ? x : null) from JSPs