### PR TITLE
20.7 fb elisa 7669

### DIFF
--- a/elisa/src/org/labkey/elisa/AbstractElisaImportHelper.java
+++ b/elisa/src/org/labkey/elisa/AbstractElisaImportHelper.java
@@ -63,7 +63,7 @@ public abstract class AbstractElisaImportHelper implements ElisaImportHelper
         row.put(ElisaAssayProvider.WELLGROUP_PROPERTY, replicate.getPositionDescription());
         row.put(ElisaAssayProvider.ABSORBANCE_PROPERTY, well.getValue());
         if (stdCurveFit != null)
-            row.put(ElisaAssayProvider.CONCENTRATION_PROPERTY, stdCurveFit.fitCurveY(well.getValue()));
+            row.put(ElisaAssayProvider.CONCENTRATION_PROPERTY, stdCurveFit.solveForX(well.getValue()));
 
         row.put(ElisaAssayProvider.MEAN_ABSORPTION_PROPERTY, replicate.getMean());
         row.put(ElisaAssayProvider.CV_ABSORPTION_PROPERTY, replicate.getStdDev() / replicate.getMean());

--- a/elisa/src/org/labkey/elisa/AbstractElisaImportHelper.java
+++ b/elisa/src/org/labkey/elisa/AbstractElisaImportHelper.java
@@ -1,0 +1,79 @@
+package org.labkey.elisa;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AssayUploadXarContext;
+import org.labkey.api.assay.plate.PlateBasedAssayProvider;
+import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Position;
+import org.labkey.api.assay.plate.Well;
+import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.assay.plate.WellGroupTemplate;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.statistics.CurveFit;
+import org.labkey.api.exp.api.ExpMaterial;
+import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ProvenanceService;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class AbstractElisaImportHelper implements ElisaImportHelper
+{
+    protected final ProvenanceService _pvs = ProvenanceService.get();
+    protected AssayUploadXarContext _context;
+    protected PlateBasedAssayProvider _provider;
+    protected ExpProtocol _protocol;
+    protected File _dataFile;
+    protected Container _container;
+    Map<Position, String> _specimenGroupMap;
+
+    public AbstractElisaImportHelper(AssayUploadXarContext context, PlateBasedAssayProvider provider, ExpProtocol protocol, File dataFile)
+    {
+        _context = context;
+        _provider = provider;
+        _protocol = protocol;
+        _dataFile = dataFile;
+        _container = context.getContainer();
+    }
+
+    protected Map<Position, String> getSpecimenGroupMap()
+    {
+        if (_specimenGroupMap == null)
+        {
+            _specimenGroupMap = new HashMap<>();
+            PlateTemplate template = _provider.getPlateTemplate(_protocol.getContainer(), _protocol);
+            for (WellGroupTemplate sample : template.getWellGroups(WellGroup.Type.SPECIMEN))
+            {
+                for (Position pos : sample.getPositions())
+                    _specimenGroupMap.put(pos, sample.getName());
+            }
+        }
+        return _specimenGroupMap;
+    }
+
+    @Override
+    public Map<String, Object> createWellRow(String plateName, Integer spot, WellGroup replicate, Well well, Position position,
+                                             @Nullable CurveFit stdCurveFit,
+                                             Map<String, ExpMaterial> materialMap)
+    {
+        Map<String, Object> row = new HashMap<>();
+
+        row.put(ElisaAssayProvider.WELL_LOCATION_PROPERTY, position.getDescription());
+        row.put(ElisaAssayProvider.WELLGROUP_PROPERTY, replicate.getPositionDescription());
+        row.put(ElisaAssayProvider.ABSORBANCE_PROPERTY, well.getValue());
+        if (stdCurveFit != null)
+            row.put(ElisaAssayProvider.CONCENTRATION_PROPERTY, stdCurveFit.fitCurveY(well.getValue()));
+
+        row.put(ElisaAssayProvider.MEAN_ABSORPTION_PROPERTY, replicate.getMean());
+        row.put(ElisaAssayProvider.CV_ABSORPTION_PROPERTY, replicate.getStdDev() / replicate.getMean());
+
+        return row;
+    }
+
+    @Override
+    public String getMaterialKey(String plateName, String sampleWellGroup)
+    {
+        return sampleWellGroup;
+    }
+}

--- a/elisa/src/org/labkey/elisa/AbstractElisaImportHelper.java
+++ b/elisa/src/org/labkey/elisa/AbstractElisaImportHelper.java
@@ -72,7 +72,7 @@ public abstract class AbstractElisaImportHelper implements ElisaImportHelper
     }
 
     @Override
-    public String getMaterialKey(String plateName, String sampleWellGroup)
+    public String getMaterialKey(String plateName, Integer analyteNum, String sampleWellGroup)
     {
         return sampleWellGroup;
     }

--- a/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
+++ b/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
@@ -308,7 +308,8 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
     {
         if (form instanceof ElisaRunUploadForm)
         {
-            return new JspView<>("/org/labkey/assay/view/tsvDataDescription.jsp", form);
+            if (((ElisaRunUploadForm)form).getSampleMetadataInputFormat() == SampleMetadataInputFormat.COMBINED)
+                return new JspView<>("/org/labkey/assay/view/tsvDataDescription.jsp", form);
         }
         return new HtmlView(HtmlString.of("The ELISA data files must be in the BioTek Microplate Reader Excel file format (.xls or .xlsx extension)."));
     }

--- a/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
+++ b/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
@@ -94,12 +94,12 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
 
     // results properties
     public static final String ABSORBANCE_PROPERTY = "Absorption";
+    public static final String STANDARD_CONCENTRATION_PROPERTY = "Std_Concentration";
     public static final String CONCENTRATION_PROPERTY = "Concentration";
     public static final String WELL_LOCATION_PROPERTY = "WellLocation";
     public static final String WELLGROUP_PROPERTY = "WellgroupLocation";
     public static final String SPOT_PROPERTY = "Spot";
     public static final String DILUTION_PROPERTY = "Dilution";
-    public static final String CV_PROPERTY = "CV";
     public static final String EXCLUDED_PROPERTY = "Excluded";
     public static final String PERCENT_RECOVERY = "Recovery_Percent";
     public static final String PERCENT_RECOVERY_MEAN = "Recovery_Mean";
@@ -114,12 +114,7 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
 
     static
     {
-        EXTRA_SAMPLE_PROPS = Set.of(
-                AUC_PROPERTY,
-                MEAN_ABSORPTION_PROPERTY,
-                CV_ABSORPTION_PROPERTY,
-                MEAN_CONCENTRATION_PROPERTY,
-                CV_CONCENTRATION_PROPERTY);
+        EXTRA_SAMPLE_PROPS = Set.of(AUC_PROPERTY);
     }
 
     enum PlateReaderType
@@ -237,11 +232,7 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
         addProperty(domain, DATE_PROPERTY_NAME, DATE_PROPERTY_CAPTION, PropertyType.DATE_TIME);
 
         // extra computed properties at the sample scope
-        addProperty(domain, AUC_PROPERTY, AUC_PROPERTY, PropertyType.DOUBLE, "Area Under the Curve");
-        addProperty(domain, MEAN_ABSORPTION_PROPERTY, "Absorption Mean", PropertyType.DOUBLE, "Mean Absorption across sample replicates");
-        addProperty(domain, CV_ABSORPTION_PROPERTY, "Absorption CV", PropertyType.DOUBLE, "Absorption CV across sample replicates");
-        addProperty(domain, MEAN_CONCENTRATION_PROPERTY, "Concentration Mean", PropertyType.DOUBLE, "Mean Concentration across sample replicates");
-        addProperty(domain, CV_CONCENTRATION_PROPERTY, "Concentration CV", PropertyType.DOUBLE, "Concentration CV across sample replicates");
+        addPropertyWithFormat(domain, AUC_PROPERTY, AUC_PROPERTY, PropertyType.DOUBLE, "Area Under the Curve", "0.0000");
 
         return result;
     }
@@ -257,16 +248,34 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
         specimenLsid.setShownInDetailsView(false);
         specimenLsid.setShownInUpdateView(false);
 
-        addProperty(dataDomain, WELL_LOCATION_PROPERTY, "Well Location", PropertyType.STRING, "Well location.");
-        addProperty(dataDomain, WELLGROUP_PROPERTY, "Well Group", PropertyType.STRING, "Well Group location.");
+        addProperty(dataDomain, WELL_LOCATION_PROPERTY, "Well Location", PropertyType.STRING, "Well location");
+        addProperty(dataDomain, WELLGROUP_PROPERTY, "Well Group", PropertyType.STRING, "Replicate Well Group");
 
-        DomainProperty absProp = addProperty(dataDomain, ABSORBANCE_PROPERTY,  "Absorption", PropertyType.DOUBLE, "Well group value measuring the absorption.");
-        absProp.setFormat("0.000");
-        DomainProperty concProp = addProperty(dataDomain, CONCENTRATION_PROPERTY,  "Concentration (ug/ml)", PropertyType.DOUBLE, "Well group value measuring the concentration.");
-        concProp.setFormat("0.000");
+        addPropertyWithFormat(dataDomain, ABSORBANCE_PROPERTY,  "Absorption", PropertyType.DOUBLE, "Raw signal value", "0.000");
+        DomainProperty concProp = addPropertyWithFormat(dataDomain, CONCENTRATION_PROPERTY,  "Concentration (ug/ml)", PropertyType.DOUBLE, "Calculated concentration", "0.000");
         concProp.setDefaultValueTypeEnum(DefaultValueType.LAST_ENTERED);
+        addPropertyWithFormat(dataDomain, STANDARD_CONCENTRATION_PROPERTY,  "Std Concentration (ug/ml)", PropertyType.DOUBLE, "Standard control concentration", "0.000");
+
+        addProperty(dataDomain, SPOT_PROPERTY, "Spot", PropertyType.INTEGER, "Spot or Analyte for the well");
+        addProperty(dataDomain, DILUTION_PROPERTY, "Dilution", PropertyType.DOUBLE, "Dilution for the well");
+        addProperty(dataDomain, EXCLUDED_PROPERTY, "Excluded", PropertyType.BOOLEAN, null);
+        addPropertyWithFormat(dataDomain, PERCENT_RECOVERY, "Percent Recovery", PropertyType.DOUBLE, "Ratio of computed concentration to specified", "0.000%");
+        addPropertyWithFormat(dataDomain, PERCENT_RECOVERY_MEAN, "Percent Recovery Mean", PropertyType.DOUBLE, "Mean of recovery for the control", "0.000%");
+
+        addPropertyWithFormat(dataDomain, MEAN_ABSORPTION_PROPERTY, "Absorption Mean", PropertyType.DOUBLE, "Mean Absorption across replicates", "0.000");
+        addPropertyWithFormat(dataDomain, CV_ABSORPTION_PROPERTY, "Absorption CV", PropertyType.DOUBLE, "Absorption CV across replicates", "0.000");
+        addPropertyWithFormat(dataDomain, MEAN_CONCENTRATION_PROPERTY, "Concentration Mean", PropertyType.DOUBLE, "Mean Concentration across replicates", "0.000");
+        addPropertyWithFormat(dataDomain, CV_CONCENTRATION_PROPERTY, "Concentration CV", PropertyType.DOUBLE, "Concentration CV across replicates", "0.000");
 
         return new Pair<>(dataDomain, Collections.emptyMap());
+    }
+
+    private DomainProperty addPropertyWithFormat(Domain domain, String name, String label, PropertyType type, String description, String format)
+    {
+        DomainProperty prop = addProperty(domain, name, label, type, description);
+        prop.setFormat(format);
+
+        return prop;
     }
 
     @Override

--- a/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
+++ b/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
@@ -94,6 +94,7 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
     public static final String CORRELATION_COEFFICIENT_PROPERTY = "RSquared";
     public static final String CURVE_FIT_METHOD_PROPERTY = "CurveFitMethod";
     public static final String CURVE_FIT_PARAMETERS_PROPERTY = "CurveFitParams";
+    public static final String CONCENTRATION_UNITS_PROPERTY = "ConcentrationUnits";
 
     // results properties
     public static final String ABSORBANCE_PROPERTY = "Absorption";
@@ -108,7 +109,6 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
     public static final String PERCENT_RECOVERY_MEAN = "Recovery_Mean";
     public static final String PLATE_PROPERTY = "PlateName";
     public static final String CONTROL_ID_PROPERTY = "ControlId";
-    public static final String CONTROL_AUC_PROPERTY = "AUC_Control";
 
     // sample properties
     public static final String AUC_PROPERTY = "AUC";
@@ -118,9 +118,19 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
     public static final String CV_CONCENTRATION_PROPERTY = "Concentration_CV";
     public static final Set<String> EXTRA_SAMPLE_PROPS;
 
+    public static Set<String> REQUIRED_RESULT_PROPERTIES;
+
     static
     {
         EXTRA_SAMPLE_PROPS = Set.of(AUC_PROPERTY);
+
+        REQUIRED_RESULT_PROPERTIES = Set.of(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY,
+                WELL_LOCATION_PROPERTY,
+                WELLGROUP_PROPERTY,
+                ABSORBANCE_PROPERTY,
+                CONCENTRATION_PROPERTY,
+                STANDARD_CONCENTRATION_PROPERTY,
+                EXCLUDED_PROPERTY);
     }
 
     enum PlateReaderType
@@ -210,6 +220,7 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
         DomainProperty fitProp = addProperty(domain, CORRELATION_COEFFICIENT_PROPERTY, "Coefficient of Determination", PropertyType.DOUBLE, "Coefficient of Determination of the calibration curve.");
         fitProp.setFormat("0.000");
         fitProp.setShownInInsertView(false);
+        addProperty(domain, CONCENTRATION_UNITS_PROPERTY, "Concentration Units", PropertyType.STRING, "Units eg. (ug/ml)");
 
         Container lookupContainer = c.getProject();
         DomainProperty method = addProperty(domain, CURVE_FIT_METHOD_PROPERTY, "Curve Fit Method", PropertyType.STRING);
@@ -259,9 +270,9 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
         addProperty(dataDomain, WELLGROUP_PROPERTY, "Well Group", PropertyType.STRING, "Replicate Well Group");
 
         addPropertyWithFormat(dataDomain, ABSORBANCE_PROPERTY,  "Absorption", PropertyType.DOUBLE, "Raw signal value", "0.000");
-        DomainProperty concProp = addPropertyWithFormat(dataDomain, CONCENTRATION_PROPERTY,  "Concentration (ug/ml)", PropertyType.DOUBLE, "Calculated concentration", "0.000");
+        DomainProperty concProp = addPropertyWithFormat(dataDomain, CONCENTRATION_PROPERTY,  "Concentration", PropertyType.DOUBLE, "Calculated concentration", "0.000");
         concProp.setDefaultValueTypeEnum(DefaultValueType.LAST_ENTERED);
-        addPropertyWithFormat(dataDomain, STANDARD_CONCENTRATION_PROPERTY,  "Std Concentration (ug/ml)", PropertyType.DOUBLE, "Standard control concentration", "0.000");
+        addPropertyWithFormat(dataDomain, STANDARD_CONCENTRATION_PROPERTY,  "Std Concentration", PropertyType.DOUBLE, "Standard control concentration", "0.000");
 
         addProperty(dataDomain, SPOT_PROPERTY, "Spot", PropertyType.INTEGER, "Spot or Analyte for the well");
         addProperty(dataDomain, PLATE_PROPERTY, "Plate Name", PropertyType.STRING, "Plate Name for multi-plate imports");
@@ -274,9 +285,7 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
         addPropertyWithFormat(dataDomain, CV_ABSORPTION_PROPERTY, "Absorption CV", PropertyType.DOUBLE, "Absorption CV across replicates", "0.000");
         addPropertyWithFormat(dataDomain, MEAN_CONCENTRATION_PROPERTY, "Concentration Mean", PropertyType.DOUBLE, "Mean Concentration across replicates", "0.000");
         addPropertyWithFormat(dataDomain, CV_CONCENTRATION_PROPERTY, "Concentration CV", PropertyType.DOUBLE, "Concentration CV across replicates", "0.000");
-
         addProperty(dataDomain, CONTROL_ID_PROPERTY, "Control ID", PropertyType.STRING, "Control Well Identifier");
-        addPropertyWithFormat(dataDomain, CONTROL_AUC_PROPERTY, "Control AUC", PropertyType.DOUBLE, "Area Under the Curve", "0.0000");
 
         return new Pair<>(dataDomain, Collections.emptyMap());
     }
@@ -350,13 +359,7 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
         runProperties.add(CURVE_FIT_PARAMETERS_PROPERTY);
 
         Set<String> resultProperties = domainMap.get(ASSAY_DOMAIN_DATA);
-        resultProperties.add(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY);
-        resultProperties.add(WELL_LOCATION_PROPERTY);
-        resultProperties.add(WELLGROUP_PROPERTY);
-        resultProperties.add(ABSORBANCE_PROPERTY);
-        resultProperties.add(CONCENTRATION_PROPERTY);
-        resultProperties.add(STANDARD_CONCENTRATION_PROPERTY);
-        resultProperties.add(EXCLUDED_PROPERTY);
+        resultProperties.addAll(REQUIRED_RESULT_PROPERTIES);
 
         domainMap.get(ASSAY_DOMAIN_SAMPLE_WELLGROUP).add(AUC_PROPERTY);
 

--- a/elisa/src/org/labkey/elisa/ElisaDataHandler.java
+++ b/elisa/src/org/labkey/elisa/ElisaDataHandler.java
@@ -253,7 +253,7 @@ public class ElisaDataHandler extends AbstractAssayTsvDataHandler implements Tra
                                 results.addAll(replicateRows);
                             }
                             // compute sample scoped statistics
-                            String materialKey = importHelper.getMaterialKey(plateName, sampleGroup.getName());
+                            String materialKey = importHelper.getMaterialKey(plateName, spot, sampleGroup.getName());
                             calculateSampleStats(context.getUser(), materialMap.get(materialKey), sampleProperties, standardCurve, samplePoints);
                         }
 
@@ -322,7 +322,7 @@ public class ElisaDataHandler extends AbstractAssayTsvDataHandler implements Tra
                     regression.addData(concentration, mean);
                 }
                 else
-                    LOG.warn("Unable to find a standard concentration for the replicate well group : " + key);
+                    LOG.info("Unable to find a standard concentration for the replicate well group : " + key);
             }
 
             if (!points.isEmpty())

--- a/elisa/src/org/labkey/elisa/ElisaDataHandler.java
+++ b/elisa/src/org/labkey/elisa/ElisaDataHandler.java
@@ -136,6 +136,8 @@ public class ElisaDataHandler extends AbstractAssayTsvDataHandler implements Tra
                         Map<String, Double> standardConcentrations = importHelper.getStandardConcentrations(plateName, analytePlateEntry.getKey());
 
                         CurveFit standardCurve = calculateStandardCurve(run, plate, regression, standardConcentrations, runProperties);
+                        if (standardCurve != null && standardCurve.getParameters() == null)
+                            throw new ExperimentException("Unable to fit the standard concentrations to a curve, please check the input data and try again");
 
                         Map<String, ExpMaterial> materialMap = data.getRun().getMaterialInputs().entrySet().stream()
                                 .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));

--- a/elisa/src/org/labkey/elisa/ElisaImportHelper.java
+++ b/elisa/src/org/labkey/elisa/ElisaImportHelper.java
@@ -1,7 +1,12 @@
 package org.labkey.elisa;
 
 import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.Position;
+import org.labkey.api.assay.plate.Well;
+import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.data.statistics.CurveFit;
 import org.labkey.api.exp.ExperimentException;
+import org.labkey.api.exp.api.ExpMaterial;
 
 import java.util.Map;
 import java.util.Set;
@@ -26,4 +31,24 @@ public interface ElisaImportHelper
      * Returns a map of replicate well group name to standard concentration value.
      */
     Map<String, Double> getStandardConcentrations(String plateName, int analyteNum) throws ExperimentException;
+
+    /**
+     * Helper to create a standard well row
+     *
+     * @param plateName the optional plate name parameter for multi plate imports
+     * @param replicate the replicate well group
+     * @param well the well we are creating the row for
+     * @param stdCurveFit the selected curvefit for the standard curve
+     * @param materialMap map of specimen well group name to expMaterial
+     */
+    Map<String, Object> createWellRow(String plateName, Integer spot, WellGroup replicate, Well well, Position position,
+                                      CurveFit stdCurveFit,
+                                      Map<String, ExpMaterial> materialMap);
+
+    /**
+     * Computes the key used to resolve material outputs. Multi-plate formatted data files may need
+     * to incorporate the plate name unless samples are the same across plates. Otherwise the well
+     * group name is sufficient.
+     */
+    String getMaterialKey(String plateName, String sampleWellGroup);
 }

--- a/elisa/src/org/labkey/elisa/ElisaImportHelper.java
+++ b/elisa/src/org/labkey/elisa/ElisaImportHelper.java
@@ -1,0 +1,29 @@
+package org.labkey.elisa;
+
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.exp.ExperimentException;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface ElisaImportHelper
+{
+    public static String PLACEHOLDER_PLATE_NAME = "PLACEHOLDER_PLATE";
+
+    /**
+     * Gets the set of plate names in this import
+     */
+    Set<String> getPlates();
+
+    /**
+     * Gets a map of analyte number to plate populated with raw signal values. Multi-plex plates will
+     * record multiple values per well (for each analyte). We will model this a multiple plates, one for
+     * each analyte.
+     */
+    Map<Integer, Plate> getAnalyteToPlate(String plateName) throws ExperimentException;
+
+    /**
+     * Returns a map of replicate well group name to standard concentration value.
+     */
+    Map<String, Double> getStandardConcentrations(String plateName, int analyteNum) throws ExperimentException;
+}

--- a/elisa/src/org/labkey/elisa/ElisaImportHelper.java
+++ b/elisa/src/org/labkey/elisa/ElisaImportHelper.java
@@ -50,5 +50,5 @@ public interface ElisaImportHelper
      * to incorporate the plate name unless samples are the same across plates. Otherwise the well
      * group name is sufficient.
      */
-    String getMaterialKey(String plateName, String sampleWellGroup);
+    String getMaterialKey(String plateName, Integer analyteNum, String sampleWellGroup);
 }

--- a/elisa/src/org/labkey/elisa/ElisaImportHelper.java
+++ b/elisa/src/org/labkey/elisa/ElisaImportHelper.java
@@ -22,7 +22,7 @@ public interface ElisaImportHelper
 
     /**
      * Gets a map of analyte number to plate populated with raw signal values. Multi-plex plates will
-     * record multiple values per well (for each analyte). We will model this a multiple plates, one for
+     * record multiple values per well (for each analyte). We will model this as multiple plates, one for
      * each analyte.
      */
     Map<Integer, Plate> getAnalyteToPlate(String plateName) throws ExperimentException;

--- a/elisa/src/org/labkey/elisa/ElisaModule.java
+++ b/elisa/src/org/labkey/elisa/ElisaModule.java
@@ -24,6 +24,7 @@ import org.labkey.api.module.CodeOnlyModule;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.AssayService;
+import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.view.WebPartFactory;
 
 import java.util.Collection;
@@ -31,6 +32,8 @@ import java.util.Collections;
 
 public class ElisaModule extends CodeOnlyModule
 {
+    public static final String EXPERIMENTAL_MULTI_PLATE_SUPPORT = "elisaMultiPlateSupport";
+
     @Override
     public String getName()
     {
@@ -59,6 +62,11 @@ public class ElisaModule extends CodeOnlyModule
         AbstractPlateBasedAssayProvider provider = new ElisaAssayProvider();
 
         AssayService.get().registerAssayProvider(provider);
+
+        AdminConsole.addExperimentalFeatureFlag(EXPERIMENTAL_MULTI_PLATE_SUPPORT,
+                "ELISA Multi-plate, multi well data support",
+                "Allows ELISA assay import of high-throughput data file formats which contain multiple plates and multiple analyte values per well.",
+                false);
     }
 
     @NotNull

--- a/elisa/src/org/labkey/elisa/ElisaPlateTypeHandler.java
+++ b/elisa/src/org/labkey/elisa/ElisaPlateTypeHandler.java
@@ -21,11 +21,14 @@ import org.labkey.api.assay.plate.AbstractPlateTypeHandler;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.util.Pair;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import static org.labkey.elisa.ElisaModule.EXPERIMENTAL_MULTI_PLATE_SUPPORT;
 
 /**
  * User: klum
@@ -175,7 +178,10 @@ public class ElisaPlateTypeHandler extends AbstractPlateTypeHandler
     @Override
     public List<Pair<Integer, Integer>> getSupportedPlateSizes()
     {
-        return List.of(new Pair<>(8, 12), new Pair<>(16, 24));
+        if (ExperimentalFeatureService.get().isFeatureEnabled(EXPERIMENTAL_MULTI_PLATE_SUPPORT))
+            return List.of(new Pair<>(8, 12), new Pair<>(16, 24));
+        else
+            return List.of(new Pair<>(8, 12));
     }
 
     @Override

--- a/elisa/src/org/labkey/elisa/ElisaProviderSchema.java
+++ b/elisa/src/org/labkey/elisa/ElisaProviderSchema.java
@@ -1,0 +1,43 @@
+package org.labkey.elisa;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssayProviderSchema;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.EnumTableInfo;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.statistics.StatsService;
+import org.labkey.api.security.User;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class ElisaProviderSchema extends AssayProviderSchema
+{
+    public static final String CURVE_FIT_METHOD_TABLE_NAME = "CurveFitMethod";
+
+    public ElisaProviderSchema(User user, Container container, AssayProvider provider, @Nullable Container targetStudy)
+    {
+        super(user, container, provider, targetStudy);
+    }
+
+    @Override
+    public Set<String> getTableNames()
+    {
+        return Collections.singleton(CURVE_FIT_METHOD_TABLE_NAME);
+    }
+
+    @Override
+    public TableInfo createTable(String name, ContainerFilter cf)
+    {
+        if (CURVE_FIT_METHOD_TABLE_NAME.equalsIgnoreCase(name))
+        {
+            EnumTableInfo<StatsService.CurveFitType> result = new EnumTableInfo<>(StatsService.CurveFitType.class, this, StatsService.CurveFitType::getLabel, false, "List of possible curve fitting methods for the " + getProvider().getResourceName() + " assay.");
+            result.setPublicSchemaName(getSchemaName());
+            result.setPublicName(CURVE_FIT_METHOD_TABLE_NAME);
+            return result;
+        }
+        return super.createTable(name, cf);
+    }
+}

--- a/elisa/src/org/labkey/elisa/ElisaProviderSchema.java
+++ b/elisa/src/org/labkey/elisa/ElisaProviderSchema.java
@@ -17,6 +17,25 @@ public class ElisaProviderSchema extends AssayProviderSchema
 {
     public static final String CURVE_FIT_METHOD_TABLE_NAME = "CurveFitMethod";
 
+    enum ElisaCurveFits
+    {
+        FOUR_PARAMETER(StatsService.CurveFitType.FOUR_PARAMETER.getLabel()),
+        FIVE_PARAMETER(StatsService.CurveFitType.FIVE_PARAMETER.getLabel()),
+        LINEAR(StatsService.CurveFitType.LINEAR.getLabel());
+
+        private String _label;
+
+        ElisaCurveFits(String label)
+        {
+            _label = label;
+        }
+
+        public String getLabel()
+        {
+            return _label;
+        }
+    }
+
     public ElisaProviderSchema(User user, Container container, AssayProvider provider, @Nullable Container targetStudy)
     {
         super(user, container, provider, targetStudy);
@@ -33,7 +52,7 @@ public class ElisaProviderSchema extends AssayProviderSchema
     {
         if (CURVE_FIT_METHOD_TABLE_NAME.equalsIgnoreCase(name))
         {
-            EnumTableInfo<StatsService.CurveFitType> result = new EnumTableInfo<>(StatsService.CurveFitType.class, this, StatsService.CurveFitType::getLabel, false, "List of possible curve fitting methods for the " + getProvider().getResourceName() + " assay.");
+            EnumTableInfo<ElisaCurveFits> result = new EnumTableInfo<>(ElisaCurveFits.class, this, ElisaCurveFits::getLabel, false, "List of possible curve fitting methods for the " + getProvider().getResourceName() + " assay.");
             result.setPublicSchemaName(getSchemaName());
             result.setPublicName(CURVE_FIT_METHOD_TABLE_NAME);
             return result;

--- a/elisa/src/org/labkey/elisa/ElisaSampleFilePropertyHelper.java
+++ b/elisa/src/org/labkey/elisa/ElisaSampleFilePropertyHelper.java
@@ -1,0 +1,114 @@
+package org.labkey.elisa;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.plate.PlateSampleFilePropertyHelper;
+import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Position;
+import org.labkey.api.assay.plate.PositionImpl;
+import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.assay.plate.WellGroupTemplate;
+import org.labkey.api.data.Container;
+import org.labkey.api.exp.ExperimentException;
+import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.reader.DataLoader;
+import org.labkey.api.reader.DataLoaderFactory;
+import org.labkey.api.reader.DataLoaderService;
+import org.labkey.api.study.assay.SampleMetadataInputFormat;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ElisaSampleFilePropertyHelper extends PlateSampleFilePropertyHelper
+{
+    public ElisaSampleFilePropertyHelper(Container container, ExpProtocol protocol, List<? extends DomainProperty> domainProperties, PlateTemplate template, SampleMetadataInputFormat inputFormat)
+    {
+        super(container, protocol, domainProperties, template, inputFormat);
+    }
+
+    @Override
+    public Map<String, Map<DomainProperty, String>> getSampleProperties(HttpServletRequest request) throws ExperimentException
+    {
+        if (_sampleProperties != null)
+            return _sampleProperties;
+
+        File metadataFile = getSampleMetadata(request);
+        if (metadataFile == null)
+            throw new ExperimentException("No metadata or data file provided");
+
+        Map<String, Map<DomainProperty, String>> allProperties = new HashMap<>();
+        try
+        {
+            DataLoaderFactory factory = DataLoaderService.get().findFactory(metadataFile, null);
+            DataLoader loader = factory.createLoader(metadataFile, true);
+
+            String plateColumnName = "Plate Name";
+            String sampleColumnName = "Sample";
+            String wellLocationColumnName = "Well";
+
+            boolean hasPlateColumn = Arrays.stream(loader.getColumns()).anyMatch(c -> c.getColumnName().equalsIgnoreCase(plateColumnName));
+            boolean hasSampleColumn = Arrays.stream(loader.getColumns()).anyMatch(c -> c.getColumnName().equalsIgnoreCase(sampleColumnName));
+            boolean hasWellLocationColumn = Arrays.stream(loader.getColumns()).anyMatch(c -> c.getColumnName().equalsIgnoreCase(wellLocationColumnName));
+
+            if (!hasPlateColumn)
+                throw new ExperimentException("Sample metadata file does not contain required column \"" + plateColumnName + "\".");
+            if (!hasSampleColumn)
+                throw new ExperimentException("Sample metadata file does not contain required column \"" + sampleColumnName + "\".");
+            if (!hasWellLocationColumn)
+                throw new ExperimentException("Sample metadata file does not contain required column \"" + hasWellLocationColumn + "\".");
+
+            for (Map<String, Object> row : loader)
+            {
+                String wellLocation = String.valueOf(row.get(wellLocationColumnName));
+                String plateName = String.valueOf(row.get(plateColumnName));
+
+                if (wellLocation != null && plateName != null)
+                {
+                    String sampleWellGroup = getSampleWellGroupFromLocation(plateName, wellLocation);
+                    if (sampleWellGroup != null)
+                    {
+                        Map<DomainProperty, String> sampleProperties = allProperties.computeIfAbsent(sampleWellGroup, k -> new HashMap<>());
+                        for (DomainProperty property : _domainProperties)
+                        {
+                            Object value = getValue(row, property);
+                            sampleProperties.put(property, value != null ? value.toString() : null);
+                        }
+                    }
+                }
+            }
+        }
+        catch (IOException e)
+        {
+            throw new ExperimentException("Unable to parse sample properties file.  Please verify that the file is a valid Excel workbook.", e);
+        }
+        _sampleProperties = allProperties;
+        return _sampleProperties;
+    }
+
+    @Nullable
+    private String getSampleWellGroupFromLocation(String plateName, String wellLocation)
+    {
+        try
+        {
+            PositionImpl position = new PositionImpl(_protocol.getContainer(), wellLocation);
+            // need to adjust the column value to be 0 based to match the template locations
+            position.setColumn(position.getColumn()-1);
+
+            for (WellGroupTemplate wellGroup : _template.getWellGroups(position))
+            {
+                if (wellGroup.getType() == WellGroup.Type.SPECIMEN)
+                    return HighThroughputImportHelper.getSpecimenGroupKey(plateName, wellGroup.getName());
+            }
+            return null;
+        }
+        catch (IllegalArgumentException e)
+        {
+            return null;
+        }
+    }
+}

--- a/elisa/src/org/labkey/elisa/ElisaSampleFilePropertyHelper.java
+++ b/elisa/src/org/labkey/elisa/ElisaSampleFilePropertyHelper.java
@@ -50,26 +50,31 @@ public class ElisaSampleFilePropertyHelper extends PlateSampleFilePropertyHelper
             String plateColumnName = "Plate Name";
             String sampleColumnName = "Sample";
             String wellLocationColumnName = "Well";
+            String spotColumnName = "Spot";
 
             boolean hasPlateColumn = Arrays.stream(loader.getColumns()).anyMatch(c -> c.getColumnName().equalsIgnoreCase(plateColumnName));
             boolean hasSampleColumn = Arrays.stream(loader.getColumns()).anyMatch(c -> c.getColumnName().equalsIgnoreCase(sampleColumnName));
             boolean hasWellLocationColumn = Arrays.stream(loader.getColumns()).anyMatch(c -> c.getColumnName().equalsIgnoreCase(wellLocationColumnName));
+            boolean hasSpotColumn = Arrays.stream(loader.getColumns()).anyMatch(c -> c.getColumnName().equalsIgnoreCase(spotColumnName));
 
             if (!hasPlateColumn)
                 throw new ExperimentException("Sample metadata file does not contain required column \"" + plateColumnName + "\".");
             if (!hasSampleColumn)
                 throw new ExperimentException("Sample metadata file does not contain required column \"" + sampleColumnName + "\".");
             if (!hasWellLocationColumn)
-                throw new ExperimentException("Sample metadata file does not contain required column \"" + hasWellLocationColumn + "\".");
+                throw new ExperimentException("Sample metadata file does not contain required column \"" + wellLocationColumnName + "\".");
+            if (!hasSpotColumn)
+                throw new ExperimentException("Sample metadata file does not contain required column \"" + spotColumnName + "\".");
 
             for (Map<String, Object> row : loader)
             {
                 String wellLocation = String.valueOf(row.get(wellLocationColumnName));
                 String plateName = String.valueOf(row.get(plateColumnName));
+                Integer spot = (Integer)row.get(spotColumnName);
 
                 if (wellLocation != null && plateName != null)
                 {
-                    String sampleWellGroup = getSampleWellGroupFromLocation(plateName, wellLocation);
+                    String sampleWellGroup = getSampleWellGroupFromLocation(plateName, spot, wellLocation);
                     if (sampleWellGroup != null)
                     {
                         Map<DomainProperty, String> sampleProperties = allProperties.computeIfAbsent(sampleWellGroup, k -> new HashMap<>());
@@ -91,7 +96,7 @@ public class ElisaSampleFilePropertyHelper extends PlateSampleFilePropertyHelper
     }
 
     @Nullable
-    private String getSampleWellGroupFromLocation(String plateName, String wellLocation)
+    private String getSampleWellGroupFromLocation(String plateName, Integer analyteNum, String wellLocation)
     {
         try
         {
@@ -102,7 +107,7 @@ public class ElisaSampleFilePropertyHelper extends PlateSampleFilePropertyHelper
             for (WellGroupTemplate wellGroup : _template.getWellGroups(position))
             {
                 if (wellGroup.getType() == WellGroup.Type.SPECIMEN)
-                    return HighThroughputImportHelper.getSpecimenGroupKey(plateName, wellGroup.getName());
+                    return HighThroughputImportHelper.getSpecimenGroupKey(plateName, analyteNum, wellGroup.getName());
             }
             return null;
         }

--- a/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
+++ b/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
@@ -1,0 +1,294 @@
+package org.labkey.elisa;
+
+import org.apache.log4j.Logger;
+import org.labkey.api.assay.AssayUploadXarContext;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateBasedAssayProvider;
+import org.labkey.api.assay.plate.PlateService;
+import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Position;
+import org.labkey.api.assay.plate.PositionImpl;
+import org.labkey.api.assay.plate.Well;
+import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.assay.plate.WellGroupTemplate;
+import org.labkey.api.data.statistics.CurveFit;
+import org.labkey.api.exp.ExperimentException;
+import org.labkey.api.exp.api.ExpMaterial;
+import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ProvenanceService;
+import org.labkey.api.reader.DataLoader;
+import org.labkey.api.reader.DataLoaderFactory;
+import org.labkey.api.reader.DataLoaderService;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.labkey.elisa.ElisaDataHandler.STANDARDS_WELL_GROUP_NAME;
+
+public class HighThroughputImportHelper extends AbstractElisaImportHelper
+{
+    private static final Logger LOG = Logger.getLogger(HighThroughputImportHelper.class);
+    private Map<String, AnalytePlate> _plateMap = new HashMap<>();
+    private PlateTemplate _plateTemplate;
+
+    public HighThroughputImportHelper(AssayUploadXarContext context, PlateBasedAssayProvider provider, ExpProtocol protocol, File dataFile) throws ExperimentException
+    {
+        super(context, provider, protocol, dataFile);
+        ensureData();
+    }
+
+    private void ensureData() throws ExperimentException
+    {
+        try
+        {
+            _plateTemplate = _provider.getPlateTemplate(_protocol.getContainer(), _protocol);
+            DataLoaderFactory factory = DataLoaderService.get().findFactory(_dataFile, null);
+            DataLoader loader = factory.createLoader(_dataFile, true);
+
+            String plateColumnName = "Plate Name";
+            String sampleColumnName = "Sample";
+            String wellLocationColumnName = "Well";
+            String signalColumnName = "Signal";
+
+            boolean hasPlateColumn = Arrays.stream(loader.getColumns()).anyMatch(c -> c.getColumnName().equalsIgnoreCase(plateColumnName));
+            boolean hasSampleColumn = Arrays.stream(loader.getColumns()).anyMatch(c -> c.getColumnName().equalsIgnoreCase(sampleColumnName));
+            boolean hasWellLocationColumn = Arrays.stream(loader.getColumns()).anyMatch(c -> c.getColumnName().equalsIgnoreCase(wellLocationColumnName));
+
+            if (!hasPlateColumn)
+                throw new ExperimentException("Sample metadata file does not contain required column \"" + plateColumnName + "\".");
+            if (!hasSampleColumn)
+                throw new ExperimentException("Sample metadata file does not contain required column \"" + sampleColumnName + "\".");
+            if (!hasWellLocationColumn)
+                throw new ExperimentException("Sample metadata file does not contain required column \"" + hasWellLocationColumn + "\".");
+
+            for (Map<String, Object> row : loader)
+            {
+                String wellLocation = String.valueOf(row.get(wellLocationColumnName));
+                String plateName = String.valueOf(row.get(plateColumnName));
+
+                AnalytePlate analytePlate = _plateMap.computeIfAbsent(plateName, p -> new AnalytePlate(p, _plateTemplate));
+
+                if (wellLocation != null && plateName != null)
+                {
+                    PositionImpl position = new PositionImpl(_container, wellLocation);
+                    Integer spot = (Integer)row.get(ElisaAssayProvider.SPOT_PROPERTY);
+                    Integer signal = (Integer)row.get(signalColumnName);
+                    Double concentration = (Double)row.get(ElisaAssayProvider.CONCENTRATION_PROPERTY);
+
+                    // store the raw signal values on a per analyte basis
+                    analytePlate.setRawSignal(position, spot, signal);
+                    analytePlate.setExtraProperties(row, position, spot);
+
+                    if (concentration != null)
+                    {
+                        analytePlate.setStdConcentration(position, spot, concentration);
+                    }
+                }
+                else
+                    LOG.warn("No well location and plate name for row : " + row.toString());
+            }
+        }
+        catch (IOException e)
+        {
+            throw new ExperimentException("Unable to parse sample properties file.  Please verify that the file is a valid Excel workbook.", e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> createWellRow(String plateName, Integer spot, WellGroup replicate, Well well, Position position, CurveFit stdCurveFit, Map<String, ExpMaterial> materialMap)
+    {
+        Map<String, Object> row = super.createWellRow(plateName, spot, replicate, well, position, stdCurveFit, materialMap);
+
+        row.put(ElisaAssayProvider.PLATE_PROPERTY, plateName);
+        row.put(ElisaAssayProvider.SPOT_PROPERTY, spot);
+
+        // add any extra properties
+        AnalytePlate analytePlate = _plateMap.get(plateName);
+        if (analytePlate != null)
+        {
+            // bail out if this isn't a valid row in the data file
+            if (!analytePlate.hasData(position, spot))
+                return Collections.emptyMap();
+
+            row.putAll(analytePlate.getExtraProperties(position, spot));
+        }
+
+        // if this well is a sample well group add the material LSID
+        Map<Position, String> specimenGroupMap = getSpecimenGroupMap();
+        if (specimenGroupMap.containsKey(position))
+        {
+            String materialKey = getMaterialKey(plateName, specimenGroupMap.get(position));
+            ExpMaterial material = materialMap.get(materialKey);
+            if (material != null)
+            {
+                row.put(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY, material.getLSID());
+                // TODO: Support adding the material to existing provenance inputs on the row, if any
+                if (_pvs != null)
+                    row.put(ProvenanceService.PROVENANCE_INPUT_PROPERTY, List.of(material.getLSID()));
+            }
+        }
+        return row;
+    }
+
+    /**
+     * For multiple plate uploads, we need to create unique specimen LSIDs for each plate/sample
+     * combination.
+     */
+    public static String getSpecimenGroupKey(String plateName, String sampleWellGroup)
+    {
+        return plateName + "-" + sampleWellGroup;
+    }
+
+    @Override
+    public String getMaterialKey(String plateName, String sampleWellGroup)
+    {
+        return getSpecimenGroupKey(plateName, sampleWellGroup);
+    }
+
+    @Override
+    public Set<String> getPlates()
+    {
+        return _plateMap.keySet();
+    }
+
+    @Override
+    public Map<Integer, Plate> getAnalyteToPlate(String plateName) throws ExperimentException
+    {
+        Map<Integer, Plate> analyteToPlate = new HashMap<>();
+        for (Map.Entry<Integer, double[][]> entry : _plateMap.get(plateName).getDataMap().entrySet())
+        {
+            Plate plate = PlateService.get().createPlate(_plateTemplate, entry.getValue(), null);
+            analyteToPlate.put(entry.getKey(), plate);
+        }
+        return analyteToPlate;
+    }
+
+    @Override
+    public Map<String, Double> getStandardConcentrations(String plateName, int analyteNum) throws ExperimentException
+    {
+        return _plateMap.get(plateName).getStdConcentrations(analyteNum);
+    }
+
+    private static class AnalytePlate
+    {
+        private Map<Integer, Map<String, Double>> _stdConcentrations = new HashMap<>();
+        private Map<Integer, double[][]> _dataMap = new HashMap<>();
+        private String _plateName;
+        private PlateTemplate _plateTemplate;
+        // contains the mapping of (well/analyte) to extra row data to merge during data import
+        private Map<String, Map<String, Object>> _extraWellData = new HashMap<>();
+        public static final String CONTROL_ID_COLUMN = "Sample";
+
+        public AnalytePlate(String plateName, PlateTemplate plateTemplate)
+        {
+            _plateName = plateName;
+            _plateTemplate = plateTemplate;
+        }
+
+        public Map<String, Double> getStdConcentrations(int analyteNum)
+        {
+            if (_stdConcentrations.containsKey(analyteNum))
+                return _stdConcentrations.get(analyteNum);
+            else
+                return Collections.emptyMap();
+        }
+
+        public Map<Integer, double[][]> getDataMap()
+        {
+            return _dataMap;
+        }
+
+        public String getPlateName()
+        {
+            return _plateName;
+        }
+
+        public void setStdConcentration(Position position, Integer spot, Double concentration)
+        {
+            WellGroupTemplate replicateWellGroup = null;
+            WellGroupTemplate controlWellGroup = null;
+
+            for (WellGroupTemplate wellGroup : _plateTemplate.getWellGroups(position))
+            {
+                if (wellGroup.getType() == WellGroup.Type.REPLICATE)
+                    replicateWellGroup = wellGroup;
+                else if (wellGroup.getType() == WellGroup.Type.CONTROL)
+                    controlWellGroup = wellGroup;
+            }
+
+            if (controlWellGroup != null && replicateWellGroup != null)
+            {
+                // limit to only the Standards controls
+                if (controlWellGroup.getName().equals(STANDARDS_WELL_GROUP_NAME))
+                {
+                    Map<String, Double> concentrations = _stdConcentrations.computeIfAbsent(spot, s -> new HashMap<>());
+                    concentrations.put(replicateWellGroup.getPositionDescription(), concentration);
+                }
+            }
+        }
+
+        public void setRawSignal(Position position, Integer spot, Integer signal)
+        {
+            if (position != null && spot != null && signal != null)
+            {
+                double[][] data = _dataMap.computeIfAbsent(spot, s -> new double[_plateTemplate.getRows()][_plateTemplate.getColumns()]);
+                data[position.getRow()][position.getColumn()-1] = signal.doubleValue();
+            }
+        }
+
+        public void setExtraProperties(Map<String, Object> row, PositionImpl position, Integer spot)
+        {
+            Map<String, Object> extraProperties = new HashMap<>();
+            // need to adjust the column value to be 0 based to match the template locations
+            position.setColumn(position.getColumn()-1);
+
+            for (WellGroupTemplate wellGroup : _plateTemplate.getWellGroups(position))
+            {
+                if (wellGroup.getType() == WellGroup.Type.CONTROL)
+                {
+                    // get the control ID for control well groups
+                    if (row.containsKey(CONTROL_ID_COLUMN))
+                        extraProperties.put(ElisaAssayProvider.CONTROL_ID_PROPERTY, row.get(CONTROL_ID_COLUMN));
+
+                    break;
+                }
+            }
+
+            if (row.containsKey(ElisaAssayProvider.DILUTION_PROPERTY))
+            {
+                extraProperties.put(ElisaAssayProvider.DILUTION_PROPERTY, row.get(ElisaAssayProvider.DILUTION_PROPERTY));
+            }
+
+            _extraWellData.put(getWellAnalyteKey(position, spot), extraProperties);
+        }
+
+        public Map<String, Object> getExtraProperties(Position position, Integer spot)
+        {
+            String key = getWellAnalyteKey(position, spot);
+            if (_extraWellData.containsKey(key))
+            {
+                return _extraWellData.get(key);
+            }
+            return Collections.emptyMap();
+        }
+
+        /**
+         * Helper to determine if the data file contained a record for the well/analyte combination
+         */
+        public boolean hasData(Position position, Integer spot)
+        {
+            return _extraWellData.containsKey(getWellAnalyteKey(position, spot));
+        }
+
+        private String getWellAnalyteKey(Position position, Integer spot)
+        {
+            return position.getDescription() + "-" + spot;
+        }
+    }
+}

--- a/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
+++ b/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
@@ -23,7 +23,6 @@ import org.labkey.api.reader.DataLoaderService;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -49,29 +48,15 @@ public class HighThroughputImportHelper extends AbstractElisaImportHelper
             _plateTemplate = _provider.getPlateTemplate(_protocol.getContainer(), _protocol);
             DataLoaderFactory factory = DataLoaderService.get().findFactory(_dataFile, null);
             DataLoader loader = factory.createLoader(_dataFile, true);
-
-            String plateColumnName = "Plate Name";
-            String sampleColumnName = "Sample";
-            String wellLocationColumnName = "Well";
             String signalColumnName = "Signal";
 
-            boolean hasPlateColumn = Arrays.stream(loader.getColumns()).anyMatch(c -> c.getColumnName().equalsIgnoreCase(plateColumnName));
-            boolean hasSampleColumn = Arrays.stream(loader.getColumns()).anyMatch(c -> c.getColumnName().equalsIgnoreCase(sampleColumnName));
-            boolean hasWellLocationColumn = Arrays.stream(loader.getColumns()).anyMatch(c -> c.getColumnName().equalsIgnoreCase(wellLocationColumnName));
-
-            if (!hasPlateColumn)
-                throw new ExperimentException("Sample metadata file does not contain required column \"" + plateColumnName + "\".");
-            if (!hasSampleColumn)
-                throw new ExperimentException("Sample metadata file does not contain required column \"" + sampleColumnName + "\".");
-            if (!hasWellLocationColumn)
-                throw new ExperimentException("Sample metadata file does not contain required column \"" + hasWellLocationColumn + "\".");
-
+            ElisaSampleFilePropertyHelper.validateRequiredColumns(loader.getColumns());
             List<? extends DomainProperty> resultDomain = _provider.getResultsDomain(_protocol).getProperties();
 
             for (Map<String, Object> row : loader)
             {
-                String wellLocation = String.valueOf(row.get(wellLocationColumnName));
-                String plateName = String.valueOf(row.get(plateColumnName));
+                String wellLocation = String.valueOf(row.get(ElisaSampleFilePropertyHelper.WELL_LOCATION_COLUMN_NAME));
+                String plateName = String.valueOf(row.get(ElisaSampleFilePropertyHelper.PLATE_COLUMN_NAME));
 
                 AnalytePlate analytePlate = _plateMap.computeIfAbsent(plateName, p -> new AnalytePlate(p, _plateTemplate));
 

--- a/elisa/src/org/labkey/elisa/ManualImportHelper.java
+++ b/elisa/src/org/labkey/elisa/ManualImportHelper.java
@@ -1,0 +1,108 @@
+package org.labkey.elisa;
+
+import org.apache.commons.lang3.math.NumberUtils;
+import org.labkey.api.assay.AssayRunUploadContext;
+import org.labkey.api.assay.AssayUploadXarContext;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateBasedAssayProvider;
+import org.labkey.api.assay.plate.PlateReader;
+import org.labkey.api.assay.plate.PlateService;
+import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Position;
+import org.labkey.api.assay.plate.Well;
+import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.data.statistics.CurveFit;
+import org.labkey.api.exp.ExperimentException;
+import org.labkey.api.exp.api.ExpMaterial;
+import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ProvenanceService;
+import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.elisa.actions.ElisaRunUploadForm;
+import org.labkey.elisa.plate.BioTekPlateReader;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Import helper that uses the standard import wizard form entry fields.
+ */
+public class ManualImportHelper extends AbstractElisaImportHelper
+{
+    public ManualImportHelper(AssayUploadXarContext context, PlateBasedAssayProvider provider, ExpProtocol protocol, File dataFile)
+    {
+        super(context, provider, protocol, dataFile);
+    }
+
+    @Override
+    public Set<String> getPlates()
+    {
+        return Set.of(PLACEHOLDER_PLATE_NAME);
+    }
+
+    @Override
+    public Map<Integer, Plate> getAnalyteToPlate(String plateName) throws ExperimentException
+    {
+        Map<Integer, Plate> analyteMap = new HashMap<>();
+        PlateReader reader = _provider.getPlateReader(BioTekPlateReader.LABEL);
+        if (reader != null)
+        {
+            PlateTemplate template = _provider.getPlateTemplate(_protocol.getContainer(), _protocol);
+            double[][] cellValues = reader.loadFile(template, _dataFile);
+            Plate plate = PlateService.get().createPlate(template, cellValues, null);
+
+            analyteMap.put(1, plate);
+        }
+        return analyteMap;
+    }
+
+    @Override
+    public Map<String, Double> getStandardConcentrations(String plateName, int analyteNum) throws ExperimentException
+    {
+        Map<String, Double> concentrations = new HashMap<>();
+        AssayRunUploadContext runUploadContext = _context.getContext();
+        if (runUploadContext instanceof ElisaRunUploadForm)
+        {
+            Map<String, Map<DomainProperty, String>> props = ((ElisaRunUploadForm)runUploadContext).getConcentrationProperties();
+
+            for (Map.Entry<String, Map<DomainProperty, String>> entry : props.entrySet())
+            {
+                for (DomainProperty dp : entry.getValue().keySet())
+                {
+                    double conc = 0;
+                    if (ElisaAssayProvider.CONCENTRATION_PROPERTY.equals(dp.getName()))
+                    {
+                        conc = NumberUtils.toDouble(entry.getValue().get(dp), 0);
+                    }
+                    concentrations.put(entry.getKey(), conc);
+                }
+            }
+            return concentrations;
+        }
+        else
+            throw new ExperimentException("The form is not an instance of ElisaRunUploadForm, concentration values were not accessible.");
+    }
+
+    @Override
+    public Map<String, Object> createWellRow(String plateName, Integer spot, WellGroup replicate, Well well, Position position, CurveFit stdCurveFit, Map<String, ExpMaterial> materialMap)
+    {
+        Map<String, Object> row = super.createWellRow(plateName, spot, replicate, well, position, stdCurveFit, materialMap);
+
+        // if this well is a sample well group add the material LSID
+        Map<Position, String> specimenGroupMap = getSpecimenGroupMap();
+        if (specimenGroupMap.containsKey(position))
+        {
+            ExpMaterial material = materialMap.get(specimenGroupMap.get(position));
+            if (material != null)
+            {
+                row.put(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY, material.getLSID());
+                // TODO: Support adding the material to existing provenance inputs on the row, if any
+                if (_pvs != null)
+                    row.put(ProvenanceService.PROVENANCE_INPUT_PROPERTY, List.of(material.getLSID()));
+            }
+        }
+        return row;
+    }
+}

--- a/elisa/src/org/labkey/elisa/actions/ElisaRunUploadForm.java
+++ b/elisa/src/org/labkey/elisa/actions/ElisaRunUploadForm.java
@@ -15,9 +15,10 @@
  */
 package org.labkey.elisa.actions;
 
-import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.assay.actions.PlateUploadFormImpl;
 import org.labkey.api.assay.plate.PlateSamplePropertyHelper;
+import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.study.assay.SampleMetadataInputFormat;
 import org.labkey.elisa.ElisaAssayProvider;
 
 import java.util.Map;
@@ -31,6 +32,7 @@ public class ElisaRunUploadForm extends PlateUploadFormImpl<ElisaAssayProvider>
     private Map<String, Map<DomainProperty, String>> _sampleProperties;
     private PlateSamplePropertyHelper _samplePropertyHelper;
     private Map<String, Map<DomainProperty, String>> _concentrationProperties;
+    private SampleMetadataInputFormat _inputFormat;
 
     @Override
     public PlateSamplePropertyHelper getSamplePropertyHelper()
@@ -64,5 +66,14 @@ public class ElisaRunUploadForm extends PlateUploadFormImpl<ElisaAssayProvider>
     public void setConcentrationProperties(Map<String, Map<DomainProperty, String>> concentrationProperties)
     {
         _concentrationProperties = concentrationProperties;
+    }
+
+    public SampleMetadataInputFormat getSampleMetadataInputFormat()
+    {
+        if (_inputFormat == null)
+        {
+            _inputFormat = getProvider().getMetadataInputFormat(getProtocol());
+        }
+        return _inputFormat;
     }
 }

--- a/elisa/src/org/labkey/elisa/actions/ElisaUploadWizardAction.java
+++ b/elisa/src/org/labkey/elisa/actions/ElisaUploadWizardAction.java
@@ -18,6 +18,11 @@ package org.labkey.elisa.actions;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.assay.AssayUrls;
+import org.labkey.api.assay.PreviouslyUploadedDataCollector;
+import org.labkey.api.assay.actions.PlateBasedUploadWizardAction;
+import org.labkey.api.assay.plate.PlateSamplePropertyHelper;
+import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
 import org.labkey.api.data.Container;
@@ -32,12 +37,8 @@ import org.labkey.api.query.ValidationError;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.permissions.InsertPermission;
-import org.labkey.api.assay.plate.PlateTemplate;
-import org.labkey.api.assay.actions.PlateBasedUploadWizardAction;
-import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.study.assay.ParticipantVisitResolverType;
-import org.labkey.api.assay.plate.PlateSamplePropertyHelper;
-import org.labkey.api.assay.PreviouslyUploadedDataCollector;
+import org.labkey.api.study.assay.SampleMetadataInputFormat;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.InsertView;
 import org.labkey.elisa.ElisaAssayProvider;
@@ -78,6 +79,7 @@ public class ElisaUploadWizardAction extends PlateBasedUploadWizardAction<ElisaR
     protected RunStepHandler getRunStepHandler()
     {
         return new PlateBasedRunStepHandler() {
+/*
             @Override
             public void validateStep(ElisaRunUploadForm form, Errors errors)
             {
@@ -95,6 +97,7 @@ public class ElisaUploadWizardAction extends PlateBasedUploadWizardAction<ElisaR
                     }
                 }
             }
+*/
 
             @Override
             public boolean executeStep(ElisaRunUploadForm form, BindException errors) throws ServletException, SQLException, ExperimentException
@@ -111,7 +114,12 @@ public class ElisaUploadWizardAction extends PlateBasedUploadWizardAction<ElisaR
                         errors.addError(new ObjectError("main", null, null, e.toString()));
                     }
                 }
-                return false;
+
+                // if this is a manual metadata upload, continue to the concentrations input view
+                if (form.getSampleMetadataInputFormat() == SampleMetadataInputFormat.MANUAL)
+                    return false;
+                else
+                    return super.executeStep(form, errors);
             }
 
             @Override
@@ -119,16 +127,21 @@ public class ElisaUploadWizardAction extends PlateBasedUploadWizardAction<ElisaR
             {
                 if (form.isResetDefaultValues() || errors.hasErrors())
                     return getRunPropertiesView(form, !form.isResetDefaultValues(), false, errors);
-                else
+                else if (form.getSampleMetadataInputFormat() == SampleMetadataInputFormat.MANUAL)
                     return getConcentrationsView(form, false, errors);
-            }
+                else
+                    return null;            }
         };
     }
 
     @Override
     protected void addRunActionButtons(ElisaRunUploadForm form, InsertView insertView, ButtonBar bbar)
     {
-        addNextButton(bbar);
+        // don't render the concentrations view
+        if (form.getSampleMetadataInputFormat() == SampleMetadataInputFormat.MANUAL)
+            addNextButton(bbar);
+        else
+            addFinishButtons(form, insertView, bbar);
         addResetButton(form, insertView, bbar);
     }
 

--- a/elisa/src/org/labkey/elisa/actions/ElisaUploadWizardAction.java
+++ b/elisa/src/org/labkey/elisa/actions/ElisaUploadWizardAction.java
@@ -80,6 +80,24 @@ public class ElisaUploadWizardAction extends PlateBasedUploadWizardAction<ElisaR
     {
         return new PlateBasedRunStepHandler() {
             @Override
+            public void validateStep(ElisaRunUploadForm form, Errors errors)
+            {
+                super.validateStep(form, errors);
+
+                if (!errors.hasErrors())
+                {
+                    try
+                    {
+                        form.getUploadedData();
+                    }
+                    catch (ExperimentException e)
+                    {
+                        errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
+                    }
+                }
+            }
+
+            @Override
             public boolean executeStep(ElisaRunUploadForm form, BindException errors) throws ServletException, SQLException, ExperimentException
             {
                 form.setSampleProperties(_postedSampleProperties);

--- a/elisa/src/org/labkey/elisa/actions/ElisaUploadWizardAction.java
+++ b/elisa/src/org/labkey/elisa/actions/ElisaUploadWizardAction.java
@@ -79,26 +79,6 @@ public class ElisaUploadWizardAction extends PlateBasedUploadWizardAction<ElisaR
     protected RunStepHandler getRunStepHandler()
     {
         return new PlateBasedRunStepHandler() {
-/*
-            @Override
-            public void validateStep(ElisaRunUploadForm form, Errors errors)
-            {
-                super.validateStep(form, errors);
-
-                if (!errors.hasErrors())
-                {
-                    try
-                    {
-                        form.getUploadedData();
-                    }
-                    catch (ExperimentException e)
-                    {
-                        errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
-                    }
-                }
-            }
-*/
-
             @Override
             public boolean executeStep(ElisaRunUploadForm form, BindException errors) throws ServletException, SQLException, ExperimentException
             {

--- a/elisa/src/org/labkey/elisa/actions/PlateConcentrationPropertyHelper.java
+++ b/elisa/src/org/labkey/elisa/actions/PlateConcentrationPropertyHelper.java
@@ -110,7 +110,7 @@ public class PlateConcentrationPropertyHelper extends SamplePropertyHelper<WellG
         for (DomainProperty prop : domainProperties)
         {
             // only interested in the concentration property
-            if (ElisaAssayProvider.CONCENTRATION_PROPERTY_NAME.equals(prop.getName()))
+            if (ElisaAssayProvider.CONCENTRATION_PROPERTY.equals(prop.getName()))
             {
                 domainProperties = Collections.singletonList(prop);
                 break;

--- a/elisa/src/org/labkey/elisa/query/ElisaResultsTable.java
+++ b/elisa/src/org/labkey/elisa/query/ElisaResultsTable.java
@@ -15,6 +15,9 @@
  */
 package org.labkey.elisa.query;
 
+import org.labkey.api.assay.AbstractAssayProvider;
+import org.labkey.api.assay.AssayProtocolSchema;
+import org.labkey.api.assay.AssayResultTable;
 import org.labkey.api.assay.plate.AbstractPlateBasedAssayProvider;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ContainerFilter;
@@ -22,20 +25,12 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.SampleTypeService;
-import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.ExpSchema;
-import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.PropertyForeignKey;
-import org.labkey.api.assay.AbstractAssayProvider;
-import org.labkey.api.assay.AssayProtocolSchema;
-import org.labkey.api.assay.AssayResultTable;
 import org.labkey.api.study.assay.SpecimenPropertyColumnDecorator;
 import org.labkey.elisa.ElisaDataHandler;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * User: klum
@@ -47,30 +42,20 @@ public class ElisaResultsTable extends AssayResultTable
     {
         super(schema, cf, includeCopiedToStudyColumns);
 
-        List<FieldKey> visibleColumns = new ArrayList<>();
-
-        // add material lookup columns to the view first, so they appear at the left:
         String sampleDomainURI = AbstractAssayProvider.getDomainURIForPrefix(schema.getProtocol(), AbstractPlateBasedAssayProvider.ASSAY_DOMAIN_SAMPLE_WELLGROUP);
         final ExpSampleType sampleType = SampleTypeService.get().getSampleType(sampleDomainURI);
-        if (sampleType != null)
-        {
-            for (DomainProperty pd : sampleType.getDomain().getProperties())
-            {
-                visibleColumns.add(FieldKey.fromParts(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY,
-                        ExpMaterialTable.Column.Property.toString(), pd.getName()));
-            }
-        }
 
         // add a lookup to the material table
         BaseColumnInfo specimenColumn = (BaseColumnInfo)_columnMap.get(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY);
-        specimenColumn.setFk(new LookupForeignKey("LSID")
+        specimenColumn.setLabel("Specimen");
+        specimenColumn.setHidden(false);
+
+        specimenColumn.setFk(new LookupForeignKey(getContainerFilter(), "LSID", null)
         {
             @Override
             public TableInfo getLookupTableInfo()
             {
-                ExpMaterialTable materials = ExperimentService.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), schema, cf);
-                // Make sure we are filtering to the same set of containers
-                materials.setContainerFilter(getContainerFilter());
+                ExpMaterialTable materials = ExperimentService.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), schema, getLookupContainerFilter());
                 if (sampleType != null)
                 {
                     materials.setSampleType(sampleType, true);
@@ -78,15 +63,13 @@ public class ElisaResultsTable extends AssayResultTable
                 var propertyCol = materials.addColumn(ExpMaterialTable.Column.Property);
                 if (propertyCol.getFk() instanceof PropertyForeignKey)
                 {
-                    ((PropertyForeignKey)propertyCol.getFk()).addDecorator(new SpecimenPropertyColumnDecorator(_provider, _protocol, schema));
+                    ((PropertyForeignKey) propertyCol.getFk()).addDecorator(new SpecimenPropertyColumnDecorator(_provider, _protocol, schema));
                 }
                 propertyCol.setHidden(false);
                 materials.addColumn(ExpMaterialTable.Column.LSID).setHidden(true);
+
                 return materials;
             }
         });
-
-        visibleColumns.addAll(getDefaultVisibleColumns());
-        setDefaultVisibleColumns(visibleColumns);
     }
 }

--- a/elisa/src/org/labkey/elisa/query/ElisaResultsTable.java
+++ b/elisa/src/org/labkey/elisa/query/ElisaResultsTable.java
@@ -27,10 +27,14 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.ExpSchema;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.PropertyForeignKey;
 import org.labkey.api.study.assay.SpecimenPropertyColumnDecorator;
+import org.labkey.elisa.ElisaAssayProvider;
 import org.labkey.elisa.ElisaDataHandler;
+
+import java.util.List;
 
 /**
  * User: klum
@@ -71,5 +75,20 @@ public class ElisaResultsTable extends AssayResultTable
                 return materials;
             }
         });
+
+        List<FieldKey> defaultColumns = List.of(
+                FieldKey.fromParts(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY, "Property", ElisaAssayProvider.SPECIMENID_PROPERTY_NAME),
+                FieldKey.fromParts(ElisaAssayProvider.WELL_LOCATION_PROPERTY),
+                FieldKey.fromParts(ElisaAssayProvider.WELLGROUP_PROPERTY),
+                FieldKey.fromParts(ElisaAssayProvider.STANDARD_CONCENTRATION_PROPERTY),
+                FieldKey.fromParts(ElisaAssayProvider.ABSORBANCE_PROPERTY),
+                FieldKey.fromParts(ElisaAssayProvider.MEAN_ABSORPTION_PROPERTY),
+                FieldKey.fromParts(ElisaAssayProvider.CV_ABSORPTION_PROPERTY),
+                FieldKey.fromParts(ElisaAssayProvider.CONCENTRATION_PROPERTY),
+                FieldKey.fromParts(ElisaAssayProvider.MEAN_CONCENTRATION_PROPERTY),
+                FieldKey.fromParts(ElisaAssayProvider.CV_CONCENTRATION_PROPERTY),
+                FieldKey.fromParts(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY, "Property", ElisaAssayProvider.AUC_PROPERTY)
+        );
+        setDefaultVisibleColumns(defaultColumns);
     }
 }

--- a/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabAssayProvider.java
+++ b/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabAssayProvider.java
@@ -115,7 +115,10 @@ public class SinglePlateDilutionNabAssayProvider extends HighThroughputNabAssayP
     @Override
     protected PlateSamplePropertyHelper createSampleFilePropertyHelper(Container c, ExpProtocol protocol, List<? extends DomainProperty> sampleProperties, PlateTemplate template, SampleMetadataInputFormat inputFormat)
     {
-        return new SinglePlateDilutionSamplePropertyHelper(c, protocol, sampleProperties, template, inputFormat);
+        if (inputFormat == SampleMetadataInputFormat.MANUAL)
+            return new PlateSamplePropertyHelper(sampleProperties, template);
+        else
+            return new SinglePlateDilutionSamplePropertyHelper(c, protocol, sampleProperties, template, inputFormat);
     }
 
     @Override

--- a/nab/src/org/labkey/nab/query/NabProviderSchema.java
+++ b/nab/src/org/labkey/nab/query/NabProviderSchema.java
@@ -18,6 +18,9 @@ package org.labkey.nab.query;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssaySchema;
+import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.dilution.SampleInfoMethod;
 import org.labkey.api.assay.dilution.query.DilutionProviderSchema;
 import org.labkey.api.data.Container;
@@ -30,9 +33,6 @@ import org.labkey.api.module.Module;
 import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.QuerySchema;
 import org.labkey.api.security.User;
-import org.labkey.api.assay.AssayProvider;
-import org.labkey.api.assay.AssaySchema;
-import org.labkey.api.assay.AssayService;
 import org.labkey.nab.NabAssayProvider;
 
 import java.util.Set;
@@ -45,6 +45,26 @@ import java.util.Set;
 public class NabProviderSchema extends DilutionProviderSchema
 {
     public static final String SCHEMA_NAME = "Nab";
+
+    enum NabCurveFits
+    {
+        FOUR_PARAMETER(StatsService.CurveFitType.FOUR_PARAMETER.getLabel()),
+        FIVE_PARAMETER(StatsService.CurveFitType.FIVE_PARAMETER.getLabel()),
+        POLYNOMIAL(StatsService.CurveFitType.POLYNOMIAL.getLabel()),
+        NONE(StatsService.CurveFitType.NONE.getLabel());
+
+        private String _label;
+
+        NabCurveFits(String label)
+        {
+            _label = label;
+        }
+
+        public String getLabel()
+        {
+            return _label;
+        }
+    }
 
     static public void register(Module module)
     {
@@ -103,7 +123,7 @@ public class NabProviderSchema extends DilutionProviderSchema
         }
         if (CURVE_FIT_METHOD_TABLE_NAME.equalsIgnoreCase(name))
         {
-            EnumTableInfo<StatsService.CurveFitType> result = new EnumTableInfo<>(StatsService.CurveFitType.class, this, StatsService.CurveFitType::getLabel, false, "List of possible curve fitting methods for the NAb assay.");
+            EnumTableInfo<NabCurveFits> result = new EnumTableInfo<>(NabCurveFits.class, this, NabCurveFits::getLabel, false, "List of possible curve fitting methods for the NAb assay.");
             result.setPublicSchemaName(SCHEMA_NAME);
             result.setPublicName(CURVE_FIT_METHOD_TABLE_NAME);
             return result;


### PR DESCRIPTION
#### Rationale
The ELISA assay is being enhanced to support a new high throughput data format which will introduce some new concepts:
- multiple plates per run (similar to the NAb high throughput variants)
- multiple values per well, through the use of analytes that could result in up to 4 values per well that need to be tracked separately
- multiple standard curves per plate, similar to the sample wells there could be multiple analytes for each plate well

Additionally, some new statistics will be added as detailed in this [spec](https://docs.google.com/document/d/1euUCUWOD-q5KESZsfiWLrTM4n6yaRuyHF2uCT2EXxWc/edit#). Run, sample, and result domains were expanded to include new data to be captured as well as to hold some of the new calculations. The ELISA data handler was refactored to handle the legacy and new behavior, this ensures that previous assays and new assays that don't use the new format will continue to work as before.

An experimental flag was put in place to hide the new features until a follow on story to update the run details report is complete.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1598

#### Changes
- Add assay provider option to collect both sample and results data from a combined file (assay design selection)
- Add run level option to specify the curve fit : 4 & 5 param, linear
- Refactor the data handler so it can process both legacy data input as well as the new high throughput format
- Add a 16 x 24 plate template which matches the NVITAL plate design
- Since linear curve fit is now a standard StatsService option, we need to constrain the NAb run option to not offer the new curve fit (NAbProviderSchema)
- Additionally for the ELISA provider schema, don't offer the polynomial fit option
- Push new features under an experimental flag
