### PR TITLE
Issue 42135: Luminex Levey-Jennings plot export to PDF button remains disabled

### DIFF
--- a/luminex/webapp/luminex/LeveyJenningsTrendPlotPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrendPlotPanel.js
@@ -396,10 +396,9 @@ LABKEY.LeveyJenningsTrendPlotPanel = Ext.extend(Ext.FormPanel, {
             yAxisScale: this.yAxisScale
         };
 
-        var renderType = LABKEY.LeveyJenningsPlotHelper.renderPlot(plotConfig);
+        LABKEY.LeveyJenningsPlotHelper.renderPlot(plotConfig);
 
-        // export to PDF doesn't work for IE<9
-        this.togglePDFExportBtn(renderType == 'd3');
+        this.togglePDFExportBtn(true);
     },
 
     activateTrendPlotPanel: function(panel) {


### PR DESCRIPTION
#### Rationale
The LabKey Vis JS API was updated somewhat recently to remove support for rendering with raphael, so that it always now renders with D3. There was a check in this Luminex Levey-Jennings report code that only enabled the PDF export button for D3 rendering. This check isn't relevant anymore and the button should always enable after plot render.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42135

#### Changes
* fix to remove the check for the plot renderType when enabling the Export PDF button (since we only render with d3 now)
