### PR TITLE
Study schema contextual roles

### DIFF
--- a/flow/src/org/labkey/flow/query/AttributeForeignKey.java
+++ b/flow/src/org/labkey/flow/query/AttributeForeignKey.java
@@ -52,7 +52,7 @@ abstract public class AttributeForeignKey<T extends Comparable<T>> extends Abstr
     @Override
     public TableInfo getLookupTableInfo()
     {
-        VirtualTable ret = new VirtualTable(FlowManager.get().getSchema(), null)
+        VirtualTable ret = new VirtualTable(FlowManager.get().getSchema(), null, (UserSchema)_sourceSchema)
         {
             @Override
             protected boolean isCaseSensitive()

--- a/flow/src/org/labkey/flow/query/FlowSchema.java
+++ b/flow/src/org/labkey/flow/query/FlowSchema.java
@@ -588,6 +588,7 @@ public class FlowSchema extends UserSchema
         @NotNull
         public SQLFragment getFromSQL()
         {
+            checkReadBeforeExecute();
             SQLFragment sqlFlowData = new SQLFragment();
 
             sqlFlowData.append("SELECT " + _expDataAlias + ".*,");
@@ -857,6 +858,12 @@ public class FlowSchema extends UserSchema
         }
 
         @Override
+        public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+        {
+            return _expData.hasPermission(user, perm);
+        }
+
+        @Override
         public UserSchema getUserSchema()
         {
             return FlowSchema.this;
@@ -1026,6 +1033,7 @@ public class FlowSchema extends UserSchema
             assert _container != null;
             assert _container.getId().equals(getContainer().getId());
 
+            checkReadBeforeExecute();
             SQLFragment where = new SQLFragment();
             SQLFragment filter = _filter.getSQLFragment(getSqlDialect());
             String and = " WHERE ";

--- a/luminex/src/org/labkey/luminex/query/AbstractExclusionTable.java
+++ b/luminex/src/org/labkey/luminex/query/AbstractExclusionTable.java
@@ -86,6 +86,7 @@ public abstract class AbstractExclusionTable extends AbstractLuminexTable
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
+        checkedPermissions.add(perm);
         return _userSchema.getContainer().hasPermission(user, perm);
     }
 

--- a/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
@@ -198,6 +198,7 @@ public class AnalyteSinglePointControlTable extends AbstractLuminexTable
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
+        checkedPermissions.add(perm);
         return (perm.equals(UpdatePermission.class) || perm.equals(ReadPermission.class))
                 && _userSchema.getContainer().hasPermission(user, perm);
     }

--- a/luminex/src/org/labkey/luminex/query/AnalyteTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteTable.java
@@ -148,6 +148,7 @@ public class AnalyteTable extends AbstractLuminexTable
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
+        checkedPermissions.add(perm);
         return (perm.equals(UpdatePermission.class) || perm.equals(ReadPermission.class))
                 && _userSchema.getContainer().hasPermission(user, perm);
     }

--- a/luminex/src/org/labkey/luminex/query/AnalyteTitrationTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteTitrationTable.java
@@ -232,6 +232,7 @@ public class AnalyteTitrationTable extends AbstractCurveFitPivotTable
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
+        checkedPermissions.add(perm);
         return (perm.equals(UpdatePermission.class) || perm.equals(ReadPermission.class))
                 && _userSchema.getContainer().hasPermission(user, perm);
     }

--- a/luminex/src/org/labkey/luminex/query/GuideSetCurveFitTable.java
+++ b/luminex/src/org/labkey/luminex/query/GuideSetCurveFitTable.java
@@ -91,6 +91,7 @@ public class GuideSetCurveFitTable extends VirtualTable<LuminexProtocolSchema> i
     @Override
     public SQLFragment getFromSQL()
     {
+        checkReadBeforeExecute();
         SQLFragment result = new SQLFragment("SELECT AVG(cf.EC50) AS EC50Average,\n");
         result.append(_userSchema.getDbSchema().getSqlDialect().getStdDevFunction());
         result.append("(cf.EC50) AS EC50StdDev, \n");

--- a/ms2/src/org/labkey/ms2/protein/query/CustomAnnotationTable.java
+++ b/ms2/src/org/labkey/ms2/protein/query/CustomAnnotationTable.java
@@ -125,6 +125,7 @@ public class CustomAnnotationTable extends FilteredTable<CustomAnnotationSchema>
     @Override @NotNull
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         if (!_includeSeqId)
             return super.getFromSQL(alias);
 

--- a/ms2/src/org/labkey/ms2/query/ComparePeptideTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/ComparePeptideTableInfo.java
@@ -142,6 +142,7 @@ public class ComparePeptideTableInfo extends VirtualTable<MS2Schema>
     @Override @NotNull
     public SQLFragment getFromSQL()
     {
+        checkReadBeforeExecute();
         SQLFragment result = new SQLFragment();
         result.append("SELECT InnerPeptide");
         for (MS2Run run : _runs)

--- a/ms2/src/org/labkey/ms2/query/CompareProteinProphetTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/CompareProteinProphetTableInfo.java
@@ -163,6 +163,7 @@ public class CompareProteinProphetTableInfo extends SequencesTableInfo<MS2Schema
     @Override @NotNull
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         String innerAlias = "_innerCPP";
         SQLFragment result = new SQLFragment();
         result.append("(SELECT * FROM ");

--- a/ms2/src/org/labkey/ms2/query/MS2Schema.java
+++ b/ms2/src/org/labkey/ms2/query/MS2Schema.java
@@ -973,7 +973,7 @@ public class MS2Schema extends UserSchema
             name = "bogusTable";
         }
 
-        rawTable = new VirtualTable(getDbSchema(), name)
+        rawTable = new VirtualTable(getDbSchema(), name, this)
         {
             @NotNull
             @Override
@@ -1016,7 +1016,7 @@ public class MS2Schema extends UserSchema
             public TableInfo getLookupTableInfo()
             {
                 // Create a junction query that connects normalized group ids with protein identifications
-                VirtualTable result = new VirtualTable(getDbSchema(), "InnerTable")
+                VirtualTable result = new VirtualTable(getDbSchema(), "InnerTable", MS2Schema.this)
                 {
                     @NotNull
                     @Override

--- a/ms2/src/org/labkey/ms2/query/SpectraCountTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/SpectraCountTableInfo.java
@@ -235,6 +235,7 @@ public class SpectraCountTableInfo extends VirtualTable<MS2Schema>
     @Override @NotNull
     public SQLFragment getFromSQL()
     {
+        checkReadBeforeExecute();
         SQLFragment sql = new SQLFragment();
         sql.append("SELECT\n");
         sql.append("f.run\n"); // FK

--- a/nab/src/org/labkey/nab/query/NabBaseTable.java
+++ b/nab/src/org/labkey/nab/query/NabBaseTable.java
@@ -100,8 +100,7 @@ public abstract class NabBaseTable extends FilteredTable<AssayProtocolSchema>
             @Override
             public TableInfo getLookupTableInfo()
             {
-                ExpRunTable expRunTable = AssayService.get().createRunTable(_protocol, provider, _schema.getUser(), _schema.getContainer(), getLookupContainerFilter());
-                return expRunTable;
+                return _schema.createRunsTable(getLookupContainerFilter());
             }
 
             @Override

--- a/nab/src/org/labkey/nab/query/NabControlAggregatesTable.java
+++ b/nab/src/org/labkey/nab/query/NabControlAggregatesTable.java
@@ -57,6 +57,7 @@ public class NabControlAggregatesTable extends VirtualTable<NabProtocolSchema> i
     @Override
     public SQLFragment getFromSQL()
     {
+        checkReadBeforeExecute();
         SQLFragment result = new SQLFragment("SELECT\n")
             .append("w.RunId,\n")
             .append("w.ControlWellgroup,\n")

--- a/nab/src/org/labkey/nab/query/NabRunDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabRunDataTable.java
@@ -393,7 +393,7 @@ public class NabRunDataTable extends NabBaseTable
                     @Override
                     public TableInfo getLookupTableInfo()
                     {
-                        AssayProtocolSchema protocolSchema = provider.createProtocolSchema(schema.getUser(), getContainer(), protocol, null);
+                        AssayProtocolSchema protocolSchema = NabRunDataTable.this._userSchema;
                         return protocolSchema.createTable(DilutionManager.VIRUS_TABLE_NAME, getContainerFilter());
                     }
                 };

--- a/nab/src/org/labkey/nab/query/NabVirusDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabVirusDataTable.java
@@ -205,9 +205,11 @@ public class NabVirusDataTable extends FilteredTable<AssayProtocolSchema> implem
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return (DeletePermission.class.isAssignableFrom(perm) || UpdatePermission.class.isAssignableFrom(perm) || ReadPermission.class.isAssignableFrom(perm)) &&
-                _provider.isEditableResults(_protocol) &&
-                _userSchema.getContainer().hasPermission(user, perm);
+        if (ReadPermission.class.isAssignableFrom(perm))
+            return _userSchema.getContainer().hasPermission(user, perm);
+        if (DeletePermission.class.isAssignableFrom(perm) || UpdatePermission.class.isAssignableFrom(perm))
+            return _provider.isEditableResults(_protocol) && _userSchema.getContainer().hasPermission(user, perm);
+        return false;
     }
 
     @Override

--- a/nab/src/org/labkey/nab/query/NabVirusDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabVirusDataTable.java
@@ -206,7 +206,7 @@ public class NabVirusDataTable extends FilteredTable<AssayProtocolSchema> implem
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         if (ReadPermission.class.isAssignableFrom(perm))
-            return _userSchema.getContainer().hasPermission(user, perm);
+            return _userSchema.getContainer().hasPermission(user, perm, _userSchema.getContextualRoles());
         if (DeletePermission.class.isAssignableFrom(perm) || UpdatePermission.class.isAssignableFrom(perm))
             return _provider.isEditableResults(_protocol) && _userSchema.getContainer().hasPermission(user, perm);
         return false;

--- a/viability/src/org/labkey/viability/ViabilityAssaySchema.java
+++ b/viability/src/org/labkey/viability/ViabilityAssaySchema.java
@@ -178,6 +178,7 @@ public class ViabilityAssaySchema extends AssayProtocolSchema
         @Override
         public SQLFragment getFromSQL(String alias)
         {
+            checkReadBeforeExecute();
             SQLFragment frag = new SQLFragment();
             frag.appendComment("<" + this.getClass().getSimpleName() + ".getFromSQL()>", getSqlDialect());
             frag.append(super.getFromSQL(alias));


### PR DESCRIPTION
#### Rationale
Flush out TableInfo.hasPermission(ReadPermission) implementations
use contextual roles for permission elevation (study schema)

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->