### PR TITLE
Issue 42990: Allow the NabPopulateFitParametersPipelineJob to be rerun to attempt to populate NAbSpecimen FitParameters for previously failed runs

### DIFF
--- a/nab/src/org/labkey/nab/NAbPopulateFitParametersTask.java
+++ b/nab/src/org/labkey/nab/NAbPopulateFitParametersTask.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.nab;
+
+import org.apache.logging.log4j.Logger;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.pipeline.PipeRoot;
+import org.labkey.api.pipeline.PipelineService;
+import org.labkey.api.util.SystemMaintenance.MaintenanceTask;
+import org.labkey.api.view.ViewBackgroundInfo;
+import org.labkey.nab.pipeline.NabPopulateFitParametersPipelineJob;
+
+public class NAbPopulateFitParametersTask implements MaintenanceTask
+{
+    @Override
+    public String getDescription()
+    {
+        return "NAb Populate Fit Parameters Pipeline Job";
+    }
+
+    @Override
+    public String getName()
+    {
+        return "NabPopulateFitParametersPipelineJob";
+    }
+
+    @Override
+    public boolean isConfigurable()
+    {
+        return false;
+    }
+
+    @Override
+    public void run(Logger log)
+    {
+        try
+        {
+            ViewBackgroundInfo info = new ViewBackgroundInfo(ContainerManager.getRoot(), null, null);
+            PipeRoot root = PipelineService.get().findPipelineRoot(ContainerManager.getRoot());
+            PipelineService.get().queueJob(new NabPopulateFitParametersPipelineJob(info, root));
+        }
+        catch (Exception e)
+        {}
+    }
+}

--- a/nab/src/org/labkey/nab/NAbPopulateFitParametersTask.java
+++ b/nab/src/org/labkey/nab/NAbPopulateFitParametersTask.java
@@ -38,7 +38,7 @@ public class NAbPopulateFitParametersTask implements MaintenanceTask
     }
 
     @Override
-    public boolean isConfigurable()
+    public boolean isRecurring()
     {
         return false;
     }

--- a/nab/src/org/labkey/nab/NabModule.java
+++ b/nab/src/org/labkey/nab/NabModule.java
@@ -28,6 +28,7 @@ import org.labkey.api.module.ModuleContext;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.SystemMaintenance;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.nab.multiplate.CrossPlateDilutionNabAssayProvider;
 import org.labkey.nab.multiplate.CrossPlateDilutionNabDataHandler;
@@ -123,6 +124,8 @@ public class NabModule extends DefaultModule
         AssayFlagHandler.registerHandler(new SinglePlateDilutionNabAssayProvider(), handler);
 
         PropertyService.get().registerDomainKind(new NabVirusDomainKind());
+
+        SystemMaintenance.addTask(new NAbPopulateFitParametersTask());
     }
 
     @NotNull


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42990
The original NabPopulateFitParametersPipelineJob run as part of the NAb Java upgrade script in 20.11 failed on the client server for a couple of the assay protocols. This PR adds a try/catch around the run level data population of that pipeline job so that a single run failure doesn't prevent the data from being populated for the rest of the assay protocol. This PR also registers a new special system maintenance task as a way to re-queue this pipeline job manually.

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/326
* https://github.com/LabKey/platform/pull/2206

#### Changes
* add new NAbPopulateFitParametersTask to re-queue the NabPopulateFitParametersPipelineJob
* update NabPopulateFitParametersPipelineJob to add try/catch for the assay run data access exception handling
