### PR TITLE
Issue 40482: Prefer using apiKey replacement parameter

### DIFF
--- a/flow/src/org/labkey/flow/data/FlowAssayProvider.java
+++ b/flow/src/org/labkey/flow/data/FlowAssayProvider.java
@@ -38,6 +38,7 @@ import org.labkey.api.pipeline.PipelineProvider;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.qc.DataExchangeHandler;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.study.TimepointType;
 import org.labkey.api.assay.actions.AssayRunUploadForm;
@@ -468,7 +469,7 @@ public class FlowAssayProvider extends AbstractAssayProvider
     }
 
     @Override
-    public void setValidationAndAnalysisScripts(ExpProtocol protocol, @NotNull List<File> scripts)
+    public ValidationException setValidationAndAnalysisScripts(ExpProtocol protocol, @NotNull List<File> scripts)
     {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
#### Rationale
AssayProvider API change to warn when using a deprecated parameter replacement

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1699

#### Changes
* warn when saving an assay design with a transform script that uses a deprecated replacement
