### PR TITLE
Use ColumnDecorator to configure LabKey "column types"

### DIFF
--- a/elisa/src/org/labkey/elisa/query/CurveFitTable.java
+++ b/elisa/src/org/labkey/elisa/query/CurveFitTable.java
@@ -26,17 +26,9 @@ public class CurveFitTable extends FilteredTable<AssayProtocolSchema>
         {
             var newCol = addWrapColumn(col);
 
-            if (newCol.getName().equalsIgnoreCase("Container"))
-            {
-                ContainerForeignKey.initColumn(newCol, userSchema);
-            }
-            else if (newCol.getName().equalsIgnoreCase("RowId") || newCol.getName().equalsIgnoreCase("ProtocolId"))
+            if (newCol.getName().equalsIgnoreCase("RowId") || newCol.getName().equalsIgnoreCase("ProtocolId"))
             {
                 newCol.setHidden(true);
-            }
-            else if (newCol.getName().equalsIgnoreCase("CreatedBy") || newCol.getName().equalsIgnoreCase("ModifiedBy"))
-            {
-                UserIdForeignKey.initColumn(newCol);
             }
         }
         addCondition(getRealTable().getColumn("ProtocolId"), protocol.getRowId());

--- a/flow/src/org/labkey/flow/query/FlowSchema.java
+++ b/flow/src/org/labkey/flow/query/FlowSchema.java
@@ -393,8 +393,6 @@ public class FlowSchema extends UserSchema
         ret.addColumn(ExpRunTable.Column.CreatedBy);
 
         var containerCol = ret.addColumn(ExpRunTable.Column.Folder);
-        containerCol.setHidden(true);
-        ContainerForeignKey.initColumn(containerCol, this, null);
 
         var colLSID = ret.addColumn(ExpRunTable.Column.LSID);
         colLSID.setHidden(true);

--- a/ms2/src/org/labkey/ms2/query/RunTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/RunTableInfo.java
@@ -43,13 +43,9 @@ public class RunTableInfo extends FilteredTable<MS2Schema>
         DetailsURL url = new DetailsURL(new ActionURL(MS2Controller.ShowListAction.class, getContainer()));
         url.setContainerContext(new ContainerContext.FieldKeyContext(FieldKey.fromParts("Container")));
         var containerColumn = getMutableColumn("Container");
-        ContainerForeignKey.initColumn(containerColumn, _userSchema, null);
         containerColumn.setURL(url);
-        containerColumn.setHidden(true);
 
         var folderColumn = wrapColumn("Folder", getRealTable().getColumn("Container"));
-        folderColumn.setHidden(false);
-        ContainerForeignKey.initColumn(folderColumn, _userSchema, null);
         folderColumn.setURL(url);
         addColumn(folderColumn);
 

--- a/nab/src/org/labkey/nab/query/NabRunDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabRunDataTable.java
@@ -26,6 +26,7 @@ import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
@@ -404,7 +405,7 @@ public class NabRunDataTable extends NabBaseTable
         }
     }
 
-    private static void updateLabelWithCutoff(BaseColumnInfo column, Integer intCutoff)
+    private static void updateLabelWithCutoff(MutableColumnInfo column, Integer intCutoff)
     {
         if (null != intCutoff)
         {

--- a/nab/src/org/labkey/nab/query/NabVirusDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabVirusDataTable.java
@@ -93,10 +93,6 @@ public class NabVirusDataTable extends FilteredTable<AssayProtocolSchema> implem
             {
                 col.setHidden(true);
             }
-            else if ("Container".equalsIgnoreCase(col.getName()))
-            {
-                ContainerForeignKey.initColumn(col, schema);
-            }
 
             DomainProperty domainProperty = _virusDomain.getPropertyByName(baseColumn.getName());
             if (domainProperty != null)


### PR DESCRIPTION
#### Rationale
We inconsistently set up certain common "column types" e.g. ParticipantId or Container.  Use the existing ConceptURI property to register ColumnDecorators that configure these columns.

#### Related Pull Requests
https://github.com/LabKey/commonAssays/pull/316
https://github.com/LabKey/dataintegration/pull/98
https://github.com/LabKey/MaxQuant/pull/37
https://github.com/LabKey/platform/pull/2121
https://github.com/LabKey/sampleManagement/pull/528