### PR TITLE
42596: IllegalStateException copying Elispot assay data to study

### DIFF
--- a/elispotassay/src/org/labkey/elispot/ElispotAssayProvider.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotAssayProvider.java
@@ -186,14 +186,17 @@ public class ElispotAssayProvider extends AbstractPlateBasedAssayProvider implem
 
             ExpRun expRun = cache.getRun(dataRow.getRunId());
             List<ExpData> dataOutputs = expRun.getDataOutputs();
+            boolean found = false;
             for (ExpData dataOutput : dataOutputs)
             {
                 if (ElispotDataHandler.NAMESPACE.equals(dataOutput.getLSIDNamespacePrefix()))
                 {
                     result.add(dataOutput);
+                    found = true;
                 }
             }
-            throw new IllegalStateException("No ELISpot Experiment data row was found for RunId: " + dataRow.getRunId());
+            if (!found)
+                throw new IllegalStateException("No ELISpot Experiment data row was found for RunId: " + dataRow.getRunId());
         }
         return result;
     }


### PR DESCRIPTION
#### Rationale
Issue was introduced during a refactor, which resulted in an error always being thrown even if there was data for the run ID.

#### Related Issue
- https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42596
