### PR TITLE
Issue 42897: remove getDefaultSampleTypeMaterialLsidPrefix

### DIFF
--- a/microarray/src/org/labkey/api/study/assay/matrix/AbstractMatrixRunCreator.java
+++ b/microarray/src/org/labkey/api/study/assay/matrix/AbstractMatrixRunCreator.java
@@ -17,21 +17,21 @@ package org.labkey.api.study.assay.matrix;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AbstractAssayProvider;
+import org.labkey.api.assay.AssayDataCollector;
+import org.labkey.api.assay.AssayRunUploadContext;
+import org.labkey.api.assay.DefaultAssayRunCreator;
 import org.labkey.api.assay.matrix.AbstractMatrixDataHandler;
+import org.labkey.api.data.RemapCache;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpRun;
-import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.qc.DefaultTransformResult;
 import org.labkey.api.qc.TransformResult;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.ColumnDescriptor;
 import org.labkey.api.reader.TabLoader;
-import org.labkey.api.assay.AbstractAssayProvider;
-import org.labkey.api.assay.AssayDataCollector;
-import org.labkey.api.assay.AssayRunUploadContext;
-import org.labkey.api.assay.DefaultAssayRunCreator;
 import org.labkey.api.study.assay.ParticipantVisitResolverType;
 
 import java.io.File;
@@ -126,7 +126,12 @@ public abstract class AbstractMatrixRunCreator <ProviderType extends AbstractAss
     }
 
     @Override
-    protected void addInputMaterials(AssayRunUploadContext<ProviderType> context, Map<ExpMaterial, String> inputMaterials, ParticipantVisitResolverType resolverType) throws ExperimentException
+    protected void addInputMaterials(AssayRunUploadContext<ProviderType> context,
+                                     Map<ExpMaterial, String> inputMaterials,
+                                     ParticipantVisitResolverType resolverType,
+                                     @NotNull RemapCache cache,
+                                     @NotNull Map<Integer, ExpMaterial> materialCache)
+            throws ExperimentException
     {
         // Attach the materials found in the matrix file to the run
         try
@@ -140,9 +145,8 @@ public abstract class AbstractMatrixRunCreator <ProviderType extends AbstractAss
                 for (ColumnDescriptor col : cols)
                     columnNames.add(col.getColumnName());
 
-                Map<String, Integer> samplesMap = AbstractMatrixDataHandler.ensureSamples(context.getContainer(), context.getUser(), columnNames, getIdColumnName());
-                List<? extends ExpMaterial> materials = ExperimentService.get().getExpMaterials(samplesMap.values());
-                for (ExpMaterial material : materials)
+                Map<String, ExpMaterial> samplesMap = AbstractMatrixDataHandler.ensureSamples(context.getContainer(), context.getUser(), columnNames, getIdColumnName(), cache, materialCache);
+                for (ExpMaterial material : samplesMap.values())
                 {
                     // TODO: Check if there is some other role that might be useful (well id)
                     inputMaterials.put(material, getRoleName());

--- a/microarray/src/org/labkey/microarray/matrix/ExpressionMatrixAssayProvider.java
+++ b/microarray/src/org/labkey/microarray/matrix/ExpressionMatrixAssayProvider.java
@@ -22,11 +22,18 @@ import org.fhcrc.cpas.exp.xml.SimpleTypeNames;
 import org.fhcrc.cpas.exp.xml.SimpleValueType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AbstractAssayProvider;
+import org.labkey.api.assay.AssayDataType;
+import org.labkey.api.assay.AssayPipelineProvider;
+import org.labkey.api.assay.AssayProtocolSchema;
+import org.labkey.api.assay.AssayRunCreator;
+import org.labkey.api.assay.AssayTableMetadata;
+import org.labkey.api.assay.actions.AssayRunUploadForm;
+import org.labkey.api.assay.matrix.ColumnMappingProperty;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.PropertyType;
-import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentUrls;
@@ -40,15 +47,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QuerySchema;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.security.User;
-import org.labkey.api.assay.actions.AssayRunUploadForm;
-import org.labkey.api.assay.AbstractAssayProvider;
-import org.labkey.api.assay.AssayDataType;
-import org.labkey.api.assay.AssayPipelineProvider;
-import org.labkey.api.assay.AssayProtocolSchema;
-import org.labkey.api.assay.AssayRunCreator;
-import org.labkey.api.assay.AssayTableMetadata;
 import org.labkey.api.study.assay.ParticipantVisitResolverType;
-import org.labkey.api.assay.matrix.ColumnMappingProperty;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
@@ -62,7 +61,6 @@ import org.labkey.microarray.MicroarrayModule;
 import org.labkey.microarray.controllers.FeatureAnnotationSetController;
 import org.labkey.microarray.query.MicroarrayUserSchema;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -71,7 +69,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class ExpressionMatrixAssayProvider extends AbstractAssayProvider
-    {
+{
     public static final String NAME = "Expression Matrix";
     public static final String RESOURCE_NAME = "ExpressionMatrix";
 


### PR DESCRIPTION
#### Rationale
The default "Unspecified" SampleType has been deprecated since 19.1, but the `ExperimentService.getExpMaterials()` method could create new samples using the default SampleType's LSID prefix.  This PR removes `getExpMaterials` method as well as the public `SampleTypeService` methods related to the default SampleType.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2140
* https://github.com/LabKey/platform/pull/2174

#### Changes
- remove `SampleTypeService.getDefaultSampleTypeLsid()` and `getDefaultSampleTypeMaterialLsidPrefix()`
- remove `ExperimentService.getExpMaterials()` and usages in favor of `findExpMaterial()`
- unresolved samples during matrix assay import will be created in a SampleType, if possible