### PR TITLE
Switch to DisplayColumn.getFormattedHtml() and use HtmlString

### DIFF
--- a/elispotassay/src/org/labkey/elispot/query/ElispotRunDataTable.java
+++ b/elispotassay/src/org/labkey/elispot/query/ElispotRunDataTable.java
@@ -37,6 +37,7 @@ import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssaySchema;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.plate.PlateReader;
+import org.labkey.api.util.HtmlString;
 import org.labkey.elispot.ElispotAssayProvider;
 import org.labkey.elispot.ElispotDataHandler;
 import org.labkey.elispot.ElispotManager;
@@ -206,13 +207,13 @@ public class ElispotRunDataTable extends PlateBasedAssayRunDataTable
 
         @NotNull
         @Override
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
-            String value = super.getFormattedValue(ctx);
+            HtmlString value = super.getFormattedHtml(ctx);
             PlateReader reader = getReader(ctx);
 
             if (reader != null)
-                return reader.getWellDisplayValue(value);
+                return HtmlString.of(reader.getWellDisplayValue(value));
             else
                 return value;
         }

--- a/flow/src/org/labkey/flow/webparts/AnalysisScriptTypeColumn.java
+++ b/flow/src/org/labkey/flow/webparts/AnalysisScriptTypeColumn.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.RenderContext;
+import org.labkey.api.util.HtmlString;
 import org.labkey.flow.data.FlowScript;
 import org.labkey.flow.data.FlowProtocolStep;
 
@@ -43,18 +44,18 @@ public class AnalysisScriptTypeColumn extends DataColumn
     }
 
     @Override @NotNull
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
     {
         Object value = getBoundColumn().getValue(ctx);
         if (!(value instanceof Number))
         {
-            return "#ERROR#";
+            return HtmlString.of("#ERROR#");
         }
         int id = ((Number) value).intValue();
         FlowScript script = FlowScript.fromScriptId(id);
         if (script == null)
         {
-            return "#NOT FOUND#";
+            return HtmlString.of("#NOT FOUND#");
         }
         String ret = "";
         String and = "";
@@ -70,6 +71,6 @@ public class AnalysisScriptTypeColumn extends DataColumn
             ret += "Analysis";
             and = " and ";
         }
-        return ret;
+        return HtmlString.of(ret);
     }
 }

--- a/flow/src/org/labkey/flow/webparts/AnalysisScriptsWebPart.java
+++ b/flow/src/org/labkey/flow/webparts/AnalysisScriptsWebPart.java
@@ -28,6 +28,7 @@ import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.AliasedColumn;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
@@ -117,9 +118,9 @@ public class AnalysisScriptsWebPart extends FlowQueryView
         }
 
         @Override @NotNull
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
-            return _actionName;
+            return HtmlString.of(_actionName);
         }
 
         @NotNull

--- a/luminex/src/org/labkey/luminex/query/GuideSetTable.java
+++ b/luminex/src/org/labkey/luminex/query/GuideSetTable.java
@@ -50,6 +50,7 @@ import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.assay.AssaySchema;
 import org.labkey.api.assay.AssayService;
+import org.labkey.api.util.HtmlString;
 import org.labkey.luminex.LuminexDataHandler;
 import org.labkey.luminex.model.AnalyteSinglePointControl;
 import org.labkey.luminex.model.AnalyteTitration;
@@ -118,9 +119,9 @@ public class GuideSetTable extends AbstractCurveFitPivotTable
             {
                 @NotNull
                 @Override
-                public String getFormattedValue(RenderContext ctx)
+                public HtmlString getFormattedHtml(RenderContext ctx)
                 {
-                    return "details";
+                    return HtmlString.of("details");
                 }
 
                 @Override

--- a/ms2/src/org/labkey/ms2/GroupNumberDisplayColumn.java
+++ b/ms2/src/org/labkey/ms2/GroupNumberDisplayColumn.java
@@ -18,6 +18,8 @@ package org.labkey.ms2;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.*;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
@@ -59,7 +61,7 @@ public class GroupNumberDisplayColumn extends DataColumn
     @Override
     public Object getDisplayValue(RenderContext ctx)
     {
-        return getFormattedValue(ctx);
+        return getFormattedHtml(ctx);
     }
 
     @Override
@@ -69,9 +71,9 @@ public class GroupNumberDisplayColumn extends DataColumn
     }
 
     @Override @NotNull
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
     {
-        Map row = ctx.getRow();
+        Map<String, Object> row = ctx.getRow();
         long collectionId;
         long groupNumber;
         if (_fromQuery)
@@ -88,24 +90,24 @@ public class GroupNumberDisplayColumn extends DataColumn
                     sb.append("Could not resolve RowId column, please be sure that it is included in any custom queries. ");
                 }
 
-                return sb.toString();
+                return HtmlString.of(sb);
             }
             else
             {
                 if (row.get(_collectionIdColumn.getAlias()) == null)
                 {
-                    return "";
+                    return HtmlString.EMPTY_STRING;
                 }
                 Number collectionIdObject = (Number) row.get(_collectionIdColumn.getAlias());
                 if (collectionIdObject == null)
                 {
-                    return "";
+                    return HtmlString.EMPTY_STRING;
                 }
                 collectionId = collectionIdObject.longValue();
                 Number groupNumberObject = (Number) row.get(getColumnInfo().getAlias());
                 if (groupNumberObject == null)
                 {
-                    return "";
+                    return HtmlString.EMPTY_STRING;
                 }
                 groupNumber = groupNumberObject.longValue();
             }
@@ -114,20 +116,20 @@ public class GroupNumberDisplayColumn extends DataColumn
         {
             if (row.get(_collectionId) == null)
             {
-                return "";
+                return HtmlString.EMPTY_STRING;
             }
             collectionId = ((Number)row.get(_collectionId)).longValue();
             groupNumber = ((Number)row.get(_groupNumber)).longValue();
         }
 
-        StringBuilder sb = new StringBuilder();
+        HtmlStringBuilder sb = HtmlStringBuilder.of();
         sb.append(groupNumber);
         if (collectionId != 0)
         {
             sb.append("-");
             sb.append(collectionId);
         }
-        return sb.toString();
+        return sb.getHtmlString();
     }
 
     @Override

--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -3699,7 +3699,7 @@ public class MS2Controller extends SpringActionController
                     if (null != ctx.get("Container") && !((Boolean)ctx.get("deleted")).booleanValue())
                         super.renderGridCellContents(ctx, out);
                     else
-                        out.write(getFormattedValue(ctx));
+                        getFormattedHtml(ctx).appendTo(out);
                 }
             };
             ActionURL showRunURL = MS2Controller.getShowRunURL(getUser(), ContainerManager.getRoot());

--- a/ms2/src/org/labkey/ms2/protein/query/ProteinUserSchema.java
+++ b/ms2/src/org/labkey/ms2/protein/query/ProteinUserSchema.java
@@ -34,6 +34,7 @@ import org.labkey.api.query.QuerySchema;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.ms2.MS2Module;
 import org.labkey.ms2.protein.ProteinManager;
@@ -358,9 +359,10 @@ public class ProteinUserSchema extends UserSchema
 
                     @NotNull
                     @Override
-                    public String getFormattedValue(RenderContext ctx)
+                    public HtmlString getFormattedHtml(RenderContext ctx)
                     {
-                        return PageFlowUtil.filter(getDisplayValue(ctx));
+                        Object value = getDisplayValue(ctx);
+                        return value == null ? HtmlString.EMPTY_STRING : HtmlString.of(value.toString());
                     }
 
                     @Override


### PR DESCRIPTION
#### Rationale
Switch to using HtmlString when rendering a grid or details value to ensure proper encoding. Fix up many problematic subclasses.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1602

#### Changes
* Remove deprecated getFormattedValue(), consolidate on getFormattedHtml()
* Use HtmlString to signal this is specifically for HTML