### PR TITLE
Fix intermittent failure saving Luminex QC flags

### DIFF
--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
@@ -625,15 +625,15 @@ public final class LuminexGuideSetTest extends LuminexTest
         click(l);
         _extHelper.waitForExt3Mask(WAIT_FOR_JAVASCRIPT);
 
-        sleep(1500);
-        waitForText("Run QC Flags");
+        _extHelper.waitForExtDialog("Run QC Flags");
 
         for(String flag : flags)
         {
-            Locator aucCheckBox = Locator.xpath("//div[text()='" + flag + "']/../../td/div/div[contains(@class, 'check')]");
+            Locator.XPathLocator aucCheckBox = Locator.xpath("//div[text()='" + flag + "']/../../td/div/div[contains(@class, 'check')]");
             click(aucCheckBox);
+            aucCheckBox.parent().parent("td").withClass("x-grid3-dirty-cell").waitForElement(shortWait());
         }
 
-        clickButton("Save");
+        clickAndWait(Locator.extButtonEnabled("Save").waitForElement(getDriver(), 1000));
     }
 }

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -40,6 +40,7 @@ import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.luminex.LuminexImportWizard;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ExtHelper;
+import org.labkey.test.util.LabKeyExpectedConditions;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.PipelineStatusTable;
@@ -705,7 +706,8 @@ public abstract class LuminexTest extends BaseWebDriverTest
         //verify unchecking a box  removes the flag
         Locator aucCheckBox = Locator.xpath("//div[text()='AUC']/../../td/div/div[contains(@class, 'check')]");
         click(aucCheckBox);
-        Locator.extButtonEnabled("Save").waitForElement(getDriver(), 1000).click();
+        shortWait().until(LabKeyExpectedConditions
+            .clickUntilStale(Locator.extButtonEnabled("Save").waitForElement(getDriver(), 1000)));
         _extHelper.waitForExt3MaskToDisappear(WAIT_FOR_JAVASCRIPT);
 
         Locator strikeoutAUC = Locator.xpath("//span[contains(@style, 'line-through') and  text()='AUC']");
@@ -715,7 +717,8 @@ public abstract class LuminexTest extends BaseWebDriverTest
         click(strikeoutAUC);
         _extHelper.waitForExt3Mask(WAIT_FOR_JAVASCRIPT);
         waitAndClick(aucCheckBox);
-        Locator.extButtonEnabled("Save").waitForElement(getDriver(), 1000).click();
+        shortWait().until(LabKeyExpectedConditions
+            .clickUntilStale(Locator.extButtonEnabled("Save").waitForElement(getDriver(), 1000)));
         _extHelper.waitForExt3MaskToDisappear(WAIT_FOR_JAVASCRIPT);
         waitForText(expectedFlag);
         assertElementNotPresent(strikeoutAUC);

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -705,7 +705,7 @@ public abstract class LuminexTest extends BaseWebDriverTest
         //verify unchecking a box  removes the flag
         Locator aucCheckBox = Locator.xpath("//div[text()='AUC']/../../td/div/div[contains(@class, 'check')]");
         click(aucCheckBox);
-        clickButton("Save", 0);
+        Locator.extButtonEnabled("Save").waitForElement(getDriver(), 1000).click();
         _extHelper.waitForExt3MaskToDisappear(WAIT_FOR_JAVASCRIPT);
 
         Locator strikeoutAUC = Locator.xpath("//span[contains(@style, 'line-through') and  text()='AUC']");
@@ -715,7 +715,7 @@ public abstract class LuminexTest extends BaseWebDriverTest
         click(strikeoutAUC);
         _extHelper.waitForExt3Mask(WAIT_FOR_JAVASCRIPT);
         waitAndClick(aucCheckBox);
-        clickButton("Save", 0);
+        Locator.extButtonEnabled("Save").waitForElement(getDriver(), 1000).click();
         _extHelper.waitForExt3MaskToDisappear(WAIT_FOR_JAVASCRIPT);
         waitForText(expectedFlag);
         assertElementNotPresent(strikeoutAUC);


### PR DESCRIPTION
#### Rationale
The test attempts to click save before ensuring that it is enabled. This causes some Luminex tests to fail fairly regularly.

#### Changes
* Wait for save button to be enabled in QC flag dialog

Dialog box:
![image](https://user-images.githubusercontent.com/5263798/110709387-f59f0a00-81b0-11eb-9b04-234c069ee4a9.png)

