### PR TITLE
Issue 42355: Perf problem during copy-to-study with many rows

### DIFF
--- a/microarray/src/org/labkey/microarray/matrix/ExpressionMatrixAssayProvider.java
+++ b/microarray/src/org/labkey/microarray/matrix/ExpressionMatrixAssayProvider.java
@@ -62,6 +62,7 @@ import org.labkey.microarray.MicroarrayModule;
 import org.labkey.microarray.controllers.FeatureAnnotationSetController;
 import org.labkey.microarray.query.MicroarrayUserSchema;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -97,12 +98,6 @@ public class ExpressionMatrixAssayProvider extends AbstractAssayProvider
     public AssayRunCreator getRunCreator()
     {
         return new ExpressionMatrixRunCreator(this);
-    }
-
-    @Override
-    public ExpData getDataForDataRow(Object dataRowId, ExpProtocol protocol)
-    {
-        return null;
     }
 
     @Override

--- a/ms2/src/org/labkey/ms2/matrix/ProteinExpressionMatrixAssayProvider.java
+++ b/ms2/src/org/labkey/ms2/matrix/ProteinExpressionMatrixAssayProvider.java
@@ -54,6 +54,7 @@ import org.labkey.ms2.MS2Controller;
 import org.labkey.ms2.MS2Module;
 import org.labkey.ms2.protein.query.ProteinUserSchema;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -82,12 +83,6 @@ public class ProteinExpressionMatrixAssayProvider extends AbstractAssayProvider
     public AssayTableMetadata getTableMetadata(@NotNull ExpProtocol protocol)
     {
         return new AssayTableMetadata(this, protocol, null, FieldKey.fromParts("Run"), FieldKey.fromParts("RowId"));
-    }
-
-    @Override
-    public ExpData getDataForDataRow(Object dataRowId, ExpProtocol protocol)
-    {
-        return null;
     }
 
     @Override

--- a/nab/src/org/labkey/nab/NabAssayProvider.java
+++ b/nab/src/org/labkey/nab/NabAssayProvider.java
@@ -25,7 +25,6 @@ import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayProviderSchema;
 import org.labkey.api.assay.AssayRunCreator;
 import org.labkey.api.assay.AssaySchema;
-import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.assay.actions.AssayRunUploadForm;
 import org.labkey.api.assay.actions.PlateUploadForm;
@@ -35,17 +34,13 @@ import org.labkey.api.assay.nab.NabSpecimen;
 import org.labkey.api.assay.plate.PlateSamplePropertyHelper;
 import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.statistics.StatsService;
-import org.labkey.api.exp.IdentifiableBase;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.LsidManager;
-import org.labkey.api.exp.OntologyManager;
-import org.labkey.api.exp.OntologyObject;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -165,16 +160,22 @@ public class NabAssayProvider extends AbstractDilutionAssayProvider<NabRunUpload
     }
 
     @Override
-    public ExpData getDataForDataRow(Object dataRowId, ExpProtocol protocol)
+    public Set<ExpData> getDatasForResultRows(Collection<Integer> rowIds, ExpProtocol protocol, ResolverCache cache)
     {
-        if (!(dataRowId instanceof Integer))
-            return null;
-
-        // dataRowId is NabSpecimen rowId
-        NabSpecimen nabSpecimen = NabManager.get().getNabSpecimen((Integer)dataRowId);
-        if (null != nabSpecimen)
-            return ExperimentService.get().getExpData(nabSpecimen.getDataId());
-        return null;
+        Set<ExpData> result = new HashSet<>();
+        for (Integer rowId : rowIds)
+        {
+            NabSpecimen nabSpecimen = NabManager.get().getNabSpecimen(rowId);
+            if (null != nabSpecimen)
+            {
+                ExpData data = cache.getDataById(nabSpecimen.getDataId());
+                if (data != null)
+                {
+                    result.add(data);
+                }
+            }
+        }
+        return result;
     }
 
     @Override

--- a/viability/src/org/labkey/viability/ViabilityAssayProvider.java
+++ b/viability/src/org/labkey/viability/ViabilityAssayProvider.java
@@ -242,29 +242,18 @@ public class ViabilityAssayProvider extends AbstractAssayProvider
     }
 
     @Override
-    public ExpData getDataForDataRow(Object resultRowId, ExpProtocol protocol)
+    public Set<ExpData> getDatasForResultRows(Collection<Integer> rowIds, ExpProtocol protocol, ResolverCache cache)
     {
-        if (resultRowId == null)
-            return null;
-
-        Integer id;
-        if (resultRowId instanceof Integer)
+        Set<ExpData> result = new HashSet<>();
+        for (Integer rowId : rowIds)
         {
-            id = (Integer)resultRowId;
-        }
-        else
-        {
-            try
+            ExpData data = ViabilityManager.getResultExpData(rowId);
+            if (data != null)
             {
-                id = Integer.parseInt(resultRowId.toString());
-            }
-            catch (NumberFormatException nfe)
-            {
-                return null;
+                result.add(data);
             }
         }
-
-        return ViabilityManager.getResultExpData(id.intValue());
+        return result;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Users want to be able to copy large assay runs to study datasets. It's painfully slow because we are iterating on each row and doing lots of DB queries

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1945

#### Changes
* Switch AssayProvider to encourage implementations to query rows in bulk
* Cache ExpData, ExpRun, and ExpExperiment references during process as they're likely to be shared by result rows