### PR TITLE
convert NAb run details display column to be a standard DetailsColumn

### DIFF
--- a/nab/src/org/labkey/nab/query/NabProtocolSchema.java
+++ b/nab/src/org/labkey/nab/query/NabProtocolSchema.java
@@ -17,10 +17,16 @@ package org.labkey.nab.query;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AssayDataLinkDisplayColumn;
+import org.labkey.api.assay.AssayProtocolSchema;
+import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.dilution.DilutionManager;
 import org.labkey.api.assay.dilution.query.DilutionResultsQueryView;
 import org.labkey.api.assay.nab.query.CutoffValueTable;
 import org.labkey.api.assay.nab.query.NAbSpecimenTable;
+import org.labkey.api.assay.query.ResultsQueryView;
+import org.labkey.api.assay.query.RunListDetailsQueryView;
+import org.labkey.api.assay.query.RunListQueryView;
 import org.labkey.api.cache.BlockingCache;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheLoader;
@@ -38,12 +44,6 @@ import org.labkey.api.query.AliasedColumn;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.security.User;
-import org.labkey.api.assay.AssayDataLinkDisplayColumn;
-import org.labkey.api.assay.AssayProtocolSchema;
-import org.labkey.api.assay.AssayProvider;
-import org.labkey.api.assay.query.RunListDetailsQueryView;
-import org.labkey.api.assay.query.ResultsQueryView;
-import org.labkey.api.assay.query.RunListQueryView;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
 import org.labkey.nab.NabAssayController;
@@ -159,9 +159,9 @@ public class NabProtocolSchema extends AssayProtocolSchema
         }
 
         @Override
-        public ActionURL getRunDetailsURL(Object runId)
+        public ActionURL getRunDetailsURL()
         {
-            return new ActionURL(NabAssayController.DetailsAction.class, getContainer()).addParameter("rowId", "" + runId);
+            return new ActionURL(NabAssayController.DetailsAction.class, getContainer());
         }
     }
 


### PR DESCRIPTION
#### Rationale
To address this [issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41748), we needed to migrate from the custom display column to the standard DetailsColumn so we get consistent behavior from both export as well as look and feel.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/551
- https://github.com/LabKey/platform/pull/1765

#### Changes
Small refactor of the API to return the details action, we no longer pass in the runId since that will come from the DetailsUrl expression string.