### PR TITLE
Update @labkey/build version to support linking via LABKEY_UI_COMPONENTS_HOME env variable

### DIFF
--- a/elisa/package-lock.json
+++ b/elisa/package-lock.json
@@ -2256,9 +2256,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0-fb-webpackEnvVarForLink.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
-      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
+      "version": "0.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.2.0.tgz",
+      "integrity": "sha1-OcC1Wc801FEAPi2uo+2I+yt5ek4=",
       "dev": true
     },
     "@labkey/components": {

--- a/elisa/package-lock.json
+++ b/elisa/package-lock.json
@@ -2256,9 +2256,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0.tgz",
-      "integrity": "sha1-K8JkWOgbyFxQhWETHHn5AvhiDnU=",
+      "version": "0.1.0-fb-webpackEnvVarForLink.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
+      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
       "dev": true
     },
     "@labkey/components": {

--- a/elisa/package.json
+++ b/elisa/package.json
@@ -53,7 +53,7 @@
     "@hot-loader/react-dom": "16.13.0",
     "@types/enzyme": "3.10.5",
     "@types/enzyme-adapter-react-16": "1.0.6",
-    "@labkey/build": "0.1.0",
+    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
     "@labkey/eslint-config-base": "0.0.8",
     "@labkey/eslint-config-react": "0.0.8",
     "@types/jest": "25.2.3",

--- a/elisa/package.json
+++ b/elisa/package.json
@@ -53,7 +53,7 @@
     "@hot-loader/react-dom": "16.13.0",
     "@types/enzyme": "3.10.5",
     "@types/enzyme-adapter-react-16": "1.0.6",
-    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
+    "@labkey/build": "0.2.0",
     "@labkey/eslint-config-base": "0.0.8",
     "@labkey/eslint-config-react": "0.0.8",
     "@types/jest": "25.2.3",


### PR DESCRIPTION
#### Rationale
The initial v0.1.0 of @labkey/build was fixed on using a relative path to get to the labkey-ui-components repository when using "npm run start-link". This version update changes that to using a LABKEY_UI_COMPONENTS_HOME environment variable so that each dev can set it based on their local setup.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/379
* https://github.com/LabKey/platform/pull/1664
* https://github.com/LabKey/inventory/pull/117
* https://github.com/LabKey/provenance/pull/42
* https://github.com/LabKey/moduleEditor/pull/17
* https://github.com/LabKey/commonAssays/pull/252
* https://github.com/LabKey/tutorialModules/pull/30

#### Changes
* Update @labkey/build package version
