### PR TITLE
Update webpack build to put views generated by webpack in their own directory

### DIFF
--- a/elisa/.gitignore
+++ b/elisa/.gitignore
@@ -26,3 +26,5 @@ hs_err_pid*
 resources/web/elisa/gen
 
 node_modules
+
+.gradle

--- a/elisa/package-lock.json
+++ b/elisa/package-lock.json
@@ -2256,9 +2256,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.2.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.2.0.tgz",
-      "integrity": "sha1-OcC1Wc801FEAPi2uo+2I+yt5ek4=",
+      "version": "0.3.0-generatedViews.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.3.0-generatedViews.0.tgz",
+      "integrity": "sha1-KM6iEVV+bfvTCsUbg5m95L0jydA=",
       "dev": true
     },
     "@labkey/components": {

--- a/elisa/package-lock.json
+++ b/elisa/package-lock.json
@@ -2256,9 +2256,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.3.0-generatedViews.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.3.0-generatedViews.0.tgz",
-      "integrity": "sha1-KM6iEVV+bfvTCsUbg5m95L0jydA=",
+      "version": "0.3.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.3.0.tgz",
+      "integrity": "sha1-zzlP1GkHjEqm5LaChvIjTLdRkes=",
       "dev": true
     },
     "@labkey/components": {

--- a/elisa/package.json
+++ b/elisa/package.json
@@ -53,7 +53,7 @@
     "@hot-loader/react-dom": "16.13.0",
     "@types/enzyme": "3.10.5",
     "@types/enzyme-adapter-react-16": "1.0.6",
-    "@labkey/build": "0.2.0",
+    "@labkey/build": "0.3.0-generatedViews.0",
     "@labkey/eslint-config-base": "0.0.8",
     "@labkey/eslint-config-react": "0.0.8",
     "@types/jest": "25.2.3",

--- a/elisa/package.json
+++ b/elisa/package.json
@@ -53,7 +53,7 @@
     "@hot-loader/react-dom": "16.13.0",
     "@types/enzyme": "3.10.5",
     "@types/enzyme-adapter-react-16": "1.0.6",
-    "@labkey/build": "0.3.0-generatedViews.0",
+    "@labkey/build": "0.3.0",
     "@labkey/eslint-config-base": "0.0.8",
     "@labkey/eslint-config-react": "0.0.8",
     "@types/jest": "25.2.3",


### PR DESCRIPTION
#### Rationale
Gradle build caching requires that the directories designated as output directories be fully under the control of the build, so any task that outputs files to a directory that may already be occupied by checked-in files makes a task not able to be cached.  With the next version of gradlePlugin, we'll have tasks enabled for using the build cache.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/98
* https://github.com/LabKey/platform/pull/1662
* https://github.com/LabKey/labkey-ui-components/pull/381

#### Changes
* Update .gitignore to ignore .gradle directory and use next @labkey/build version