### PR TITLE
Issue 43279: XML Metadata: GUI editor loses previous changes

### DIFF
--- a/flow/src/org/labkey/flow/data/FlowProtocol.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocol.java
@@ -324,7 +324,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
             return Collections.emptyMap();
         SamplesSchema schema = new SamplesSchema(user, getContainer());
 
-        ExpMaterialTable sampleTable = schema.getSampleTable(st, null);
+        TableInfo sampleTable = schema.getTable(st, null);
         List<ColumnInfo> selectedColumns = new ArrayList<>();
         ColumnInfo colRowId = sampleTable.getColumn(ExpMaterialTable.Column.RowId.toString());
         selectedColumns.add(colRowId);


### PR DESCRIPTION
#### Rationale
TableInfos should generally be created via UserSchema.getTable() which applies XML metadata by default, but callers can opt-out when we're wanting to diff the configuration against the "real" table as opposed to the customized table

Sample types and data classes were always applying the XML customizations, messing up the diffing, and making subsequent edits destructive of prior changes

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2330

#### Changes
* Let getTable() control how XML metadata is applied
* Make it harder to call methods that are for internal schema implementation…e types and data classes
