### PR TITLE
Issue 43832: MS2 peptide tables ignore ContainerFilter

### DIFF
--- a/ms2/src/org/labkey/ms2/query/MS2Schema.java
+++ b/ms2/src/org/labkey/ms2/query/MS2Schema.java
@@ -437,7 +437,7 @@ public class MS2Schema extends UserSchema
         {
             if (runType.getPeptideTableName().equalsIgnoreCase(name))
             {
-                return createPeptidesTable(ContainerFilter.current(getContainer()), runType);
+                return createPeptidesTable(cf, runType);
             }
         }
 


### PR DESCRIPTION
#### Rationale
The immutable TableInfo refactor accidentally hard-coded some peptide tables to always use the current container as the ContainerFilter

#### Changes
* Propagate the selected ContainerFilter into the table creation