### PR TITLE
Issue 42620: Fix for NAb run SQL query inclusion of control aggregate columns in views that don't include them

### DIFF
--- a/nab/src/org/labkey/nab/query/NabProtocolSchema.java
+++ b/nab/src/org/labkey/nab/query/NabProtocolSchema.java
@@ -104,12 +104,16 @@ public class NabProtocolSchema extends AssayProtocolSchema
         AliasedColumn cellControlAggCol = new AliasedColumn(CELL_CONTROL_AGGREGATES_TABLE_NAME, runTable.getColumn("RowId"));
         cellControlAggCol.setFk(QueryForeignKey.from(this, cf).to(CELL_CONTROL_AGGREGATES_TABLE_NAME, "RunId", "ControlWellgroup"));
         cellControlAggCol.setHidden(true);
+        cellControlAggCol.setIsUnselectable(true);
+        cellControlAggCol.setKeyField(false); // Ticket 42587
         runTable.addColumn(cellControlAggCol);
 
         // Add hidden aliased column from Run/RowId to expose the virus control aggregates for this run
         AliasedColumn virusControlAggCol = new AliasedColumn(VIRUS_CONTROL_AGGREGATES_TABLE_NAME, runTable.getColumn("RowId"));
         virusControlAggCol.setFk(QueryForeignKey.from(this, cf).to(VIRUS_CONTROL_AGGREGATES_TABLE_NAME, "RunId", "ControlWellgroup"));
         virusControlAggCol.setHidden(true);
+        virusControlAggCol.setIsUnselectable(true);
+        virusControlAggCol.setKeyField(false); // Ticket 42587
         runTable.addColumn(virusControlAggCol);
 
         return runTable;

--- a/nab/src/org/labkey/nab/query/NabProtocolSchema.java
+++ b/nab/src/org/labkey/nab/query/NabProtocolSchema.java
@@ -105,7 +105,7 @@ public class NabProtocolSchema extends AssayProtocolSchema
         cellControlAggCol.setFk(QueryForeignKey.from(this, cf).to(CELL_CONTROL_AGGREGATES_TABLE_NAME, "RunId", "ControlWellgroup"));
         cellControlAggCol.setHidden(true);
         cellControlAggCol.setIsUnselectable(true);
-        cellControlAggCol.setKeyField(false); // Ticket 42587
+        cellControlAggCol.setKeyField(false); // Issue 42620
         runTable.addColumn(cellControlAggCol);
 
         // Add hidden aliased column from Run/RowId to expose the virus control aggregates for this run
@@ -113,7 +113,7 @@ public class NabProtocolSchema extends AssayProtocolSchema
         virusControlAggCol.setFk(QueryForeignKey.from(this, cf).to(VIRUS_CONTROL_AGGREGATES_TABLE_NAME, "RunId", "ControlWellgroup"));
         virusControlAggCol.setHidden(true);
         virusControlAggCol.setIsUnselectable(true);
-        virusControlAggCol.setKeyField(false); // Ticket 42587
+        virusControlAggCol.setKeyField(false); // Issue 42620
         runTable.addColumn(virusControlAggCol);
 
         return runTable;


### PR DESCRIPTION
#### Rationale
Issue [42620](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42620): Nab assay runs perf issue with cell and virus control aggregate joins always being included in generated SQL

Note: discussed with Matt, and the plan is to open a PR against develop which will set the "setPrimaryKey(false)" in the AliasedColumn constructor.

#### Changes
* Explicitly set the aliased aggregate columns to `setIsUnselectable(true)` and `setKeyField(false)`
