### PR TITLE
Organize shared test components

### DIFF
--- a/ms2/test/src/org/labkey/test/ms2/AbstractMS2SearchEngineTest.java
+++ b/ms2/test/src/org/labkey/test/ms2/AbstractMS2SearchEngineTest.java
@@ -19,10 +19,8 @@ package org.labkey.test.ms2;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.components.experiment.LineageGraph;
+import org.labkey.test.components.ui.lineage.LineageGraph;
 import org.openqa.selenium.NoSuchElementException;
-
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/ms2/test/src/org/labkey/test/ms2/QuantitationTest.java
+++ b/ms2/test/src/org/labkey/test/ms2/QuantitationTest.java
@@ -20,7 +20,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.DailyB;
-import org.labkey.test.components.experiment.LineageGraph;
+import org.labkey.test.components.ui.lineage.LineageGraph;
 
 import java.io.File;
 


### PR DESCRIPTION
#### Rationale
Numerous test components are organized into inconsistent, inaccurate, or obsolete java packages.

#### Related Pull Requests
* LabKey/testAutomation#645

#### Changes
* Move most components related to `labkey-ui-components` to `org.labkey.test.components.ui`
