### PR TITLE
Issue38536: Fix button tooltip related test outages

### DIFF
--- a/luminex/src/org/labkey/luminex/LuminexController.java
+++ b/luminex/src/org/labkey/luminex/LuminexController.java
@@ -924,6 +924,7 @@ public class LuminexController extends SpringActionController
                     urlDelete.addParameter("rowId", protocolId);
                     ActionButton btnDelete = new ActionButton(urlDelete, "Delete");
                     btnDelete.setIconCls("trash");
+                    btnDelete.setTooltip("Delete");
                     btnDelete.setActionType(ActionButton.Action.POST);
                     btnDelete.setDisplayPermission(DeletePermission.class);
                     btnDelete.setRequiresSelection(true);


### PR DESCRIPTION
#### Rationale
The previous merge overlooked the existence of buttons setting their icon class using `setIconCls`. For all instances where this is the case, the tooltip must be set explicitly.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2383

#### Changes
* Add necessary calls to `setTooltip`
