### PR TITLE
Fix url handling and simplify ButtonTag

### DIFF
--- a/flow/src/org/labkey/flow/controllers/BaseFlowController.java
+++ b/flow/src/org/labkey/flow/controllers/BaseFlowController.java
@@ -24,7 +24,6 @@ import org.labkey.api.data.DataRegion;
 import org.labkey.api.jsp.JspBase;
 import org.labkey.api.jsp.JspLoader;
 import org.labkey.api.pipeline.PipelineService;
-import org.labkey.api.pipeline.PipelineValidationException;
 import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.PageFlowUtil;

--- a/flow/src/org/labkey/flow/controllers/executescript/chooseAnalysisName.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/chooseAnalysisName.jsp
@@ -59,7 +59,7 @@
         <input type="text" name="ff_analysisName" value="<%=h(name)%>">
     </p>
 
-    <%=button("Analyze runs").href(urlFor(AnalyzeSelectedRunsAction.class)).usePost()%>
+    <%=button("Analyze runs").submit(true)%>
     <%=button("Go back").href(urlFor(ChooseRunsToAnalyzeAction.class)).usePost()%>
     <% for (int runid : form.getSelectedRunIds()) { %>
     <input type="hidden" name="<%=h(DataRegion.SELECT_CHECKBOX_NAME)%>" value="<%=runid%>">

--- a/flow/src/org/labkey/flow/controllers/executescript/chooseAnalysisName.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/chooseAnalysisName.jsp
@@ -59,8 +59,8 @@
         <input type="text" name="ff_analysisName" value="<%=h(name)%>">
     </p>
 
-    <labkey:button text="Analyze runs" action="<%=urlFor(AnalyzeSelectedRunsAction.class)%>"/>
-    <labkey:button text="Go back" action="<%=urlFor(ChooseRunsToAnalyzeAction.class)%>"/>
+    <%=button("Analyze runs").href(urlFor(AnalyzeSelectedRunsAction.class)).usePost()%>
+    <%=button("Go back").href(urlFor(ChooseRunsToAnalyzeAction.class)).usePost()%>
     <% for (int runid : form.getSelectedRunIds()) { %>
     <input type="hidden" name="<%=h(DataRegion.SELECT_CHECKBOX_NAME)%>" value="<%=runid%>">
     <% } %>

--- a/flow/src/org/labkey/flow/controllers/executescript/confirmRunsToImport.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/confirmRunsToImport.jsp
@@ -94,7 +94,7 @@
         <% } %>
 
         <br />
-        <%=button("Import Selected Runs").href(urlFor(ImportRunsAction.class)).usePost()%>
+        <%=button("Import Selected Runs").submit(true)%>
         <labkey:button text="Cancel" href="<%=form.getReturnURLHelper()%>"/>
         </labkey:form><%
     }

--- a/flow/src/org/labkey/flow/controllers/executescript/confirmRunsToImport.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/confirmRunsToImport.jsp
@@ -24,7 +24,7 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.flow.FlowModule" %>
-<%@ page import="org.labkey.flow.controllers.executescript.AnalysisScriptController" %>
+<%@ page import="org.labkey.flow.controllers.executescript.AnalysisScriptController.ImportRunsAction" %>
 <%@ page import="org.labkey.flow.controllers.executescript.ImportRunsForm" %>
 <%@ page import="org.labkey.flow.data.FlowRun" %>
 <%@ page import="java.util.LinkedHashMap" %>
@@ -61,7 +61,7 @@
 
     if (paths != null && paths.size() != 0)
     {
-        %><labkey:form method="POST" action="<%=new ActionURL(AnalysisScriptController.ImportRunsAction.class, c)%>">
+        %><labkey:form method="POST" action="<%=new ActionURL(ImportRunsAction.class, c)%>">
         <input type="hidden" name="path" value="<%=h(form.getPath())%>">
         <input type="hidden" name="current" value="<%=form.isCurrent()%>">
         <input type="hidden" name="confirm" value="true">
@@ -94,7 +94,7 @@
         <% } %>
 
         <br />
-        <labkey:button text="Import Selected Runs" action="<%=new ActionURL(AnalysisScriptController.ImportRunsAction.class, c)%>"/>
+        <%=button("Import Selected Runs").href(urlFor(ImportRunsAction.class)).usePost()%>
         <labkey:button text="Cancel" href="<%=form.getReturnURLHelper()%>"/>
         </labkey:form><%
     }

--- a/flow/src/org/labkey/flow/controllers/well/editWell.jsp
+++ b/flow/src/org/labkey/flow/controllers/well/editWell.jsp
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 %>
+<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.flow.controllers.run.RunController" %>
 <%@ page import="org.labkey.flow.controllers.well.EditWellForm" %>
 <%@ page import="org.labkey.flow.controllers.well.WellController" %>
 <%@ page import="org.labkey.flow.data.FlowDataType" %>
 <%@ page import="org.labkey.flow.data.FlowWell" %>
-<%@ page import="org.labkey.api.view.ActionURL" %>
-<%@ page import="org.labkey.flow.controllers.run.RunController" %>
 <%@ page import="java.util.List" %>
 <%@ page extends="org.labkey.api.jsp.FormPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -131,10 +131,10 @@
 
     <labkey:button text="update"/>
     <%
-        String cancelURL = String.valueOf(well.urlFor(WellController.ShowWellAction.class));
+        ActionURL cancelURL = well.urlFor(WellController.ShowWellAction.class);
         if (form.ff_isBulkEdit)
         {
-            cancelURL = new ActionURL(form.editWellReturnUrl).toString();
+            cancelURL = new ActionURL(form.editWellReturnUrl);
         }
     %>
     <labkey:button text="cancel" href="<%=cancelURL%>"/>


### PR DESCRIPTION
#### Rationale
Use `ActionURL` instead of `String`. `ButtonTag` no longer supports `href(String)` or `action()`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1842
