### PR TITLE
41640: Protein views NPE without query parameter

### DIFF
--- a/ms2/src/org/labkey/ms2/protein/ProteinController.java
+++ b/ms2/src/org/labkey/ms2/protein/ProteinController.java
@@ -16,6 +16,7 @@
 
 package org.labkey.ms2.protein;
 
+import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.action.FormHandlerAction;
 import org.labkey.api.action.FormViewAction;
 import org.labkey.api.action.SimpleViewAction;
@@ -99,6 +100,10 @@ public class ProteinController extends SpringActionController
             settings.setAllowChooseQuery(true);
             settings.setAllowChooseView(true);
             _setName = settings.getQueryName();
+
+            // 41640: Expect valid "CustomAnnotation.queryName" URL parameter
+            if (StringUtils.isEmpty(_setName))
+                throw new NotFoundException("Custom Protein List not found.");
 
             QueryView queryView = new QueryView(schema, settings, errors)
             {


### PR DESCRIPTION
#### Rationale
This addresses 41640 which is an NPE caused by invalid query parameters on the `protein-showSet.view` action. This prevents the NPE by returning 404 if the parameter is not specified.

#### Changes
* Return `NotFoundException` if the query name parameter is not specified for `protein-showSet.view` action.
