### PR TITLE
FileFilter change to support usage of Paths

### DIFF
--- a/flow/src/org/labkey/flow/script/FCSDirectoryFileFilter.java
+++ b/flow/src/org/labkey/flow/script/FCSDirectoryFileFilter.java
@@ -15,13 +15,21 @@
  */
 package org.labkey.flow.script;
 
+import org.labkey.api.pipeline.file.FileAnalysisTaskPipeline;
 import org.labkey.flow.analysis.model.FCS;
 
 import java.io.File;
 import java.io.FileFilter;
+import java.nio.file.Path;
 
-public class FCSDirectoryFileFilter implements FileFilter
+public class FCSDirectoryFileFilter implements FileAnalysisTaskPipeline.FilePathFilter
 {
+    @Override
+    public boolean accept(Path path)
+    {
+        return accept(path.toFile());
+    }
+
     @Override
     public boolean accept(File dir)
     {

--- a/flow/src/org/labkey/flow/script/FlowPipelineProvider.java
+++ b/flow/src/org/labkey/flow/script/FlowPipelineProvider.java
@@ -139,7 +139,7 @@ public class FlowPipelineProvider extends PipelineProvider
         }
 
         // UNDONE: walk directory once instead of multiple times
-        File[] workspaces = directory.listFiles(new IsFlowJoWorkspaceFilter());
+        File[] workspaces = directory.listFiles((FileFilter)new IsFlowJoWorkspaceFilter());
         if (includeAll || (workspaces != null && workspaces.length > 0))
         {
             ActionURL importWorkspaceURL = new ActionURL(AnalysisScriptController.ImportAnalysisFromPipelineAction.class, context.getContainer());

--- a/ms2/src/org/labkey/ms2/pipeline/QuantitationAlgorithm.java
+++ b/ms2/src/org/labkey/ms2/pipeline/QuantitationAlgorithm.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJobException;
-import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.pipeline.WorkDirectory;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.Pair;
@@ -28,6 +27,7 @@ import org.labkey.ms2.pipeline.client.ParameterNames;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -72,13 +72,13 @@ public enum QuantitationAlgorithm
                 throw new PipelineJobException("Libra configuration files containing a space are not supported");
             }
             LibraProtocolFactory factory = new LibraProtocolFactory();
-            File result = factory.getProtocolFile(root, libraConfigName, false);
+            Path result = factory.getProtocolFile(root, libraConfigName, false);
             if (!NetworkDrive.exists(result))
             {
                 throw new PipelineJobException("Libra config file does not exist: " + result);
             }
-            wd.inputFile(result, true);
-            return new Pair<>(result, TPPTask.LIBRA_CONFIG_INPUT_ROLE);
+            wd.inputFile(result.toFile(), true);
+            return new Pair<>(result.toFile(), TPPTask.LIBRA_CONFIG_INPUT_ROLE);
     }};
 
     protected List<String> getCommonXpressQ3Params(Map<String, String> params, String pathMzXml)

--- a/ms2/test/src/org/labkey/test/ms2/AbstractMS2SearchEngineTest.java
+++ b/ms2/test/src/org/labkey/test/ms2/AbstractMS2SearchEngineTest.java
@@ -88,7 +88,7 @@ public abstract class AbstractMS2SearchEngineTest extends MS2TestBase
         log("View log file.");
 
         pushLocation();
-        clickAndWait(Locator.linkWithText(LOG_BASE_NAME + ".log"));
+        clickAndWait(Locator.linkContainingText(LOG_BASE_NAME).containing(".log")); //Filename Link has a time stamp
 
         log("Verify log.");
         assertTextPresent("search");


### PR DESCRIPTION
#### Rationale
New feature work to add support for using File Watchers on containers backed by Cloud pipeline roots. 
https://docs.google.com/document/d/1adCI1KteCV-vNuCJ6Okz1lVcsO6AgZIKXZeSSg2cKQ0/

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2663

#### Changes
* FileFilter change to support usage of Paths
