### PR TITLE
Adjust all JSPs to extend JspContext

### DIFF
--- a/ms2/src/org/labkey/ms2/compare/compareSearchEngineProteinOptions.jsp
+++ b/ms2/src/org/labkey/ms2/compare/compareSearchEngineProteinOptions.jsp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 %>
+<%@ page extends="org.labkey.api.jsp.JspContext" %>
 <input type="hidden" name="column" value="Protein" />
 <table>
     <tr>


### PR DESCRIPTION
#### Rationale
All JSPs need to extend `JspContext`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1564
