### PR TITLE
Issue 41675: exp.object deleted when detaching exp.data from run

### DIFF
--- a/elispotassay/src/org/labkey/elispot/AbstractElispotDataHandler.java
+++ b/elispotassay/src/org/labkey/elispot/AbstractElispotDataHandler.java
@@ -17,13 +17,13 @@
 package org.labkey.elispot;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
+import org.labkey.api.assay.AssayUrls;
+import org.labkey.api.assay.plate.Position;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.ObjectProperty;
-import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.api.AbstractExperimentDataHandler;
@@ -32,8 +32,6 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.security.User;
-import org.labkey.api.assay.plate.Position;
-import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
@@ -225,6 +223,5 @@ public abstract class AbstractElispotDataHandler extends AbstractExperimentDataH
     @Override
     public void deleteData(ExpData data, Container container, User user)
     {
-        OntologyManager.deleteOntologyObject(data.getLSID(), container, true);
     }
 }


### PR DESCRIPTION
#### Rationale
As a part of fixing Issue 37518, we added `objectId` column to the `exp.data`, `exp.material`, and `exp.experimentrun` tables and created an `exp.object` when a new row was inserted.  When deleting an experiment run, the `exp.data` is detached from the run and ExperimentDataHandler.deleteData() is called to clean up any data handler specific stuff.  The underlying issue is that the `exp.object` for the `exp.data` row was deleted.  When the `exp.data` file was used to import into another run, we created a new `exp.object` for the same `exp.data` and ended up getting out of sync with the `objectId`.

The issue only repros if the first assay run is imported from a file in the pipeline root that was not uploaded via WebDAV.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1741
* https://github.com/LabKey/platform/pull/249

#### Related Issues
* [Issue 37518](https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=37518): deadlock when concurrently inserting samples with lineage

#### Changes
- associate assay import background job with the resulting run
- add FK from exp.data, exp.material, exp.experimentrun to exp.object by LSID and objectId
- don't delete exp.object in assay ExperimentDataHandler subclasses; it will be cleaned up when the exp.data is deleted
- added AssayIntegrationTestCase.java regression test
