### PR TITLE
Add plugins block in anticipation of removal of modules/build.gradle file

### DIFF
--- a/elisa/build.gradle
+++ b/elisa/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 dependencies {
     external "org.apache.commons:commons-math3:${commonsMath3Version}"
 }

--- a/elispotassay/build.gradle
+++ b/elispotassay/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
 BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "published", depExtension: "module")
 BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: "published", depExtension: "module")

--- a/flow/build.gradle
+++ b/flow/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 sourceSets {
     engine {
         java {

--- a/luminex/build.gradle
+++ b/luminex/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
 
 BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: "published", depExtension: "module")

--- a/microarray/build.gradle
+++ b/microarray/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: "published", depExtension: "module")

--- a/ms2/build.gradle
+++ b/ms2/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies {
    external("org.apache.httpcomponents:httpmime:${httpmimeVersion}")
    external("org.ardverk:patricia-trie:${patriciaTrieVersion}")

--- a/nab/build.gradle
+++ b/nab/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
 BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
 

--- a/viability/build.gradle
+++ b/viability/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 dependencies{
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
     


### PR DESCRIPTION
#### Rationale
We plan to remove the `server/modules/build.gradle` file that has logic to apply plugins for subprojects since that logic is only a heuristic and fails to do the right thing for file-based modules that include only client source code.  Instead, we will update each module's own `build.gradle` file so it applies the appropriate plugins (and add `build.gradle` files where there are none).  

#### Changes
* apply module plugin in build.gradle file
