### PR TITLE
fix handling of quadrant gate

### DIFF
--- a/flow/enginesrc/org/labkey/flow/analysis/model/FlowJo10_0_6Workspace.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/FlowJo10_0_6Workspace.java
@@ -118,7 +118,7 @@ public class FlowJo10_0_6Workspace extends PC75Workspace
         for (RectangleGateDimensionType dim : xRectangleGate.getDimensionArray())
         {
             axes.add(dim.getFcsDimension().getName());
-            lstMin.add(dim.isSetMin() ? dim.getMin() : Double.MIN_VALUE); // XXX: Comment in IntervalGate implies we use Float.MIN/MAX_VALUE instead
+            lstMin.add(dim.isSetMin() ? dim.getMin() : -Double.MAX_VALUE); // XXX: Comment in IntervalGate implies we use Float.MIN/MAX_VALUE instead
             lstMax.add(dim.isSetMax() ? dim.getMax() : Double.MAX_VALUE);
         }
 

--- a/flow/enginesrc/org/labkey/flow/analysis/model/PC75Workspace.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/PC75Workspace.java
@@ -97,7 +97,7 @@ public class PC75Workspace extends PCWorkspace
         for (RectangleGateDimensionType dim : xRectangleGate.getDimensionArray())
         {
             axes.add(dim.getParameter().getName());
-            lstMin.add(dim.isSetMin() ? dim.getMin() : Double.MIN_VALUE); // XXX: Comment in IntervalGate implies we use Float.MIN/MAX_VALUE instead
+            lstMin.add(dim.isSetMin() ? dim.getMin() : -Double.MAX_VALUE); // XXX: Comment in IntervalGate implies we use Float.MIN/MAX_VALUE instead
             lstMax.add(dim.isSetMax() ? dim.getMax() : Double.MAX_VALUE);
         }
 

--- a/flow/enginesrc/org/labkey/flow/analysis/util/LogicleRangeFunction.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/util/LogicleRangeFunction.java
@@ -37,6 +37,11 @@ public class LogicleRangeFunction extends AbstractRangeFunction
     {
         try
         {
+            // We need to prevent placeholder max values (Double.MAX_VALUE or Float.MAX_VALUE) from causing IllegalStateException
+            // one way to do that is to check ==Float.MAX_VALUE or ==Double.MAX_VALUE.
+            // We could also consider filtering out range>_logicle.T
+            if (Math.abs(range) >= Float.MAX_VALUE)
+                return range;
             return _logicle.scale(range);
         }
         catch (IllegalStateException e)


### PR DESCRIPTION
#### Rationale
Quadrant gates are interval gates with no limit on one edge (e.g. no max), so we use MAX_VALUE instead.  The logicle function does not like that.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
