### PR TITLE
Item 7882:  allow use of optional transaction auditEvent in importData operations

### DIFF
--- a/luminex/src/org/labkey/luminex/LuminexController.java
+++ b/luminex/src/org/labkey/luminex/LuminexController.java
@@ -26,6 +26,7 @@ import org.labkey.api.action.FormViewAction;
 import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.audit.TransactionAuditProvider;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
@@ -499,7 +500,7 @@ public class LuminexController extends SpringActionController
         }
 
         @Override
-        protected int importData(DataLoader dl, FileStream file, String originalName, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType) throws IOException
+        protected int importData(DataLoader dl, FileStream file, String originalName, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, @Nullable TransactionAuditProvider.TransactionAuditEvent auditEvent) throws IOException
         {
             // NOTE: consider being smarter here and intersecting the list of desired columns with dl.getColumns()
             // NOTE: consider making case-insentive


### PR DESCRIPTION
#### Rationale
Within LKSM, we want to enable users to work with the samples and sources that have just been imported, either via a file import or import within a grid.  Currently, this is possible when importing from a grid because the records created from using the `insertRows` operation are returned in the api response.  When importing from a file, only a count of the rows is returned (which is reasonable).  Here we add in an ability to find the data items that were inserted or updated during an upload operation by way of a new audit event type, which is created when the transaction begins and contains a unique transactionId that can then be stored in other audit logs as a reference.  

* [Issue 39594](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39594)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1621

#### Changes
* Update interface for importData
