### PR TITLE
Use helper methods to wait for and switch browser windows

### DIFF
--- a/ms2/test/src/org/labkey/test/tests/ms2/MS2Test.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/MS2Test.java
@@ -1174,15 +1174,14 @@ public class MS2Test extends AbstractMS2ImportTest
         clickAndWait(Locator.linkWithText(ms2Run));
 
         click(Locator.linkWithText("Show Peptide Prophet Details"));
-        Object[] windows = getDriver().getWindowHandles().toArray();
-        getDriver().switchTo().window((String) windows[1]);
+        switchToWindow(1);
         waitForElement(Locator.tagWithAttribute("img", "alt", "Charge 3+ Cumulative Observed vs. Model"));
         assertEquals("Incorrect number of graphs", 1, getElementCount(Locator.tag("img").withAttributeContaining("src", WebTestHelper.buildRelativeUrl("ms2", "MS2VerifyProject/ms2folder", "showPeptideProphetSensitivityPlot"))));
         assertEquals("Incorrect number of graphs", 6, getElementCount(Locator.tag("img").withAttributeContaining("src", WebTestHelper.buildRelativeUrl("ms2", "MS2VerifyProject/ms2folder", "showPeptideProphetDistributionPlot"))));
         assertEquals("Incorrect number of graphs", 6, getElementCount(Locator.tag("img").withAttributeContaining("src", WebTestHelper.buildRelativeUrl("ms2", "MS2VerifyProject/ms2folder", "showPeptideProphetObservedVsModelPlot"))));
         assertTextPresent("PeptideProphet Details: ms2pipe/truncated (pepXML)");
         getDriver().close();
-        getDriver().switchTo().window((String) windows[0]);
+        switchToMainWindow();
     }
 
     //issue 12342

--- a/ms2/test/src/org/labkey/test/tests/ms2/XTandemTest.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/XTandemTest.java
@@ -182,8 +182,7 @@ public class XTandemTest extends AbstractXTandemTest
     {
         log("Test peptide details page");
         click(Locator.linkWithText(PEPTIDE2));
-        Object[] windows = getDriver().getWindowHandles().toArray();
-        getDriver().switchTo().window((String)windows[1]);
+        switchToWindow(1);
         waitForText("44.0215"); // Look for b3+ ions, populated bu JavaScript
         assertTextPresent(
                 "gi|4689022|ribosomal_protein_",  // Check for protein
@@ -192,7 +191,7 @@ public class XTandemTest extends AbstractXTandemTest
                 "87.0357",
                 "130.0499");
         getDriver().close();
-        getDriver().switchTo().window((String)windows[0]);
+        switchToMainWindow();
     }
 
     private void verifyPeptideCrosstab()


### PR DESCRIPTION
#### Rationale
Tests fail intermittently when the new window doesn't open quite fast enough.

#### Changes
* Use helper methods to wait for and switch browser windows
