### PR TITLE
Migrate use of boxed primitive constructors

### DIFF
--- a/ms2/gwtsrc/org/labkey/ms2/pipeline/client/ResidueModComposite.java
+++ b/ms2/gwtsrc/org/labkey/ms2/pipeline/client/ResidueModComposite.java
@@ -188,10 +188,9 @@ public abstract class ResidueModComposite extends SearchFormComposite
 
         for(String sig : modMap.values())
         {
-            Character res = new Character(sig.charAt(sig.length()-1));
+            Character res = sig.charAt(sig.length()-1);
             if(al.contains(res)) return "Two static residue modifications for the same residue.";
             al.add(res);
-
         }
         return "";
     }

--- a/ms2/src/org/labkey/ms2/pipeline/sequest/SequestParamsBuilder.java
+++ b/ms2/src/org/labkey/ms2/pipeline/sequest/SequestParamsBuilder.java
@@ -555,7 +555,7 @@ public abstract class SequestParamsBuilder
             }
             else
             {
-                defaultMods.remove(res);
+                defaultMods.remove(Character.valueOf(res));
                 workList.add(new ResidueMod(res, masses.get(i)));
             }
         }

--- a/ms2/src/org/labkey/ms2/pipeline/sequest/SequestParamsBuilder.java
+++ b/ms2/src/org/labkey/ms2/pipeline/sequest/SequestParamsBuilder.java
@@ -555,9 +555,8 @@ public abstract class SequestParamsBuilder
             }
             else
             {
-                defaultMods.remove(new Character(res));
+                defaultMods.remove(res);
                 workList.add(new ResidueMod(res, masses.get(i)));
-
             }
         }
         if(workList.size() > 6) Collections.singletonList("Sequest will only accept a max of 6 variable modifications.");

--- a/nab/src/org/labkey/nab/query/NabWellDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabWellDataTable.java
@@ -116,7 +116,7 @@ public class NabWellDataTable extends NabBaseTable
         for (int i = 0; i < rowCount; i++)
         {
             char chr = (char)('A' + i);
-            rowSql.append("\nWHEN ").append(row.getValueSql(ExprColumn.STR_TABLE_ALIAS)).append("=").append(i + 1).append(" THEN '").append(new Character(chr)).append("'");
+            rowSql.append("\nWHEN ").append(row.getValueSql(ExprColumn.STR_TABLE_ALIAS)).append("=").append(i + 1).append(" THEN '").append(chr).append("'");
         }
         rowSql.append("\nELSE '' END) ");
         SQLFragment colSql = new SQLFragment("CAST(");


### PR DESCRIPTION
#### Rationale
"Boxed primitive constructors" (e.g., `new Double(0.23457)`) have been deprecated since JDK 9 and marked for removal as of JDK 16. Migrate away from them to reduce warnings.