### PR TITLE
Update dependencies for 21.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Generated files
 */resources/credits/dependencies.txt
+*/resources/credits/jars.txt

--- a/elisa/build.gradle
+++ b/elisa/build.gradle
@@ -1,12 +1,22 @@
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.ExternalDependency
 
 plugins {
     id 'org.labkey.build.module'
 }
 
-dependencies {
-    external "org.apache.commons:commons-math3:${commonsMath3Version}"
-}
+BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
+                "org.apache.commons:commons-math3:${commonsMath3Version}",
+                "Commons Math",
+                "Apache",
+                "http://commons.apache.org/math/",
+                ExternalDependency.APACHE_2_LICENSE_NAME,
+                ExternalDependency.APACHE_2_LICENSE_URL,
+                "Lightweight, self-contained mathematics and statistics components"
+        )
+)
 
 BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
 

--- a/elisa/package-lock.json
+++ b/elisa/package-lock.json
@@ -2215,7 +2215,7 @@
     },
     "@labkey/api": {
       "version": "1.5.0",
-      "resolved": "http://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.5.0.tgz",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.5.0.tgz",
       "integrity": "sha1-iew0iZBBUdnxYA5Nk7QjuHHdAh4="
     },
     "@labkey/build": {

--- a/elisa/resources/credits/jars.txt
+++ b/elisa/resources/credits/jars.txt
@@ -1,4 +1,0 @@
-{table}
-Filename|Component|Version|Source|License|LabKey Dev|Purpose
-commons-math3-3.6.1.jar|Commons Math|3.6.1|{link:Apache|http://commons.apache.org/math/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|klum|Lightweight, self-contained mathematics and statistics components
-{table}

--- a/ms2/build.gradle
+++ b/ms2/build.gradle
@@ -1,12 +1,35 @@
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.ExternalDependency
 
 plugins {
    id 'org.labkey.build.module'
 }
 
 dependencies {
-   external("org.apache.httpcomponents:httpmime:${httpmimeVersion}")
-   external("org.ardverk:patricia-trie:${patriciaTrieVersion}")
+   BuildUtils.addExternalDependency(
+           project,
+           new ExternalDependency(
+                   "org.apache.httpcomponents:httpmime:${httpmimeVersion}",
+                   "Apache HTTP Mime",
+                   "Apache",
+                   "http://hc.apache.org/httpcomponents-client-ga",
+                   ExternalDependency.APACHE_2_LICENSE_NAME,
+                   ExternalDependency.APACHE_2_LICENSE_URL,
+                   "HTTP client for requests of remote servers"
+           )
+   )
+   BuildUtils.addExternalDependency(
+           project,
+           new ExternalDependency(
+                   "org.ardverk:patricia-trie:${patriciaTrieVersion}",
+                   "PATRICIA Trie",
+                   "PATRICIA Trie",
+                   "http://code.google.com/p/patricia-trie/",
+                   ExternalDependency.APACHE_2_LICENSE_NAME,
+                   ExternalDependency.APACHE_2_LICENSE_URL,
+                   "PATRICIA Trie data structure implementation"
+           )
+   )
    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
 

--- a/ms2/resources/credits/jars.txt
+++ b/ms2/resources/credits/jars.txt
@@ -1,5 +1,5 @@
 {table}
-Filename|Component|Version|Source|License|LabKey Dev|Purpose
-httpmime-4.5.3.jar|Apache HTTP Mime|4.5.3|{link:Apache|http://hc.apache.org/httpcomponents-client-ga}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|HTTP client for requests of remote servers
-patricia-trie-0.6.jar|PATRICIA Trie|0.6|{link:PATRICIA Trie|http://code.google.com/p/patricia-trie/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jeckels|PATRICIA Trie data structure implementation
+Filename|Component|Source|License|Purpose
+httpmime-4.5.13.jar|Apache HTTP Mime|{link:Apache|http://hc.apache.org/httpcomponents-client-ga}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|HTTP client for requests of remote servers
+patricia-trie-0.6.jar|PATRICIA Trie|{link:PATRICIA Trie|http://code.google.com/p/patricia-trie/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|PATRICIA Trie data structure implementation
 {table}

--- a/ms2/resources/credits/jars.txt
+++ b/ms2/resources/credits/jars.txt
@@ -1,5 +1,0 @@
-{table}
-Filename|Component|Source|License|Purpose
-httpmime-4.5.13.jar|Apache HTTP Mime|{link:Apache|http://hc.apache.org/httpcomponents-client-ga}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|HTTP client for requests of remote servers
-patricia-trie-0.6.jar|PATRICIA Trie|{link:PATRICIA Trie|http://code.google.com/p/patricia-trie/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|PATRICIA Trie data structure implementation
-{table}


### PR DESCRIPTION
#### Rationale
Keeping dependency versions updated.  We also take this opportunity to transition some of the modules to use the new `BuildUtils.addExternalDependency` method that provides the information to be used in populating the `jars.txt` file.  Because the file is now generated, it can be remove from and ignored by git.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/21
* https://github.com/LabKey/gradlePlugin/pull/126
* https://github.com/LabKey/platform/pull/2352

#### Changes
* Update various dependency versions
* Update `build.gradle` files to use `BuildUtils.addExternalDependency`
* Remove `jars.txt` files from git
