### PR TITLE
Issue 38958: ArrayIndexOutOfBoundsException in SamplesConfirmGridView

### DIFF
--- a/flow/src/org/labkey/flow/controllers/executescript/SamplesConfirmGridView.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/SamplesConfirmGridView.java
@@ -61,6 +61,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -110,15 +111,21 @@ public class SamplesConfirmGridView extends GridView
         if (hasGroupInfo)
             columns.put(GROUP_NAMES_FIELD_KEY, new BaseColumnInfo(GROUP_NAMES_FIELD_KEY, JdbcType.VARCHAR));
 
+        Set<String> uniqueKeywords = new LinkedHashSet<>();
         for (String keyword : keywords)
         {
             FieldKey fieldKey = new FieldKey(null, keyword);
             var col = new BaseColumnInfo(fieldKey, JdbcType.VARCHAR);
             col.setAlias(fieldKey.getName());
             if (!columns.containsKey(fieldKey))
+            {
+                uniqueKeywords.add(keyword);
                 columns.put(fieldKey, col);
+            }
             else
-                LOG.warn("Duplicate columns for FieldKey '" + fieldKey + "', got: '" + col.getName() + "' and '" + columns.get(fieldKey).getName() + "'");
+            {
+                LOG.warn("Ignoring duplicate columns for FieldKey '" + fieldKey + "', got: '" + col.getName() + "' and '" + columns.get(fieldKey).getName() + "'");
+            }
         }
 
         int columnCount = columns.size();
@@ -165,7 +172,7 @@ public class SamplesConfirmGridView extends GridView
 
             // Keywords
             Map<String, String> sampleKeywords = sample.getKeywords();
-            for (String keyword : keywords)
+            for (String keyword : uniqueKeywords)
                 row[i++] = sampleKeywords.get(keyword);
 
             Map<String, Object> rowMap = factory.getRowMap(row);
@@ -256,7 +263,7 @@ public class SamplesConfirmGridView extends GridView
         }
 
         // Add keyword columns
-        for (String keyword : keywords)
+        for (String keyword : uniqueKeywords)
         {
             dc = new SimpleDisplayColumn("${" + keyword + "}");
             dc.setCaption(keyword);


### PR DESCRIPTION
not accounting for duplicate keywords when building row object