### PR TITLE
ELISA assay run details - fix issue to restore display of run details information panel above plot

### DIFF
--- a/elisa/webapp/elisa/runDetailsPanel.js
+++ b/elisa/webapp/elisa/runDetailsPanel.js
@@ -22,15 +22,29 @@ Ext4.define('LABKEY.elisa.RunDetailsPanel', {
     },
 
     initComponent : function() {
-
-        this.items = [
-            this.createRunDetailView()
-        ];
+        this.items = [];
 
         this.callParent([arguments]);
+
+        this.queryRunDetails();
     },
 
-    createRunDetailView : function() {
+    queryRunDetails : function() {
+        LABKEY.Query.selectRows({
+            schemaName: this.schemaName,
+            queryName: this.runTableName,
+            columns: 'Name,Created,RSquared,CurveFitParams',
+            filterArray: [LABKEY.Filter.create('RowId', this.runId)],
+            scope: this,
+            success: function(response) {
+                if (response.rows.length === 1) {
+                    this.createRunDetailView(response.rows[0]);
+                }
+            }
+        });
+    },
+
+    createRunDetailView : function(data) {
 
         Ext4.define('Elisa.model.RunDetail', {
             extend : 'Ext.data.Model',
@@ -42,119 +56,41 @@ Ext4.define('LABKEY.elisa.RunDetailsPanel', {
             ]
         });
 
-        var config = {
-            model   : 'Elisa.model.RunDetail',
-            autoLoad: true,
-            proxy   : {
-                type   : 'ajax',
-                url    : LABKEY.ActionURL.buildURL('query', 'selectRows.api'),
-                extraParams : {
-                    schemaName : this.schemaName,
-                    queryName  : this.runTableName,
-                    'query.columns' : 'Name,Created,RSquared,CurveFitParams'
-                },
-                reader : {
-                    type : 'json',
-                    root : 'rows'
-                }
-            },
-            filters : [{property:'RowId', value : this.runId}]
-        };
-
-        this.elisaDetailStore = Ext4.create('Ext.data.Store', config);
+        this.elisaDetailStore = Ext4.create('Ext.data.Store', {
+            model: 'Elisa.model.RunDetail',
+            data: data
+        });
 
         var tpl = new Ext4.XTemplate(
-            '<div>',
+                '<div>',
                 '<table>',
-                    '<tpl for=".">',
-                    '<tr><td style="padding-right: 10px; font-weight: bold;">Name</td><td>{Name}</td></tr>',
-                    '<tr><td style="padding-right: 10px; font-weight: bold;">Curve Fit Type</td><td>Linear</td></tr>',
-                    '<tr><td style="padding-right: 10px; font-weight: bold;">Curve Fit Parameters</td><td>{[this.formatFitParams(values)]}</td></tr>',
-                    '<tr><td style="padding-right: 10px; font-weight: bold;">Coefficient of Determination</td><td>{[Ext.util.Format.number(values.RSquared, "0.00000")]}</td></tr>',
-                    '<tr><td style="padding-right: 10px; font-weight: bold;">Created</td><td>{Created}</td></tr>',
+                '<tpl for=".">',
+                '<tr><td style="padding-right: 10px; font-weight: bold;">Name</td><td>{Name}</td></tr>',
+                '<tr><td style="padding-right: 10px; font-weight: bold;">Curve Fit Type</td><td>Linear</td></tr>',
+                '<tr><td style="padding-right: 10px; font-weight: bold;">Curve Fit Parameters</td><td>{[this.formatFitParams(values)]}</td></tr>',
+                '<tr><td style="padding-right: 10px; font-weight: bold;">Coefficient of Determination</td><td>{[Ext.util.Format.number(values.RSquared, "0.00000")]}</td></tr>',
+                '<tr><td style="padding-right: 10px; font-weight: bold;">Created</td><td>{Created}</td></tr>',
                 '</tpl></table>',
-            '</div>',
-            {
-                formatFitParams : function(data) {
-                    if (data.CurveFitParams)
-                    {
-                        var parts = data.CurveFitParams.split('&');
-                        return 'slope : ' + Ext.util.Format.number(parts[0], "0.00") + ' intercept : ' + Ext.util.Format.number(parts[1], "0.00");
+                '</div>',
+                {
+                    formatFitParams : function(data) {
+                        if (data.CurveFitParams)
+                        {
+                            var parts = data.CurveFitParams.split('&');
+                            return 'slope : ' + Ext4.util.Format.number(parts[0], "0.00") + ', intercept : ' + Ext4.util.Format.number(parts[1], "0.00");
+                        }
+                        else
+                            return 'error';
                     }
-                    else
-                        return 'error';
                 }
-            }
         );
 
-        return Ext4.create('Ext.view.View', {
+        this.add(Ext4.create('Ext.view.View', {
             store   : this.elisaDetailStore,
-            loadMask: true,
             tpl     : tpl,
             ui      : 'custom',
             flex    : 1,
             scope   : this
-        });
-    },
-
-    createRunDataView : function() {
-
-        Ext4.define('Elisa.model.RunData', {
-            extend : 'Ext.data.Model',
-            fields : [
-                {name : 'WellgroupLocation'},
-                {name : 'WellLocation'},
-                {name : 'Absorption'},
-                {name : 'Concentration'},
-                {name : 'RSquared', mapping : 'Run/RSquared'}
-            ]
-        });
-
-        var urlParams = LABKEY.ActionURL.getParameters(this.baseUrl);
-        var filterUrl = urlParams['filterUrl'];
-
-        // lastly check if there is a filter on the url
-        var filters = LABKEY.Filter.getFiltersFromUrl(filterUrl, this.dataRegionName);
-
-        var config = {
-            model   : 'Elisa.model.RunData',
-            autoLoad: true,
-            pageSize: 92,
-            proxy   : {
-                type   : 'ajax',
-                url    : LABKEY.ActionURL.buildURL('query', 'selectRows.api'),
-                extraParams : {
-                    schemaName : this.schemaName,
-                    queryName  : this.queryName,
-                    filters    : filters
-                },
-                reader : {
-                    type : 'json',
-                    root : 'rows'
-                }
-            }
-        };
-
-        this.elisaDetailStore = Ext4.create('Ext.data.Store', config);
-
-        var tpl = new Ext4.XTemplate(
-            '<div>',
-                '<table width="100%">',
-                    '<tr><td>Well Location</td><td>Well Group</td><td>Absorption</td><td>Concentration</td></tr>',
-                    '<tpl for=".">',
-                    '<tr class="{[xindex % 2 === 0 ? "labkey-alternate-row" : "labkey-row"]}"><td>{WellLocation}</td><td>{WellgroupLocation}</td><td>{Absorption}</td><td>{[Ext.util.Format.number(values.Concentration, "0.000")]}</td></tr>',
-                '</tpl></table>',
-            '</div>'
-        );
-
-        return Ext4.create('Ext.view.View', {
-            store   : this.elisaDetailStore,
-            loadMask: true,
-            tpl     : tpl,
-            ui      : 'custom',
-            flex    : 1,
-            padding : '20, 8',
-            scope   : this
-        });
+        }));
     }
 });

--- a/elisa/webapp/elisa/runDetailsPanel.js
+++ b/elisa/webapp/elisa/runDetailsPanel.js
@@ -63,14 +63,14 @@ Ext4.define('LABKEY.elisa.RunDetailsPanel', {
 
         var tpl = new Ext4.XTemplate(
                 '<div>',
-                '<table>',
-                '<tpl for=".">',
-                '<tr><td style="padding-right: 10px; font-weight: bold;">Name</td><td>{Name}</td></tr>',
-                '<tr><td style="padding-right: 10px; font-weight: bold;">Curve Fit Type</td><td>Linear</td></tr>',
-                '<tr><td style="padding-right: 10px; font-weight: bold;">Curve Fit Parameters</td><td>{[this.formatFitParams(values)]}</td></tr>',
-                '<tr><td style="padding-right: 10px; font-weight: bold;">Coefficient of Determination</td><td>{[Ext.util.Format.number(values.RSquared, "0.00000")]}</td></tr>',
-                '<tr><td style="padding-right: 10px; font-weight: bold;">Created</td><td>{Created}</td></tr>',
-                '</tpl></table>',
+                    '<table>',
+                        '<tpl for=".">',
+                        '<tr><td style="padding-right: 10px; font-weight: bold;">Name</td><td>{Name}</td></tr>',
+                        '<tr><td style="padding-right: 10px; font-weight: bold;">Curve Fit Type</td><td>Linear</td></tr>',
+                        '<tr><td style="padding-right: 10px; font-weight: bold;">Curve Fit Parameters</td><td>{[this.formatFitParams(values)]}</td></tr>',
+                        '<tr><td style="padding-right: 10px; font-weight: bold;">Coefficient of Determination</td><td>{[Ext.util.Format.number(values.RSquared, "0.00000")]}</td></tr>',
+                        '<tr><td style="padding-right: 10px; font-weight: bold;">Created</td><td>{Created}</td></tr>',
+                    '</tpl></table>',
                 '</div>',
                 {
                     formatFitParams : function(data) {


### PR DESCRIPTION
#### Rationale
Issue [41521](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41521): ELISA: run details page no longer showing top panel for run param information

As we are about to update the ELISA assay run details page, I thought it would be good to fix the current issue that was preventing the run details information panel from showing on the current run details page. This way we know where we are actually starting from before making changes.

#### Changes
* simplify the data loading logic for the Ext4 store
* fix JS error with Ext.util.Format.number instead of Ext4.util.Format.number
