### PR TITLE
customize permission checks

### DIFF
--- a/luminex/src/org/labkey/luminex/LuminexController.java
+++ b/luminex/src/org/labkey/luminex/LuminexController.java
@@ -573,6 +573,12 @@ public class LuminexController extends SpringActionController
         }
 
         @Override
+        protected boolean canInsert(User user)
+        {
+            return getContainer().hasPermission(user, DesignAssayPermission.class);
+        }
+
+        @Override
         protected void validatePermission(User user, BindException errors)
         {
             checkPermissions();


### PR DESCRIPTION
#### Rationale
This recent PR https://github.com/LabKey/platform/pull/2193 introduced some additional checking of permissions for insert or update options. However, some actions don't test for the standard insert permission and instead test for an alternate permission:
- ImportDefaultValuesAction `DesignAssayPermission.class`

We need to override `canInsert` for those actions that require a different permission.



