### PR TITLE
Use ActionURLs instead of Strings

### DIFF
--- a/flow/src/org/labkey/flow/controllers/protocol/editICSMetadata.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/editICSMetadata.jsp
@@ -58,7 +58,7 @@
 
     ActionURL submitURL = form.getProtocol().urlFor(ProtocolController.EditICSMetadataAction.class);
     if (form.getReturnActionURL() != null)
-        submitURL.addParameter(ActionURL.Param.returnUrl, form.getReturnActionURL().toString());
+        submitURL.addReturnURL(form.getReturnActionURL());
 %>
 <labkey:errors />
 <labkey:form action="<%=submitURL%>" method="POST">

--- a/flow/src/org/labkey/flow/controllers/reports.jsp
+++ b/flow/src/org/labkey/flow/controllers/reports.jsp
@@ -92,7 +92,7 @@ table.reports td {
             <td style='min-width:80px'><%=h(description == null ? " " : description)%></td>
             <%
             if (canEdit){
-                NavTree navtree = new NavTree("manage", (String)null);
+                NavTree navtree = new NavTree("manage", (ActionURL)null);
                 navtree.addChild("Edit", editURL);
                 navtree.addChild("Copy", copyURL);
                 navtree.addChild("Delete", deleteURL);

--- a/flow/src/org/labkey/flow/reports/PositivityFlowReport.java
+++ b/flow/src/org/labkey/flow/reports/PositivityFlowReport.java
@@ -174,7 +174,7 @@ public class PositivityFlowReport extends FilterFlowReport
             FlowProtocol protocol = FlowProtocol.getForContainer(context.getContainer());
             ActionURL currentURL = context.getActionURL();
             ActionURL editICSMetadataURL = protocol.urlFor(ProtocolController.EditICSMetadataAction.class);
-            editICSMetadataURL.addParameter(ActionURL.Param.returnUrl, currentURL.toString());
+            editICSMetadataURL.addReturnURL(currentURL);
 
             return new HtmlView(
                     "<p class='labkey-error'>Positivity report requires configuring flow experiment metadata for study and background information before running.</p>" +

--- a/flow/src/org/labkey/flow/reports/editPositivityReport.jsp
+++ b/flow/src/org/labkey/flow/reports/editPositivityReport.jsp
@@ -61,7 +61,7 @@
     if (protocol != null)
     {
         editICSMetadataURL = protocol.urlFor(EditICSMetadataAction.class);
-        editICSMetadataURL.addParameter(ActionURL.Param.returnUrl, currentURL.toString());
+        editICSMetadataURL.addReturnURL(currentURL);
     }
 %>
 

--- a/flow/src/org/labkey/flow/view/FlowQueryView.java
+++ b/flow/src/org/labkey/flow/view/FlowQueryView.java
@@ -146,7 +146,7 @@ public class FlowQueryView extends QueryView
                 NavTree showInline = new NavTree("Inline", urlShow.clone().replaceParameter(param("showGraphs"), FlowQuerySettings.ShowGraphs.Inline.name()));
                 showInline.setSelected(showGraphs == FlowQuerySettings.ShowGraphs.Inline);
 
-                NavTree navtree = new NavTree("Show Graphs", (String)null);
+                NavTree navtree = new NavTree("Show Graphs", (ActionURL)null);
                 navtree.addChild(showNone);
                 navtree.addChild(showHover);
                 navtree.addChild(showInline);
@@ -244,10 +244,7 @@ public class FlowQueryView extends QueryView
                 URLHelper url = target.clone();
                 if (entry.getKey().intValue() != 0)
                     url.replaceParameter(FlowParam.experimentId.name(), entry.getKey());
-                button.addMenuItem(entry.getValue(),
-                        url.toString(),
-                        null,
-                        currentId == entry.getKey());
+                button.addMenuItem(entry.getValue(), url, null, currentId == entry.getKey());
             }
             bar.add(button);
         }

--- a/microarray/src/org/labkey/microarray/view/FeatureAnnotationSetQueryView.java
+++ b/microarray/src/org/labkey/microarray/view/FeatureAnnotationSetQueryView.java
@@ -70,7 +70,7 @@ public class FeatureAnnotationSetQueryView extends QueryView
         ActionButton deleteButton = new ActionButton(FeatureAnnotationSetController.DeleteAction.class, "Delete", ActionButton.Action.GET);
         deleteButton.setDisplayPermission(DeletePermission.class);
         ActionURL deleteURL = new ActionURL(FeatureAnnotationSetController.DeleteAction.class, getContainer());
-        deleteURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
+        deleteURL.addReturnURL(getViewContext().getActionURL());
         deleteButton.setURL(deleteURL);
         deleteButton.setActionType(ActionButton.Action.POST);
         deleteButton.setRequiresSelection(true);
@@ -78,13 +78,11 @@ public class FeatureAnnotationSetQueryView extends QueryView
 
         ActionButton uploadButton = new ActionButton(FeatureAnnotationSetController.UploadAction.class, "Import Feature Annotation Set", ActionButton.Action.LINK);
         ActionURL uploadURL = new ActionURL(FeatureAnnotationSetController.UploadAction.class, getContainer());
-        uploadURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
+        uploadURL.addReturnURL(getViewContext().getActionURL());
         uploadButton.setURL(uploadURL);
         uploadButton.setDisplayPermission(UpdatePermission.class);
         bar.add(uploadButton);
 
         bar.add(new ActionButton(new ActionURL(FeatureAnnotationSetController.UploadAction.class, getContainer()), "Submit"));
     }
-
-
 }

--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -338,28 +338,28 @@ public class MS2Controller extends SpringActionController
         {
             proteinProphetQueryURL.addParameter("experimentRunIds", "true");
         }
-        compareMenu.addMenuItem("ProteinProphet", null, view.createVerifySelectedScript(proteinProphetQueryURL, "runs"));
+        compareMenu.addMenuItem("ProteinProphet", view.createVerifySelectedScript(proteinProphetQueryURL, "runs"));
 
         ActionURL peptideQueryURL = new ActionURL(MS2Controller.ComparePeptideQuerySetupAction.class, container);
         if (experimentRunIds)
         {
             peptideQueryURL.addParameter("experimentRunIds", "true");
         }
-        compareMenu.addMenuItem("Peptide", null, view.createVerifySelectedScript(peptideQueryURL, "runs"));
+        compareMenu.addMenuItem("Peptide", view.createVerifySelectedScript(peptideQueryURL, "runs"));
 
         ActionURL searchEngineURL = new ActionURL(MS2Controller.CompareSearchEngineProteinSetupAction.class, container);
         if (experimentRunIds)
         {
             searchEngineURL.addParameter("experimentRunIds", "true");
         }
-        compareMenu.addMenuItem("Search Engine Protein", null, view.createVerifySelectedScript(searchEngineURL, "runs"));
+        compareMenu.addMenuItem("Search Engine Protein", view.createVerifySelectedScript(searchEngineURL, "runs"));
 
         ActionURL spectraURL = new ActionURL(SpectraCountSetupAction.class, container);
         if (experimentRunIds)
         {
             spectraURL.addParameter("experimentRunIds", "true");
         }
-        compareMenu.addMenuItem("Spectra Count", null, view.createVerifySelectedScript(spectraURL, "runs"));
+        compareMenu.addMenuItem("Spectra Count", view.createVerifySelectedScript(spectraURL, "runs"));
         return compareMenu;
     }
 
@@ -2813,15 +2813,15 @@ public class MS2Controller extends SpringActionController
             ActionURL setBestNameURL = new ActionURL(SetBestNameAction.class, getContainer());
 
             setBestNameURL.replaceParameter("nameType", SetBestNameForm.NameType.LOOKUP_STRING.toString());
-            setBestNameMenu.addMenuItem("to name from FASTA", null, result.createVerifySelectedScript(setBestNameURL, "FASTA files"));
+            setBestNameMenu.addMenuItem("to name from FASTA", result.createVerifySelectedScript(setBestNameURL, "FASTA files"));
             setBestNameURL.replaceParameter("nameType", SetBestNameForm.NameType.IPI.toString());
-            setBestNameMenu.addMenuItem("to IPI (if available)", null, result.createVerifySelectedScript(setBestNameURL, "FASTA files"));
+            setBestNameMenu.addMenuItem("to IPI (if available)", result.createVerifySelectedScript(setBestNameURL, "FASTA files"));
             setBestNameURL.replaceParameter("nameType", SetBestNameForm.NameType.SWISS_PROT.toString());
-            setBestNameMenu.addMenuItem("to Swiss-Prot Name (if available)", null, result.createVerifySelectedScript(setBestNameURL, "FASTA files"));
+            setBestNameMenu.addMenuItem("to Swiss-Prot Name (if available)", result.createVerifySelectedScript(setBestNameURL, "FASTA files"));
             setBestNameURL.replaceParameter("nameType", SetBestNameForm.NameType.SWISS_PROT_ACCN.toString());
-            setBestNameMenu.addMenuItem("to Swiss-Prot Accession (if available)", null, result.createVerifySelectedScript(setBestNameURL, "FASTA files"));
+            setBestNameMenu.addMenuItem("to Swiss-Prot Accession (if available)", result.createVerifySelectedScript(setBestNameURL, "FASTA files"));
             setBestNameURL.replaceParameter("nameType", SetBestNameForm.NameType.GEN_INFO.toString());
-            setBestNameMenu.addMenuItem("to GI number (if available)", null, result.createVerifySelectedScript(setBestNameURL, "FASTA files"));
+            setBestNameMenu.addMenuItem("to GI number (if available)", result.createVerifySelectedScript(setBestNameURL, "FASTA files"));
 
             bb.add(setBestNameMenu);
 

--- a/ms2/src/org/labkey/ms2/peptideview/AbstractMS2RunView.java
+++ b/ms2/src/org/labkey/ms2/peptideview/AbstractMS2RunView.java
@@ -138,7 +138,7 @@ public abstract class AbstractMS2RunView
         for (MS2ExportType exportFormat : exportFormats)
         {
             exportUrl.replaceParameter("exportFormat", exportFormat.name());
-            NavTree menuItem = exportAll.addMenuItem(exportFormat.toString(), null, dataRegion.getJavascriptFormReference() + ".action=\"" + exportUrl.getLocalURIString() + "\"; " + dataRegion.getJavascriptFormReference() + ".submit();");
+            NavTree menuItem = exportAll.addMenuItem(exportFormat.toString(), dataRegion.getJavascriptFormReference() + ".action=\"" + exportUrl.getLocalURIString() + "\"; " + dataRegion.getJavascriptFormReference() + ".submit();");
             if (exportFormat.getDescription() != null)
             {
                 menuItem.setDescription(exportFormat.getDescription());
@@ -154,7 +154,7 @@ public abstract class AbstractMS2RunView
             if (exportFormat.supportsSelectedOnly())
             {
                 exportUrl.replaceParameter("exportFormat", exportFormat.name());
-                NavTree menuItem = exportSelected.addMenuItem(exportFormat.toString(), null, "if (verifySelected(" + dataRegion.getJavascriptFormReference() + ", \"" + exportUrl.getLocalURIString() + "\", \"post\", \"" + whatWeAreSelecting + "\")) { " + dataRegion.getJavascriptFormReference() + ".submit(); }");
+                NavTree menuItem = exportSelected.addMenuItem(exportFormat.toString(), "if (verifySelected(" + dataRegion.getJavascriptFormReference() + ", \"" + exportUrl.getLocalURIString() + "\", \"post\", \"" + whatWeAreSelecting + "\")) { " + dataRegion.getJavascriptFormReference() + ".submit(); }");
                 if (exportFormat.getDescription() != null)
                 {
                     menuItem.setDescription(exportFormat.getDescription());
@@ -173,7 +173,7 @@ public abstract class AbstractMS2RunView
             for (ProteinDictionaryHelpers.GoTypes goType : types)
             {
                 ActionURL url = MS2Controller.getPeptideChartURL(getContainer(), goType);
-                goButton.addMenuItem(goType.toString(), null, dataRegion.getJavascriptFormReference() + ".action=\"" + url.getLocalURIString() + "\"; " + dataRegion.getJavascriptFormReference() + ".submit();");
+                goButton.addMenuItem(goType.toString(), dataRegion.getJavascriptFormReference() + ".action=\"" + url.getLocalURIString() + "\"; " + dataRegion.getJavascriptFormReference() + ".submit();");
             }
             result.add(goButton);
         }


### PR DESCRIPTION
#### Rationale
Use `ActionURL.addReturnURL()` to reduce String URL handling. Update for `addMenuItem()` method signature change.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1866