### PR TITLE
Switch usages to TableInsertDataIteratorBuilder

### DIFF
--- a/luminex/src/org/labkey/luminex/query/LuminexDataTable.java
+++ b/luminex/src/org/labkey/luminex/query/LuminexDataTable.java
@@ -25,7 +25,6 @@ import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.OORDisplayColumnFactory;
-import org.labkey.api.data.Parameter;
 import org.labkey.api.data.ParameterMapStatement;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.StatementUtils;
@@ -33,7 +32,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.UpdateableTableInfo;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
-import org.labkey.api.dataiterator.TableInsertDataIterator;
+import org.labkey.api.dataiterator.TableInsertDataIteratorBuilder;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.Domain;
@@ -463,7 +462,7 @@ public class LuminexDataTable extends FilteredTable<LuminexProtocolSchema> imple
     @Override
     public DataIteratorBuilder persistRows(DataIteratorBuilder data, DataIteratorContext context)
     {
-        return TableInsertDataIterator.create(data, this, null, context);
+        return new TableInsertDataIteratorBuilder(data, this);
     }
 
     @Override

--- a/nab/src/org/labkey/nab/query/NabVirusDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabVirusDataTable.java
@@ -23,14 +23,13 @@ import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerForeignKey;
-import org.labkey.api.data.Parameter;
 import org.labkey.api.data.ParameterMapStatement;
 import org.labkey.api.data.StatementUtils;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.UpdateableTableInfo;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
-import org.labkey.api.dataiterator.TableInsertDataIterator;
+import org.labkey.api.dataiterator.TableInsertDataIteratorBuilder;
 import org.labkey.api.exp.PropertyColumn;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.RawValueColumn;
@@ -224,7 +223,7 @@ public class NabVirusDataTable extends FilteredTable<AssayProtocolSchema> implem
     @Override
     public DataIteratorBuilder persistRows(DataIteratorBuilder data, DataIteratorContext context)
     {
-        return TableInsertDataIterator.create(data, this, null, context);
+        return new TableInsertDataIteratorBuilder(data, this);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Migrates usages to use `new TableInsertDataIteratorBuilder()` in lieu of `TableInsertDataIterator.create()`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1925