### PR TITLE
Run sans specimen module

### DIFF
--- a/viability/src/org/labkey/viability/ViabilityModule.java
+++ b/viability/src/org/labkey/viability/ViabilityModule.java
@@ -70,7 +70,10 @@ public class ViabilityModule extends DefaultModule
         ExperimentService.get().registerExperimentDataHandler(new ViabilityTsvDataHandler());
         ExperimentService.get().registerExperimentDataHandler(new GuavaDataHandler());
         AssayService.get().registerAssayProvider(new ViabilityAssayProvider());
-        SpecimenService.get().registerSpecimenChangeListener(new ViabilitySpecimenChangeListener());
+
+        SpecimenService ss = SpecimenService.get();
+        if (null != ss)
+            ss.registerSpecimenChangeListener(new ViabilitySpecimenChangeListener());
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We're removing the specimen module from most distributions. Modules with optional dependencies on specimen need to check SpecimenService.get() != null before using the service.
