### PR TITLE
42884: show sample join fields and values

### DIFF
--- a/flow/src/org/labkey/flow/controllers/protocol/showSamples2.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/showSamples2.jsp
@@ -81,7 +81,7 @@
     <%=link("Create sample type").href(protocol.urlCreateSampleType())%><br>
 <% } else { %>
 <p>
-There are <a href="<%=h(st.detailsURL())%>"><%=sampleCount%> sample descriptions</a> in this folder.<br>
+There are <a id="all-samples" href="<%=h(st.detailsURL())%>"><%=sampleCount%> sample descriptions</a> in this folder.<br>
 
 <% if (sampleTypeJoinFields.size() == 0) { %>
 <p>
@@ -127,7 +127,7 @@ There are <a href="<%=h(st.detailsURL())%>"><%=sampleCount%> sample descriptions
         <td style="background-color:#ddd;padding:0.5em;" colspan="<%=colCount%>">
             <b>Linked Samples and FCSFiles</b>
             <small>
-                &mdash; <a href="<%=h(urlFcsFilesWithSamples)%>"><%=linkedFCSFileCount%> FCS Files</a> are joined with samples<br>
+                &mdash; <a id="linked-fcsfiles" href="<%=h(urlFcsFilesWithSamples)%>"><%=linkedFCSFileCount%> FCS Files</a> are joined with samples<br>
             </small>
         </td>
     </tr>
@@ -193,7 +193,7 @@ There are <a href="<%=h(st.detailsURL())%>"><%=sampleCount%> sample descriptions
             <b>Unlinked Samples</b>
             <small>
                 &mdash;
-                <a href="<%=h(urlUnlinkedSamples)%>"><%=unlinkedSampleIds.size()%> samples</a> <%=text(unlinkedSampleIds.size() == 1 ? "is" : "are")%> not joined to any FCS Files<br>
+                <a id="unlinked-samples" href="<%=h(urlUnlinkedSamples)%>"><%=unlinkedSampleIds.size()%> samples</a> <%=text(unlinkedSampleIds.size() == 1 ? "is" : "are")%> not joined to any FCS Files<br>
             </small>
         </td>
     </tr>
@@ -232,7 +232,7 @@ There are <a href="<%=h(st.detailsURL())%>"><%=sampleCount%> sample descriptions
             <b>Unlinked FCSFiles</b>
             <small>
                 &mdash;
-                <a href="<%=h(urlFcsFilesWithoutSamples)%>"><%=unlinkedFcsFileIds.size()%> FCS Files</a> are not joined with any samples<br>
+                <a id="unlinked-fcsfiles" href="<%=h(urlFcsFilesWithoutSamples)%>"><%=unlinkedFcsFileIds.size()%> FCS Files</a> are not joined with any samples<br>
             </small>
         </td>
     </tr>

--- a/flow/src/org/labkey/flow/controllers/protocol/showSamples2.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/showSamples2.jsp
@@ -26,12 +26,15 @@
 <%@ page import="org.labkey.flow.controllers.protocol.ProtocolForm" %>
 <%@ page import="org.labkey.flow.controllers.well.WellController" %>
 <%@ page import="org.labkey.flow.data.FlowProtocol" %>
+<%@ page import="org.labkey.flow.data.FlowProtocol.FCSFilesGroupedBySample" %>
 <%@ page import="org.labkey.flow.query.FlowTableType" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.LinkedHashMap" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="static org.labkey.api.data.CompareType.IN" %>
+<%@ page import="org.labkey.flow.controllers.run.RunController" %>
+<%@ page import="org.labkey.flow.controllers.FlowParam" %>
 <%@ page extends="org.labkey.api.jsp.FormPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -41,41 +44,23 @@
 
     ExperimentUrls expUrls = urlProvider(ExperimentUrls.class);
 
-    Map<Pair<Integer, String>, List<Pair<Integer, String>>> fcsFilesBySample = protocol.getFCSFilesGroupedBySample(getUser(), getContainer());
-    Map<Pair<Integer, String>, List<Pair<Integer,String>>> linkedSamples = new LinkedHashMap<>();
-    List<Pair<Integer,String>> unlinkedSamples = new ArrayList<>();
-    List<Pair<Integer,String>> unlinkedFCSFiles = new ArrayList<>();
-    List<Integer> unlinkedSampleIds = new ArrayList<>();
+    var nameFieldKey = FieldKey.fromParts("Name");
 
-    int linkedFCSFileCount = 0;
-    for (Pair<Integer, String> sample : fcsFilesBySample.keySet())
-    {
-        List<Pair<Integer, String>> fcsFiles = fcsFilesBySample.get(sample);
-        if (sample.first == null)
-        {
-            unlinkedFCSFiles.addAll(fcsFiles);
-            continue;
-        }
+    var sampleTypeJoinFields = protocol.getSampleTypeJoinFields();
 
-        int fcsFileCount = 0;
-        for (Pair<Integer, String> fcsFile : fcsFiles)
-        {
-            if (fcsFile.first != null)
-                fcsFileCount++;
-        }
+    FCSFilesGroupedBySample fcsFilesBySample = protocol.getFCSFilesGroupedBySample(getUser(), getContainer());
+    var samples = fcsFilesBySample.samples;
+    var fcsFiles = fcsFilesBySample.fcsFiles;
+    var fcsFileRuns = fcsFilesBySample.fcsFileRuns;
+    var linkedSampleIdToFcsFileIds = fcsFilesBySample.linkedSampleIdToFcsFileIds;
+    var unlinkedSampleIds = fcsFilesBySample.unlinkedSampleIds;
+    var unlinkedFcsFileIds = fcsFilesBySample.unlinkedFcsFileIds;
+    var linkedFCSFileCount = fcsFilesBySample.linkedFcsFileCount;
+    var fcsFileFields = fcsFilesBySample.fcsFileFields;
+    var sampleFields = fcsFilesBySample.sampleFields;
 
-        if (fcsFileCount == 0)
-        {
-            unlinkedSamples.add(sample);
-            unlinkedSampleIds.add(sample.getKey());
-            continue;
-        }
-
-        linkedFCSFileCount += fcsFileCount;
-        linkedSamples.put(sample, fcsFiles);
-    }
-
-    int sampleCount = linkedSamples.size() + unlinkedSamples.size();
+    int sampleCount = samples.size();
+    int colCount = sampleFields.size() + 1 + fcsFileFields.size() + 1;
 
     ActionURL urlFcsFilesWithSamples = FlowTableType.FCSFiles.urlFor(getUser(), getContainer(), QueryAction.executeQuery)
             .addParameter("query.Sample/Name~isnonblank", "");
@@ -98,129 +83,192 @@
 <p>
 There are <a href="<%=h(st.detailsURL())%>"><%=sampleCount%> sample descriptions</a> in this folder.<br>
 
-<% if (protocol.getSampleTypeJoinFields().size() == 0) { %>
+<% if (sampleTypeJoinFields.size() == 0) { %>
 <p>
     <%=link("Join samples to FCS File Data").href(protocol.urlFor(JoinSampleTypeAction.class))%><br>
     No sample join fields have been defined yet.  The samples are linked to the FCS files using keywords.  When new samples are added or FCS files are loaded, new links will be created.
 <% } else { %>
-
-    <% if (unlinkedSamples.size() > 0) { %>
-    <a href="<%=h(urlUnlinkedSamples)%>"><%=unlinkedSamples.size()%> <%=text(unlinkedSamples.size() == 1 ? "sample is" : "samples are")%> not joined</a> to any FCS Files. <br>
+    Samples are joined to FCSFiles by the following properties (<a href="<%=h(protocol.urlFor(JoinSampleTypeAction.class))%>">edit</a>):
+<ul>
+    <% for (var entry : sampleTypeJoinFields.entrySet()) { %>
+    <li>Sample <%=h(entry.getKey())%> => FCSFile <%=h(entry.getValue())%></li>
     <% } %>
-    <a href="<%=h(urlFcsFilesWithSamples)%>"><%=linkedFCSFileCount%> FCS Files</a> have been joined with a sample.<br>
-    <a href="<%=h(urlFcsFilesWithoutSamples)%>"><%=unlinkedFCSFiles.size()%> FCS Files</a> are not joined with any samples.<br>
+</ul>
+<br>
 
-    <table style="border-collapse: separate; border-spacing: 15px;">
-        <tr>
-            <td valign="top">
-                <h3>Linked Samples</h3>
+<style>
+    #flow-sample-fcsfiles {
+        border-collapse: separate;
+    }
+    #flow-sample-fcsfiles th {
+        position: sticky;
+        top: 0;
+        box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.4);
+        background-color: white;
+        border-right: 1px solid #d3d3d3;
+    }
+</style>
+<table id="flow-sample-fcsfiles" class="labkey-data-region-legacy labkey-show-borders" width="100%" style="min-width: 300px">
+    <thead>
+    <tr>
+        <th class="labkey-column-header"><b>Sample Name</b></th>
+        <% for (var sampleField : sampleFields) { %>
+        <th class="labkey-column-header"><%=h(sampleField)%></th>
+        <% } %>
+        <th class="labkey-column-header"><b>FCS Files (Run)</b></th>
+        <% for (var fcsFileField : fcsFileFields) { %>
+        <th class="labkey-column-header"><%=h(fcsFileField)%></th>
+        <% } %>
+    </tr>
+    </thead>
 
-    <table class="labkey-data-region-legacy labkey-show-borders" width="100%" style="min-width: 300px">
-        <thead>
-        <tr>
-            <td class="labkey-column-header">Sample Name</td>
-            <td class="labkey-column-header">FCS Files</td>
-        </tr>
-        </thead>
+    <tbody>
+    <tr class="labkey-row">
+        <td style="background-color:#ddd;padding:0.5em;" colspan="<%=colCount%>">
+            <b>Linked Samples and FCSFiles</b>
+            <small>
+                &mdash; <a href="<%=h(urlFcsFilesWithSamples)%>"><%=linkedFCSFileCount%> FCS Files</a> are joined with samples<br>
+            </small>
+        </td>
+    </tr>
+    <% if (linkedSampleIdToFcsFileIds.isEmpty()) { %>
+    <tr>
+        <td colspan="<%=colCount%>">
+            <em>No data to show.</em>
+        </td>
+    </tr>
+    <% } %>
     <%
         int i = 0;
-        for (Pair<Integer, String> sample : linkedSamples.keySet())
+        for (Map.Entry<Integer, List<Integer>> entry : linkedSampleIdToFcsFileIds.entrySet())
         {
             i++;
-            List<Pair<Integer, String>> fcsFiles = fcsFilesBySample.get(sample);
-            int fcsFileCount = fcsFiles.size();
-            %>
-        <tr class="<%=getShadeRowClass(i)%>">
-            <td valign="top">
-                <a href="<%=h(expUrls.getMaterialDetailsURL(getContainer(), sample.first))%>"><%=h(sample.second)%></a>
-                (<%=fcsFileCount%>)
-            </td>
-            <td>
+            List<Integer> fcsFileIds = entry.getValue();
+            var sampleId = entry.getKey();
+            var sample = samples.get(entry.getKey());
+            String sampleName = (String)sample.get(nameFieldKey);
+    %>
+    <tr class="<%=getShadeRowClass(i)%>">
+        <td valign="top">
+            <a href="<%=h(expUrls.getMaterialDetailsURL(getContainer(), sampleId))%>"><%=h(sampleName)%></a>
+        </td>
+        <% for (var sampleField : sampleFields) { %>
+        <td valign="top"><%=h(sample.get(sampleField))%></td>
+        <% } %>
+        <td>
             <%
-                for (Pair<Integer, String> fcsFile : fcsFiles)
+                for (Integer fcsFileId : fcsFileIds)
                 {
-                    if (fcsFile.first != null)
-                    {
-                        %><a href="<%=h(new ActionURL(WellController.ShowWellAction.class, getContainer()).addParameter("wellId", fcsFile.first))%>"><%=h(fcsFile.second)%></a><br><%
-                    }
+                    var fcsFile = fcsFiles.get(fcsFileId);
+                    String fcsFileName = (String)fcsFile.get(nameFieldKey);
+                    var fcsFileRun = fcsFileRuns.get(fcsFileId);
+            %><a href="<%=h(new ActionURL(WellController.ShowWellAction.class, getContainer()).addParameter(FlowParam.wellId, fcsFileId))%>"><%=h(fcsFileName)%></a>
+            <% if (fcsFileRun != null) { %>
+            (<a href="<%=h(new ActionURL(RunController.ShowRunAction.class, getContainer()).addParameter(FlowParam.runId, fcsFileRun.first))%>"><%=h(fcsFileRun.second)%></a>)
+            <% } %>
+            <br><%
                 }
-            %>
-            </td>
-        </tr>
+        %>
+        </td>
+        <% for (var fcsFileField : fcsFileFields) { %>
+        <td valign="top">
             <%
+                for (Integer fcsFileId : fcsFileIds)
+                {
+                    var fcsFile = fcsFiles.get(fcsFileId);
+            %><%=h(fcsFile.get(fcsFileField))%><br><%
+            }
+        %>
+        </td>
+        <% } %>
+    </tr>
+    <%
         }
     %>
-        <tr class="labkey-col-total labkey-row">
-            <td>Count: <%=linkedSamples.size()%></td>
-            <td><%=linkedFCSFileCount%></td>
-        </tr>
-    </table>
+    </tbody>
 
-            </td>
-
-            <td valign="top">
-                <h3>Unlinked Samples</h3>
-                <table class="labkey-data-region-legacy labkey-show-borders" width="100%" style="min-width: 200px">
-                    <thead>
-                    <tr>
-                        <td class="labkey-column-header">Sample Name</td>
-                    </tr>
-                    </thead>
-                    <%
-                        int sampleIdx = 0;
-                        for (Pair<Integer,String> sample : unlinkedSamples)
-                        {
-                            sampleIdx++;
-                    %>
-                    <tr class="<%=getShadeRowClass(sampleIdx)%>">
-                        <td valign="top">
-                            <a href="<%=h(expUrls.getMaterialDetailsURL(getContainer(), sample.first))%>"><%=h(sample.second)%></a>
-                        </td>
-                    </tr>
-                    <% } %>
-                    <tr class="labkey-col-total labkey-row">
-                        <td>Count: <%=unlinkedSamples.size()%></td>
-                    </tr>
-                </table>
-            </td>
-
-            <td valign="top">
-                <h3>Unlinked FCSFiles</h3>
-                <table class="labkey-data-region-legacy labkey-show-borders" width="100%" style="min-width: 200px">
-                    <thead>
-                    <tr>
-                        <td class="labkey-column-header">FCSFile</td>
-                    </tr>
-                    </thead>
-                    <%
-                        int fcsFileIdx = 0;
-                        for (Pair<Integer,String> fcsFile : unlinkedFCSFiles)
-                        {
-                            fcsFileIdx++;
-                    %>
-                    <tr class="<%=getShadeRowClass(fcsFileIdx)%>">
-                        <td valign="top">
-                            <a href="<%=h(new ActionURL(WellController.ShowWellAction.class, getContainer()).addParameter("wellId", fcsFile.first))%>"><%=h(fcsFile.second)%></a>
-                        </td>
-                    </tr>
-                    <% } %>
-                    <tr class="labkey-col-total labkey-row">
-                        <td>Count: <%=unlinkedFCSFiles.size()%></td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
-
-    <p>
-        <%=link("Show sample type").href(st.detailsURL())%>"/><br>
-        <%=link("Upload more samples from a spreadsheet").href(protocol.urlUploadSamples())%><br>
-        <% if (protocol.getSampleTypeJoinFields().size() != 0) { %>
-        <%=link("Modify sample join fields").href(protocol.urlFor(JoinSampleTypeAction.class))%><br>
-        <% } else { %>
-        <%=link("Join samples to FCS File Data").href(protocol.urlFor(JoinSampleTypeAction.class))%><br>
+    <tbody>
+    <tr class="labkey-row">
+        <td style="background-color:#ddd;padding:0.5em;" colspan="<%=colCount%>">
+            <b>Unlinked Samples</b>
+            <small>
+                &mdash;
+                <a href="<%=h(urlUnlinkedSamples)%>"><%=unlinkedSampleIds.size()%> samples</a> <%=text(unlinkedSampleIds.size() == 1 ? "is" : "are")%> not joined to any FCS Files<br>
+            </small>
+        </td>
+    </tr>
+    <% if (unlinkedSampleIds.isEmpty()) { %>
+    <tr>
+        <td colspan="<%=colCount%>">
+            <em>No data to show.</em>
+        </td>
+    </tr>
+    <% } %>
+    <%
+        for (Integer sampleId : unlinkedSampleIds)
+        {
+            i++;
+            var sample = samples.get(sampleId);
+            String sampleName = (String) sample.get(nameFieldKey);
+    %>
+    <tr class="<%=getShadeRowClass(i)%>">
+        <td valign="top">
+            <a href="<%=h(expUrls.getMaterialDetailsURL(getContainer(), sampleId))%>"><%=h(sampleName)%></a>
+        </td>
+        <% for (var sampleField : sampleFields) { %>
+        <td><%=h(sample.get(sampleField))%></td>
         <% } %>
-    </p>
+        <td>&nbsp;</td>
+        <% for (var fcsFileField : fcsFileFields) { %>
+        <td valign="top">&nbsp;</td>
+        <% } %>
+    </tr>
+    <% } %>
+    </tbody>
+
+    <tbody>
+    <tr class="labkey-row">
+        <td style="background-color:#ddd;padding:0.5em;" colspan="<%=colCount%>">
+            <b>Unlinked FCSFiles</b>
+            <small>
+                &mdash;
+                <a href="<%=h(urlFcsFilesWithoutSamples)%>"><%=unlinkedFcsFileIds.size()%> FCS Files</a> are not joined with any samples<br>
+            </small>
+        </td>
+    </tr>
+    <% if (unlinkedFcsFileIds.isEmpty()) { %>
+    <tr>
+        <td colspan="<%=colCount%>">
+            <em>No data to show.</em>
+        </td>
+    </tr>
+    <% } %>
+    <%
+        for (Integer fcsFileId : unlinkedFcsFileIds)
+        {
+            i++;
+            Map<FieldKey, Object> fcsFile = fcsFiles.get(fcsFileId);
+            String fcsFileName = (String)fcsFile.get(nameFieldKey);
+    %>
+    <tr class="<%=getShadeRowClass(i)%>">
+        <td>&nbsp;</td>
+        <% for (var sampleField : sampleFields) { %>
+        <td valign="top">&nbsp;</td>
+        <% } %>
+        <td valign="top">
+            <a href="<%=h(new ActionURL(WellController.ShowWellAction.class, getContainer()).addParameter("wellId", fcsFileId))%>"><%=h(fcsFileName)%></a>
+        </td>
+        <% for (var fcsFileField : fcsFileFields) { %>
+        <td valign="top">
+            <%=h(fcsFile.get(fcsFileField))%>
+        </td>
+        <% } %>
+    </tr>
+    <% } %>
+    </tbody>
+
+</table>
+
     <% } %>
 
 <% } %>

--- a/flow/src/org/labkey/flow/data/FlowProtocol.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocol.java
@@ -773,7 +773,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
 
     public String getFCSAnalysisName(FlowWell well) throws SQLException
     {
-        FlowSchema schema = new FlowSchema(null, getContainer());
+        FlowSchema schema = new FlowSchema(User.getSearchUser(), getContainer());
         ExpDataTable table = schema.createFCSFileTable("fcsFiles", null);
         ColumnInfo colRowId = table.getColumn(ExpDataTable.Column.RowId);
         SimpleFilter filter = new SimpleFilter();

--- a/flow/src/org/labkey/flow/data/FlowRun.java
+++ b/flow/src/org/labkey/flow/data/FlowRun.java
@@ -459,7 +459,7 @@ public class FlowRun extends FlowObject<ExpRun>
     {
         if (protocol == null && settings == null)
             return getFCSFiles();
-        FlowSchema schema = new FlowSchema(null, getContainer());
+        FlowSchema schema = new FlowSchema(User.getSearchUser(), getContainer());
         schema.setRun(this);
         TableInfo table = schema.createFCSFileTable("FCSFiles", null);
         ColumnInfo colRowId = table.getColumn("RowId");


### PR DESCRIPTION
#### Rationale
The flow module can link FCSFiles to samples by one or more join fields.  The show samples page lists the samples and FCSFiles that have been linked as well as those unlinked.  However, it didn't show what the values were for each making it hard to understand why.  This patch changes the layout to include the join field criteria as well as displays the join field values for the samples and FCSFiles.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/693

![show-samples-cropped](https://user-images.githubusercontent.com/3923845/114105338-2634a980-98ff-11eb-9ac4-737d4e6a3bcd.png)
