### PR TITLE
Hide archived assay designs

### DIFF
--- a/flow/src/org/labkey/flow/data/FlowAssayProvider.java
+++ b/flow/src/org/labkey/flow/data/FlowAssayProvider.java
@@ -219,7 +219,7 @@ public class FlowAssayProvider extends AbstractAssayProvider
     }
 
     @Override
-    public ExpProtocol createAssayDefinition(User user, Container container, String name, String description)
+    public ExpProtocol createAssayDefinition(User user, Container container, String name, String description, ExpProtocol.Status status)
     {
         // UNDONE: could just call FlowProtocol.ensureForContainer() ?
         throw new UnsupportedOperationException();


### PR DESCRIPTION
#### Rationale
Supports changes that provide a way for admins to archive an assay design. See [platform PR](https://github.com/LabKey/platform/pull/2719) for more details.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2719
* https://github.com/LabKey/sampleManagement/pull/732
* https://github.com/LabKey/biologics/pull/1036
* https://github.com/LabKey/labkey-ui-components/pull/659

#### Changes
* Add status column to exp.protocol table
