### PR TITLE
Issue 41364: Having a date field in an assay run result creates bogus material

### DIFF
--- a/luminex/src/org/labkey/luminex/LuminexDataHandler.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataHandler.java
@@ -1908,10 +1908,10 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
 
         if (match != null)
         {
-            ExpMaterial material = match.getMaterial();
+            ExpMaterial material = match.getMaterial(false);
             if (material != null)
             {
-                materialInputs.put(match.getMaterial(), null);
+                materialInputs.put(material, null);
             }
         }
     }

--- a/luminex/src/org/labkey/luminex/LuminexDataHandler.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataHandler.java
@@ -1908,7 +1908,11 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
 
         if (match != null)
         {
-            materialInputs.put(match.getMaterial(), null);
+            ExpMaterial material = match.getMaterial();
+            if (material != null)
+            {
+                materialInputs.put(match.getMaterial(), null);
+            }
         }
     }
 

--- a/luminex/src/org/labkey/luminex/LuminexDataHandler.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataHandler.java
@@ -1908,11 +1908,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
 
         if (match != null)
         {
-            ExpMaterial material = match.getMaterial(false);
-            if (material != null)
-            {
-                materialInputs.put(material, null);
-            }
+            materialInputs.put(match.getMaterial(true), null);
         }
     }
 


### PR DESCRIPTION
#### Rationale
The original theory behind creating this sample records was to let you find assay data that was probably derived from the same sample, even if you don't have a sample ID. I doubt it's ever helped anyone, and ends up creating a bunch of bogus records.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1687

#### Changes
* Match against an existing material in the exceedingly unlikely case where it already exists, but otherwise don't bother creating it, and make sure callers handle nulls.
