### PR TITLE
Refactor usages of deprecated 'ComponentElements'

### DIFF
--- a/ms2/test/src/org/labkey/test/pages/ms2/MascotConfigPage.java
+++ b/ms2/test/src/org/labkey/test/pages/ms2/MascotConfigPage.java
@@ -18,25 +18,15 @@ package org.labkey.test.pages.ms2;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.components.ComponentElements;
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.selenium.LazyWebElement;
-import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
 
-public class MascotConfigPage extends LabKeyPage
+public class MascotConfigPage extends LabKeyPage<MascotConfigPage.Elements>
 {
-    private final Elements _elements;
-
     public MascotConfigPage(BaseWebDriverTest test)
     {
         super(test);
-        _elements = new Elements();
-    }
-
-    BaseWebDriverTest getTest()
-    {
-        return _test;
     }
 
     public static MascotConfigPage beginAt(BaseWebDriverTest test)
@@ -47,59 +37,54 @@ public class MascotConfigPage extends LabKeyPage
 
     public MascotConfigPage setMascotServer(String serverUrl)
     {
-        _test.setFormElement(elements().serverUrlInput, serverUrl);
+        setFormElement(elementCache().serverUrlInput, serverUrl);
         return this;
     }
 
     public MascotConfigPage setMascotUser(String user)
     {
-        _test.setFormElement(elements().userInput, user);
+        setFormElement(elementCache().userInput, user);
         return this;
     }
 
     public MascotConfigPage setMascotPassword(String password)
     {
-        _test.setFormElement(elements().passwordInput, password);
+        setFormElement(elementCache().passwordInput, password);
         return this;
     }
 
     public MascotConfigPage setMascotProxy(String proxyUrl)
     {
-        _test.setFormElement(elements().proxyUrlInput, proxyUrl);
+        setFormElement(elementCache().proxyUrlInput, proxyUrl);
         return this;
     }
 
     public MascotTestPage testMascotSettings()
     {
-        elements().testLink.click();
+        elementCache().testLink.click();
         return new MascotTestPage(this);
     }
 
     public LabKeyPage save()
     {
-        _test.clickAndWait(elements().saveButton);
-        return new LabKeyPage(_test);
+        clickAndWait(elementCache().saveButton);
+        return null;
     }
 
     public LabKeyPage cancel()
     {
-        _test.clickAndWait(elements().cancelButton);
-        return new LabKeyPage(_test);
+        clickAndWait(elementCache().cancelButton);
+        return null;
     }
 
-    private Elements elements()
+    @Override
+    protected Elements newElementCache()
     {
-        return _elements;
+        return new Elements();
     }
 
-    private class Elements extends ComponentElements
+    protected class Elements extends LabKeyPage<?>.ElementCache
     {
-        @Override
-        protected SearchContext getContext()
-        {
-            return getDriver();
-        }
-
         WebElement serverUrlInput = new LazyWebElement(Locator.name("mascotServer"), this);
         WebElement userInput = new LazyWebElement(Locator.name("mascotUserAccount"), this);
         WebElement passwordInput = new LazyWebElement(Locator.name("mascotUserPassword"), this);

--- a/ms2/test/src/org/labkey/test/pages/ms2/MascotTestPage.java
+++ b/ms2/test/src/org/labkey/test/pages/ms2/MascotTestPage.java
@@ -17,32 +17,28 @@ package org.labkey.test.pages.ms2;
 
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
-import org.labkey.test.components.ComponentElements;
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.selenium.LazyWebElement;
 import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
 
-public class MascotTestPage extends LabKeyPage
+public class MascotTestPage extends LabKeyPage<MascotTestPage.Elements>
 {
-    private final Elements _elements;
     private final MascotConfigPage _configPage;
 
     public MascotTestPage(MascotConfigPage configPage)
     {
-        super(configPage.getTest());
-        _elements = new Elements();
+        super(configPage);
         _configPage = configPage;
 
-        _test.switchToWindow(1);
+        switchToWindow(1);
     }
 
     public String getError()
     {
         try
         {
-            return elements().testError.getText();
+            return elementCache().testError.getText();
         }
         catch (NoSuchElementException ignore)
         {
@@ -52,30 +48,25 @@ public class MascotTestPage extends LabKeyPage
 
     public String getConfigurationText()
     {
-        return elements().configurationTextArea.getText();
+        return elementCache().configurationTextArea.getText();
     }
 
     public MascotConfigPage close()
     {
-        _test.getDriver().close();
-        _test.switchToMainWindow();
+        getDriver().close();
+        switchToMainWindow();
 
         return _configPage;
     }
 
-    private Elements elements()
+    @Override
+    protected Elements newElementCache()
     {
-        return _elements;
+        return new Elements();
     }
 
-    private class Elements extends ComponentElements
+    protected class Elements extends LabKeyPage<?>.ElementCache
     {
-        @Override
-        protected SearchContext getContext()
-        {
-            return getDriver();
-        }
-
         WebElement testError = new LazyWebElement(Locators.labkeyError, this);
         WebElement configurationTextArea = new LazyWebElement(Locator.tag("textarea"), this);
     }


### PR DESCRIPTION
#### Rationale
`org.labkey.test.components.ComponentElements` was deprecated in 2016. Time to get rid of it.

#### Related Pull Requests
* LabKey/testAutomation#643

#### Changes
* Refactor usages of `ComponentElements` to use `Component.ElementCache` or `LabKeyPage.ElementCache`
