### PR TITLE
Double.MAX_VALUE -> Float.MAX_VALUE everywhere

### DIFF
--- a/flow/enginesrc/org/labkey/flow/analysis/chart/DensityPlot.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/chart/DensityPlot.java
@@ -58,6 +58,11 @@ public class DensityPlot extends ContourPlot
         super(dataset, domainAxis, rangeAxis, colorBar);
     }
 
+    static int constrain(double x)
+    {
+        return (int)Math.min((double)Integer.MAX_VALUE/2,Math.max(-(double)Integer.MAX_VALUE/2,x));
+    }
+
     protected void drawLine(Graphics2D g2, Rectangle2D dataArea, double x1, double y1, double x2, double y2)
     {
         int prevX, prevY, nextX, nextY;
@@ -66,10 +71,10 @@ public class DensityPlot extends ContourPlot
             // quick bail on far out rectangle gate edges
             if (x1==x2 && Math.abs(x1) >= Float.MAX_VALUE || y1==y2 && Math.abs(y1) >= Float.MAX_VALUE)
                 return;
-            prevX = (int)getDomainAxis().valueToJava2D(x1, dataArea, RectangleEdge.BOTTOM);
-            prevY = (int)getRangeAxis().valueToJava2D(y1, dataArea, RectangleEdge.LEFT);
-            nextX = (int)getDomainAxis().valueToJava2D(x2, dataArea, RectangleEdge.BOTTOM);
-            nextY = (int)getRangeAxis().valueToJava2D(y2, dataArea, RectangleEdge.LEFT);
+            prevX = constrain(getDomainAxis().valueToJava2D(x1, dataArea, RectangleEdge.BOTTOM));
+            prevY = constrain(getRangeAxis().valueToJava2D(y1, dataArea, RectangleEdge.LEFT));
+            nextX = constrain(getDomainAxis().valueToJava2D(x2, dataArea, RectangleEdge.BOTTOM));
+            nextY = constrain(getRangeAxis().valueToJava2D(y2, dataArea, RectangleEdge.LEFT));
             g2.drawLine(prevX, prevY, nextX, nextY);
             return;
         }

--- a/flow/enginesrc/org/labkey/flow/analysis/chart/DensityPlot.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/chart/DensityPlot.java
@@ -63,6 +63,9 @@ public class DensityPlot extends ContourPlot
         int prevX, prevY, nextX, nextY;
         if (x1 == x2 || y1 == y2)
         {
+            // quick bail on far out rectangle gate edges
+            if (x1==x2 && Math.abs(x1) >= Float.MAX_VALUE || y1==y2 && Math.abs(y1) >= Float.MAX_VALUE)
+                return;
             prevX = (int)getDomainAxis().valueToJava2D(x1, dataArea, RectangleEdge.BOTTOM);
             prevY = (int)getRangeAxis().valueToJava2D(y1, dataArea, RectangleEdge.LEFT);
             nextX = (int)getDomainAxis().valueToJava2D(x2, dataArea, RectangleEdge.BOTTOM);

--- a/flow/enginesrc/org/labkey/flow/analysis/model/FlowJo10_0_6Workspace.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/FlowJo10_0_6Workspace.java
@@ -118,8 +118,8 @@ public class FlowJo10_0_6Workspace extends PC75Workspace
         for (RectangleGateDimensionType dim : xRectangleGate.getDimensionArray())
         {
             axes.add(dim.getFcsDimension().getName());
-            lstMin.add(dim.isSetMin() ? dim.getMin() : -Double.MAX_VALUE); // XXX: Comment in IntervalGate implies we use Float.MIN/MAX_VALUE instead
-            lstMax.add(dim.isSetMax() ? dim.getMax() : Double.MAX_VALUE);
+            lstMin.add(dim.isSetMin() ? dim.getMin() : -Float.MAX_VALUE);
+            lstMax.add(dim.isSetMax() ? dim.getMax() : Float.MAX_VALUE);
         }
 
         if (axes.size() == 1)

--- a/flow/enginesrc/org/labkey/flow/analysis/model/FlowJoWorkspace.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/FlowJoWorkspace.java
@@ -1090,7 +1090,7 @@ abstract public class FlowJoWorkspace extends Workspace
                 if ("7.2.5".equals(version))
                     assertEquals(1384.662, bifurcateCD8plusGate.getMax(), 0.001d);
                 else
-                    assertEquals(Double.MAX_VALUE, bifurcateCD8plusGate.getMax(), DELTA);
+                    assertEquals(Float.MAX_VALUE, bifurcateCD8plusGate.getMax(), DELTA);
             }
 
             Population CD4CD8ellipse = workspace.findPopulation(analysis, SubsetSpec.fromParts("CD4, CD8 ellipse"));

--- a/flow/enginesrc/org/labkey/flow/analysis/model/IntervalGate.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/IntervalGate.java
@@ -28,7 +28,7 @@ import org.labkey.flow.analysis.data.NumberArray;
  */
 public class IntervalGate extends RegionGate
 {
-    static final double MAX_VALUE = Float.MAX_VALUE;    // using Double.MAX_VALUE is likely to cause errors if anytone tries arithmetic
+    static final double MAX_VALUE = Float.MAX_VALUE;    // using Double.MAX_VALUE is likely to cause errors if anyone tries arithmetic
     String _axis;
     double _min;
     double _max;

--- a/flow/enginesrc/org/labkey/flow/analysis/model/PC75Workspace.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/PC75Workspace.java
@@ -97,8 +97,8 @@ public class PC75Workspace extends PCWorkspace
         for (RectangleGateDimensionType dim : xRectangleGate.getDimensionArray())
         {
             axes.add(dim.getParameter().getName());
-            lstMin.add(dim.isSetMin() ? dim.getMin() : -Double.MAX_VALUE); // XXX: Comment in IntervalGate implies we use Float.MIN/MAX_VALUE instead
-            lstMax.add(dim.isSetMax() ? dim.getMax() : Double.MAX_VALUE);
+            lstMin.add(dim.isSetMin() ? dim.getMin() : -Float.MAX_VALUE);
+            lstMax.add(dim.isSetMax() ? dim.getMax() : Float.MAX_VALUE);
         }
 
         if (axes.size() == 1)

--- a/flow/enginesrc/org/labkey/flow/analysis/model/Polygon.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/Polygon.java
@@ -25,10 +25,10 @@ public class Polygon implements Serializable
     public int len;
     public double[] X;
     public double[] Y;
-    public double xmin = Double.MAX_VALUE;
-    public double ymin = Double.MAX_VALUE;
-    public double xmax = -Double.MAX_VALUE;
-    public double ymax = -Double.MAX_VALUE;
+    public double xmin = Float.MAX_VALUE;
+    public double ymin = Float.MAX_VALUE;
+    public double xmax = -Float.MAX_VALUE;
+    public double ymax = -Float.MAX_VALUE;
 
     public Polygon()
     {

--- a/flow/enginesrc/org/labkey/flow/analysis/util/LogicleRangeFunction.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/util/LogicleRangeFunction.java
@@ -37,9 +37,7 @@ public class LogicleRangeFunction extends AbstractRangeFunction
     {
         try
         {
-            // We need to prevent placeholder max values (Double.MAX_VALUE or Float.MAX_VALUE) from causing IllegalStateException
-            // one way to do that is to check ==Float.MAX_VALUE or ==Double.MAX_VALUE.
-            // We could also consider filtering out range>_logicle.T
+            // We need to prevent placeholder max values from causing IllegalStateException
             if (Math.abs(range) >= Float.MAX_VALUE)
                 return range;
             return _logicle.scale(range);

--- a/flow/enginesrc/org/labkey/flow/analysis/web/ChannelData.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/web/ChannelData.java
@@ -135,10 +135,10 @@ class ChannelData
         List<Polygon> displayPolys = new ArrayList();
         if (polys.size() > 0)
         {
-            double xMin = Double.MAX_VALUE;
-            double xMax = -Double.MAX_VALUE;
-            double yMin = -Double.MAX_VALUE;
-            double yMax = Double.MAX_VALUE;
+            double xMin = Float.MAX_VALUE;
+            double xMax = -Float.MAX_VALUE;
+            double yMin = -Float.MAX_VALUE;
+            double yMax = Float.MAX_VALUE;
             for (Polygon poly : polys)
             {
                 for (Double x : poly.X)


### PR DESCRIPTION
#### Rationale
As a comment suggested Double.MAX_VALUE can cause arithmetic problems.  This proved to be true when using the "Logicle" transform.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
