### PR TITLE
Issue 41058: Remove public name override for FastFlowDataTable

### DIFF
--- a/flow/src/org/labkey/flow/query/FlowSchema.java
+++ b/flow/src/org/labkey/flow/query/FlowSchema.java
@@ -835,13 +835,6 @@ public class FlowSchema extends UserSchema
         }
 
         @Override
-        public String getPublicName()
-        {
-            // 7471 Let schema explorer resolve lookup table names to "exp.Data" table.
-            return ExpSchema.TableType.Data.toString();
-        }
-
-        @Override
         public void addAllowablePermission(Class<? extends Permission> permission)
         {
             _expData.addAllowablePermission(permission);


### PR DESCRIPTION
#### Rationale
The related PR updates GetQueriesAction to return public name of queries.  The FastFlowDataTable, which is inherited by several other Flow tables, overrides the public name with Flow.Data instead of the default behavior to use table name.  This PR removes that override.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/1883

#### Changes
- Remove Flow.Data public name override