### PR TITLE
Fb close protein expression loader

### DIFF
--- a/ms2/src/org/labkey/ms2/matrix/ProteinExpressionMatrixDataHandler.java
+++ b/ms2/src/org/labkey/ms2/matrix/ProteinExpressionMatrixDataHandler.java
@@ -104,16 +104,17 @@ public class ProteinExpressionMatrixDataHandler extends AbstractMatrixDataHandle
 
             Map<String, String> runProps = getRunPropertyValues(expRun, runDomain);
 
-            DataLoader loader = createLoader(dataFile, PROTEIN_SEQ_ID_COLUMN_NAME);
+            try (DataLoader loader = createLoader(dataFile, PROTEIN_SEQ_ID_COLUMN_NAME))
+            {
+                ColumnDescriptor[] cols = loader.getColumns();
+                List<String> columnNames = new ArrayList<>(cols.length);
+                for (ColumnDescriptor col : cols)
+                    columnNames.add(col.getColumnName());
 
-            ColumnDescriptor[] cols = loader.getColumns();
-            List<String> columnNames = new ArrayList<>(cols.length);
-            for (ColumnDescriptor col : cols)
-                columnNames.add(col.getColumnName());
+                Map<String, Integer> samplesMap = ensureSamples(info.getContainer(), info.getUser(), columnNames, PROTEIN_SEQ_ID_COLUMN_NAME);
 
-            Map<String, Integer> samplesMap = ensureSamples(info.getContainer(), info.getUser(), columnNames, PROTEIN_SEQ_ID_COLUMN_NAME);
-
-            insertMatrixData(info.getContainer(), info.getUser(), samplesMap, loader, runProps, data.getRowId());
+                insertMatrixData(info.getContainer(), info.getUser(), samplesMap, loader, runProps, data.getRowId());
+            }
         }
         catch (IOException e)
         {


### PR DESCRIPTION
#### Rationale
ProteinExpressionMatrixAssayTest is failing pretty regularly on Windows because it can't delete one of the files. It's being held by the code that opens it but doesn't close it.

#### Changes
* Close the DataLoader when we're done parsing