### PR TITLE
Demote Flow module metrics logging to debug

### DIFF
--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -1398,7 +1398,7 @@ public class FlowManager
     // Get usage metrics for all flow containers
     public Map<String, Object> getUsageMetrics()
     {
-        _log.info("Collecting flow usage metrics");
+        _log.debug("Collecting flow usage metrics");
         User user = User.getSearchUser();
 
         Map<String, Object> allMetrics = new HashMap<>();
@@ -1417,7 +1417,7 @@ public class FlowManager
             merge(allMetrics, containerMetrics);
         }
 
-        _log.info("Collected flow usage metrics:\n" + allMetrics);
+        _log.debug("Collected flow usage metrics:\n" + allMetrics);
         return allMetrics;
     }
 


### PR DESCRIPTION
#### Rationale
Capturing metrics is good, but we don't need to spam the log file by default

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/293

#### Changes
* Demote logging from INFO to DEBUG
