### PR TITLE
Issue 41807: Luminex query performance issues

### DIFF
--- a/luminex/src/org/labkey/luminex/query/AbstractLuminexTable.java
+++ b/luminex/src/org/labkey/luminex/query/AbstractLuminexTable.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.luminex.query;
 
-import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
@@ -51,11 +50,11 @@ public abstract class AbstractLuminexTable extends FilteredTable<LuminexProtocol
         if (_needsFilter)
         {
             clearConditions(CONTAINER_FAKE_COLUMN_NAME);
-            addCondition(createContainerFilterSQL(filter, _userSchema.getContainer()), CONTAINER_FAKE_COLUMN_NAME);
+            addCondition(createContainerFilterSQL(filter), CONTAINER_FAKE_COLUMN_NAME);
         }
     }
 
-    protected abstract SQLFragment createContainerFilterSQL(ContainerFilter filter, Container container);
+    protected abstract SQLFragment createContainerFilterSQL(ContainerFilter filter);
 
     // param: titrationSinglePointControlSwitch - TitrationId for AnalyteTitration, SinglePointControlId for AnalyteSinglePointControl
     public static SQLFragment createQCFlagEnabledSQLFragment(SqlDialect sqlDialect, String flagType, String curveType, String titrationSinglePointControlSwitch)

--- a/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
@@ -185,15 +185,13 @@ public class AnalyteSinglePointControlTable extends AbstractLuminexTable
     }
 
     @Override
-    protected SQLFragment createContainerFilterSQL(ContainerFilter filter, Container container)
+    protected SQLFragment createContainerFilterSQL(ContainerFilter filter)
     {
         SQLFragment sql = new SQLFragment("SinglePointControlId IN (SELECT RowId FROM ");
         sql.append(LuminexProtocolSchema.getTableInfoSinglePointControl(), "spc");
-        sql.append(" WHERE RunId IN (SELECT RowId FROM ");
-        sql.append(ExperimentService.get().getTinfoExperimentRun(), "r");
         sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container"), container));
-        sql.append("))");
+        sql.append(getUserSchema().createRunIdContainerFilterSQL(filter));
+        sql.append(")");
         return sql;
     }
 

--- a/luminex/src/org/labkey/luminex/query/AnalyteTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteTable.java
@@ -26,7 +26,6 @@ import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.PropertyDescriptor;
-import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.query.ExprColumn;
@@ -140,14 +139,9 @@ public class AnalyteTable extends AbstractLuminexTable
     }
 
     @Override
-    protected SQLFragment createContainerFilterSQL(ContainerFilter filter, Container container)
+    protected SQLFragment createContainerFilterSQL(ContainerFilter filter)
     {
-        SQLFragment sql = new SQLFragment("DataId IN (SELECT RowId FROM ");
-        sql.append(ExperimentService.get().getTinfoData(), "d");
-        sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container"), container));
-        sql.append(")");
-        return sql;
+        return getUserSchema().createDataIdContainerFilterSQL("DataId", filter);
     }
 
     @Override

--- a/luminex/src/org/labkey/luminex/query/GuideSetTable.java
+++ b/luminex/src/org/labkey/luminex/query/GuideSetTable.java
@@ -329,7 +329,7 @@ public class GuideSetTable extends AbstractCurveFitPivotTable
     }
 
     @Override
-    protected SQLFragment createContainerFilterSQL(ContainerFilter filter, Container container)
+    protected SQLFragment createContainerFilterSQL(ContainerFilter filter)
     {
         // Guide sets are scoped to the protocol, not to folders, so filter on ProtocolId instead of Container
         SQLFragment sql = new SQLFragment("ProtocolId = ?");

--- a/luminex/src/org/labkey/luminex/query/LuminexProtocolSchema.java
+++ b/luminex/src/org/labkey/luminex/query/LuminexProtocolSchema.java
@@ -165,81 +165,57 @@ public class LuminexProtocolSchema extends AssayProtocolSchema
 
             if (ANALYTE_TITRATION_TABLE_NAME.equalsIgnoreCase(tableType))
             {
-                AnalyteTitrationTable result = createAnalyteTitrationTable(cf, true);
-                SQLFragment filter = new SQLFragment("AnalyteId IN (SELECT a.RowId FROM ");
-                filter.append(getTableInfoAnalytes(), "a");
-                filter.append(" WHERE a.DataId ");
-                filter.append(createDataFilterInClause());
-                filter.append(")");
-                result.addCondition(filter, FieldKey.fromParts("RunId"));
-                return result;
+                return createAnalyteTitrationTable(cf, true);
             }
 
             if (DATA_FILE_TABLE_NAME.equalsIgnoreCase(tableType))
             {
                 ExpDataTable result = createDataFileTable(cf);
-                SQLFragment filter = new SQLFragment("RowId");
-                filter.append(createDataFilterInClause());
-                result.addCondition(filter, FieldKey.fromParts("RowId"));
+                // Filter to just the files associated with this this protocol (container filter is already handled by ExpDataTable)
+                result.addCondition(createDataIdContainerFilterSQL("RowId", null), FieldKey.fromParts("RowId"));
                 return result;
             }
 
             if (WELL_EXCLUSION_TABLE_NAME.equalsIgnoreCase(tableType))
             {
-                FilteredTable result = createWellExclusionTable(cf, true);
+                WellExclusionTable result = createWellExclusionTable(cf, true);
                 result.addCondition(new SimpleFilter(FieldKey.fromParts("Type"), null, CompareType.NONBLANK));
-                result.removeColumn(new BaseColumnInfo("Dilution"));
-                SQLFragment filter = new SQLFragment("DataId");
-                filter.append(createDataFilterInClause());
-                result.addCondition(filter, FieldKey.fromParts("DataId"));
+                result.removeColumn(result.getColumn("Dilution"));
                 return result;
             }
 
             if (TITRATION_EXCLUSION_TABLE_NAME.equalsIgnoreCase(tableType))
             {
-                FilteredTable result = createWellExclusionTable(cf, true);
+                WellExclusionTable result = createWellExclusionTable(cf, true);
                 result.setName(TITRATION_EXCLUSION_TABLE_NAME);
                 SimpleFilter exclusionFilter = new SimpleFilter(FieldKey.fromParts("Type"), null, CompareType.ISBLANK);
                 exclusionFilter.addCondition(FieldKey.fromParts("Dilution"), null, CompareType.ISBLANK);
                 result.addCondition(exclusionFilter);
-                result.removeColumn(new BaseColumnInfo("Dilution"));
-                result.removeColumn(new BaseColumnInfo("Type"));
-                result.removeColumn(new BaseColumnInfo("Well"));
-                result.removeColumn(new BaseColumnInfo("Wells"));
-                result.removeColumn(new BaseColumnInfo("Well Role"));
-                SQLFragment filter = new SQLFragment("DataId");
-                filter.append(createDataFilterInClause());
-                result.addCondition(filter, FieldKey.fromParts("DataId"));
+                result.removeColumn(result.getColumn("Dilution"));
+                result.removeColumn(result.getColumn("Type"));
+                result.removeColumn(result.getColumn("Well"));
+                result.removeColumn(result.getColumn("Wells"));
+                result.removeColumn(result.getColumn("Well Role"));
                 return result;
             }
 
             if (SINGLEPOINT_UNKNOWN_EXCLUSION_TABLE_NAME.equalsIgnoreCase(tableType))
             {
-                FilteredTable result = createWellExclusionTable(cf, true);
+                WellExclusionTable result = createWellExclusionTable(cf, true);
                 result.setName(SINGLEPOINT_UNKNOWN_EXCLUSION_TABLE_NAME);
                 SimpleFilter exclusionFilter = new SimpleFilter(FieldKey.fromParts("Type"), null, CompareType.ISBLANK);
                 exclusionFilter.addCondition(FieldKey.fromParts("Dilution"), null, CompareType.NONBLANK);
                 result.addCondition(exclusionFilter);
-                result.removeColumn(new BaseColumnInfo("Type"));
-                result.removeColumn(new BaseColumnInfo("Well"));
-                result.removeColumn(new BaseColumnInfo("Wells"));
-                result.removeColumn(new BaseColumnInfo("Well Role"));
-                SQLFragment filter = new SQLFragment("DataId");
-                filter.append(createDataFilterInClause());
-                result.addCondition(filter, FieldKey.fromParts("DataId"));
+                result.removeColumn(result.getColumn("Type"));
+                result.removeColumn(result.getColumn("Well"));
+                result.removeColumn(result.getColumn("Wells"));
+                result.removeColumn(result.getColumn("Well Role"));
                 return result;
             }
 
             if (CURVE_FIT_TABLE_NAME.equalsIgnoreCase(tableType))
             {
-                CurveFitTable result = createCurveFitTable(cf, true);
-                SQLFragment filter = new SQLFragment("AnalyteId IN (SELECT a.RowId FROM ");
-                filter.append(getTableInfoAnalytes(), "a");
-                filter.append(" WHERE a.DataId ");
-                filter.append(createDataFilterInClause());
-                filter.append(")");
-                result.addCondition(filter, FieldKey.fromParts("RunId"));
-                return result;
+                return createCurveFitTable(cf, true);
             }
 
             if (GUIDE_SET_CURVE_FIT_TABLE_NAME.equalsIgnoreCase(tableType))
@@ -249,16 +225,7 @@ public class LuminexProtocolSchema extends AssayProtocolSchema
 
             if (RUN_EXCLUSION_TABLE_NAME.equalsIgnoreCase(tableType))
             {
-                FilteredTable result = createRunExclusionTable(cf, true);
-                SQLFragment filter = new SQLFragment("RunId IN (SELECT pa.RunId FROM ");
-                filter.append(ExperimentService.get().getTinfoProtocolApplication(), "pa");
-                filter.append(", ");
-                filter.append(ExperimentService.get().getTinfoData(), "d");
-                filter.append(" WHERE pa.RowId = d.SourceApplicationId AND d.RowId ");
-                filter.append(createDataFilterInClause());
-                filter.append(")");
-                result.addCondition(filter, FieldKey.fromParts("RunId"));
-                return result;
+                return createRunExclusionTable(cf, true);
             }
 
             if (ANALYTE_TITRATION_QC_FLAG_TABLE_NAME.equalsIgnoreCase(tableType))
@@ -323,38 +290,12 @@ public class LuminexProtocolSchema extends AssayProtocolSchema
 
     private SinglePointControlTable createSinglePointControlTable(ContainerFilter cf, boolean filterTable)
     {
-        SinglePointControlTable result = new SinglePointControlTable(this, cf, filterTable);
-        if (filterTable)
-        {
-            SQLFragment sql = new SQLFragment("RunId IN (SELECT pa.RunId FROM ");
-            sql.append(ExperimentService.get().getTinfoProtocolApplication(), "pa");
-            sql.append(", ");
-            sql.append(ExperimentService.get().getTinfoData(), "d");
-            sql.append(" WHERE pa.RowId = d.SourceApplicationId AND d.RowId ");
-            sql.append(createDataFilterInClause());
-            sql.append(")");
-            result.addCondition(sql);
-        }
-        return result;
+        return new SinglePointControlTable(this, cf, filterTable);
     }
 
     public AnalyteSinglePointControlTable createAnalyteSinglePointControlTable(ContainerFilter cf, boolean filterTable)
     {
-        AnalyteSinglePointControlTable result = new AnalyteSinglePointControlTable(this, cf, filterTable);
-        if (filterTable)
-        {
-            SQLFragment sql = new SQLFragment("SinglePointControlId IN (SELECT RowId FROM ");
-            sql.append(getTableInfoSinglePointControl(), "spc");
-            sql.append(" WHERE RunId IN (SELECT pa.RunId FROM ");
-            sql.append(ExperimentService.get().getTinfoProtocolApplication(), "pa");
-            sql.append(", ");
-            sql.append(ExperimentService.get().getTinfoData(), "d");
-            sql.append(" WHERE pa.RowId = d.SourceApplicationId AND d.RowId ");
-            sql.append(createDataFilterInClause());
-            sql.append("))");
-            result.addCondition(sql);
-        }
-        return result;
+        return new AnalyteSinglePointControlTable(this, cf, filterTable);
     }
 
     private RunExclusionTable createRunExclusionTable(ContainerFilter cf, boolean filterTable)
@@ -364,33 +305,12 @@ public class LuminexProtocolSchema extends AssayProtocolSchema
 
     public AnalyteTable createAnalyteTable(ContainerFilter cf, boolean filterTable)
     {
-        AnalyteTable result = new AnalyteTable(this, cf, filterTable);
-
-        if (filterTable)
-        {
-            SQLFragment sql = new SQLFragment("DataId");
-            sql.append(createDataFilterInClause());
-            result.addCondition(sql);
-        }
-        result.setTitleColumn("Name");
-        return result;
+        return new AnalyteTable(this, cf, filterTable);
     }
 
     public TitrationTable createTitrationTable(ContainerFilter cf, boolean filter)
     {
-        TitrationTable result = new TitrationTable(this, cf, filter);
-        if (filter)
-        {
-            SQLFragment sql = new SQLFragment("RunId IN (SELECT pa.RunId FROM ");
-            sql.append(ExperimentService.get().getTinfoProtocolApplication(), "pa");
-            sql.append(", ");
-            sql.append(ExperimentService.get().getTinfoData(), "d");
-            sql.append(" WHERE pa.RowId = d.SourceApplicationId AND d.RowId ");
-            sql.append(createDataFilterInClause());
-            sql.append(")");
-            result.addCondition(sql);
-        }
-        return result;
+        return new TitrationTable(this, cf, filter);
     }
 
     public ExpDataTable createDataFileTable(ContainerFilter cf)
@@ -408,19 +328,16 @@ public class LuminexProtocolSchema extends AssayProtocolSchema
         protocol.setHidden(true);
 
         var runCol = ret.addColumn(ExpDataTable.Column.Run);
-        if (getProtocol() != null)
+        runCol.setFk(new LookupForeignKey(ret.getContainerFilter(),"RowId", null)
         {
-            runCol.setFk(new LookupForeignKey(ret.getContainerFilter(),"RowId", null)
+            @Override
+            public TableInfo getLookupTableInfo()
             {
-                @Override
-                public TableInfo getLookupTableInfo()
-                {
-                    ExpRunTable result = AssayService.get().createRunTable(getProtocol(), AssayService.get().getProvider(getProtocol()), _user, _container, null);
-                    result.setContainerFilter(getLookupContainerFilter());
-                    return result;
-                }
-            });
-        }
+                ExpRunTable result = AssayService.get().createRunTable(getProtocol(), AssayService.get().getProvider(getProtocol()), _user, _container, null);
+                result.setContainerFilter(getLookupContainerFilter());
+                return result;
+            }
+        });
 
         Domain domain = LuminexAssayProvider.getExcelRunDomain(getProtocol());
         ret.addColumns(domain, null);
@@ -520,20 +437,33 @@ public class LuminexProtocolSchema extends AssayProtocolSchema
         return result;
     }
 
-    protected SQLFragment createDataFilterInClause()
+    public SQLFragment createDataIdContainerFilterSQL(String dataIdColumnName, @Nullable ContainerFilter cf)
     {
-        SQLFragment filter = new SQLFragment(" IN (SELECT d.RowId FROM ");
+        SQLFragment filter = new SQLFragment(dataIdColumnName);
+        filter.append(" IN (SELECT d.RowId FROM ");
         filter.append(ExperimentService.get().getTinfoData(), "d");
         filter.append(", ");
         filter.append(ExperimentService.get().getTinfoExperimentRun(), "r");
-        filter.append(" WHERE d.RunId = r.RowId");
-        if (getProtocol() != null)
+        filter.append(" WHERE d.RunId = r.RowId AND r.ProtocolLSID = ?");
+        filter.add(getProtocol().getLSID());
+        if (cf != null)
         {
-            filter.append(" AND r.ProtocolLSID = ?");
-            filter.add(getProtocol().getLSID());
+            filter.append(" AND ");
+            filter.append(cf.getSQLFragment(getSchema(), new SQLFragment("r.Container")));
         }
         filter.append(") ");
         return filter;
+    }
+
+    public SQLFragment createRunIdContainerFilterSQL(ContainerFilter filter)
+    {
+        SQLFragment sql = new SQLFragment("RunId IN (SELECT r.RowId FROM ");
+        sql.append(ExperimentService.get().getTinfoExperimentRun(), "r");
+        sql.append(" WHERE r.ProtocolLSID = ? AND ");
+        sql.add(getProtocol().getLSID());
+        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("r.Container")));
+        sql.append(")");
+        return sql;
     }
 
     public static DbSchema getSchema()
@@ -613,7 +543,7 @@ public class LuminexProtocolSchema extends AssayProtocolSchema
 
     public TableInfo createWellExclusionAnalyteTable(ContainerFilter cf)
     {
-        FilteredTable result = new FilteredTable<>(getTableInfoWellExclusionAnalyte(), this, cf);
+        FilteredTable<?> result = new FilteredTable<>(getTableInfoWellExclusionAnalyte(), this, cf);
         result.wrapAllColumns(true);
         result.getMutableColumn("AnalyteId").setFk(new AnalyteForeignKey(this, cf));
         return result;
@@ -621,7 +551,7 @@ public class LuminexProtocolSchema extends AssayProtocolSchema
 
     public TableInfo createRunExclusionAnalyteTable(ContainerFilter cf)
     {
-        FilteredTable result = new FilteredTable<>(getTableInfoRunExclusionAnalyte(), this, cf);
+        FilteredTable<?> result = new FilteredTable<>(getTableInfoRunExclusionAnalyte(), this, cf);
         result.wrapAllColumns(true);
         result.getMutableColumn("AnalyteId").setFk(new AnalyteForeignKey(this, cf));
         return result;
@@ -651,7 +581,7 @@ public class LuminexProtocolSchema extends AssayProtocolSchema
                 return new DataColumn(colInfo)
                 {
                     /** RowId -> Name */
-                    private Map<FieldKey, FieldKey> _pdfColumns = new HashMap<>();
+                    private final Map<FieldKey, FieldKey> _pdfColumns = new HashMap<>();
 
                     {
                         TableInfo outputTable = result.getColumn(ExpRunTable.Column.Output).getFk().getLookupTableInfo();
@@ -798,7 +728,7 @@ public class LuminexProtocolSchema extends AssayProtocolSchema
                 String runId = context.getRequest().getParameter(result.getDataRegion().getName() + ".Data/Run/RowId~eq");
 
                 // if showing controls and user is viewing data results for a single run, add the Exclusions menu button to button bar
-                if (showControls() && runId != null && NumberUtils.isDigits(runId))
+                if (showControls() && NumberUtils.isDigits(runId))
                 {
                     MenuButton exclusionsMenu = new MenuButton("Exclusions");
                     exclusionsMenu.setDisplayPermission(UpdatePermission.class);

--- a/luminex/src/org/labkey/luminex/query/RunExclusionTable.java
+++ b/luminex/src/org/labkey/luminex/query/RunExclusionTable.java
@@ -16,7 +16,6 @@
 package org.labkey.luminex.query;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.MultiValuedForeignKey;
 import org.labkey.api.data.SQLFragment;
@@ -71,14 +70,9 @@ public class RunExclusionTable extends AbstractExclusionTable
     }
 
     @Override
-    protected SQLFragment createContainerFilterSQL(ContainerFilter filter, Container container)
+    protected SQLFragment createContainerFilterSQL(ContainerFilter filter)
     {
-        SQLFragment sql = new SQLFragment("RunId IN (SELECT RowId FROM ");
-        sql.append(ExperimentService.get().getTinfoExperimentRun(), "r");
-        sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container"), container));
-        sql.append(")");
-        return sql;
+        return getUserSchema().createRunIdContainerFilterSQL(filter);
     }
 
     @Override

--- a/luminex/src/org/labkey/luminex/query/SinglePointControlTable.java
+++ b/luminex/src/org/labkey/luminex/query/SinglePointControlTable.java
@@ -15,10 +15,8 @@
  */
 package org.labkey.luminex.query;
 
-import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.SQLFragment;
-import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.assay.AssayProtocolSchema;
 
@@ -42,14 +40,9 @@ public class SinglePointControlTable extends AbstractLuminexTable
     }
 
     @Override
-    protected SQLFragment createContainerFilterSQL(ContainerFilter filter, Container container)
+    protected SQLFragment createContainerFilterSQL(ContainerFilter filter)
     {
-        SQLFragment sql = new SQLFragment("RunId IN (SELECT RowId FROM ");
-        sql.append(ExperimentService.get().getTinfoExperimentRun(), "r");
-        sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container"), container));
-        sql.append(")");
-        return sql;
+        return getUserSchema().createRunIdContainerFilterSQL(filter);
     }
 
 

--- a/luminex/src/org/labkey/luminex/query/TitrationTable.java
+++ b/luminex/src/org/labkey/luminex/query/TitrationTable.java
@@ -15,11 +15,9 @@
  */
 package org.labkey.luminex.query;
 
-import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.SQLFragment;
-import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.assay.AssayProtocolSchema;
@@ -68,13 +66,8 @@ public class TitrationTable extends AbstractLuminexTable
     }
 
     @Override
-    protected SQLFragment createContainerFilterSQL(ContainerFilter filter, Container container)
+    protected SQLFragment createContainerFilterSQL(ContainerFilter filter)
     {
-        SQLFragment sql = new SQLFragment("RunId IN (SELECT RowId FROM ");
-        sql.append(ExperimentService.get().getTinfoExperimentRun(), "r");
-        sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container"), container));
-        sql.append(")");
-        return sql;
+        return getUserSchema().createRunIdContainerFilterSQL(filter);
     }
 }

--- a/luminex/src/org/labkey/luminex/query/WellExclusionTable.java
+++ b/luminex/src/org/labkey/luminex/query/WellExclusionTable.java
@@ -151,14 +151,9 @@ public class WellExclusionTable extends AbstractExclusionTable
     }
 
     @Override
-    protected SQLFragment createContainerFilterSQL(ContainerFilter filter, Container container)
+    protected SQLFragment createContainerFilterSQL(ContainerFilter filter)
     {
-        SQLFragment sql = new SQLFragment("DataId IN (SELECT RowId FROM ");
-        sql.append(ExperimentService.get().getTinfoData(), "d");
-        sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container"), container));
-        sql.append(")");
-        return sql;
+        return getUserSchema().createDataIdContainerFilterSQL("DataId", filter);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Improve our SQL generation for Luminex queries, resulting in 100x or better execution times on large databases

#### Changes
* Avoid double-filtering on many tables. Previously we applied separate conditions for the container and the protocol (assay design). Collapse to a single filter that handles both.

* No need to filter analytetitration via both titration and analyte. Titration has a more direct link to the run table, so use that exclusively

* A bit of general code cleanup to remove deprecation warnings
