### PR TITLE
support for flow subfolder samples to be scoped to the project level

### DIFF
--- a/flow/src/org/labkey/flow/controllers/protocol/EditICSMetadataForm.java
+++ b/flow/src/org/labkey/flow/controllers/protocol/EditICSMetadataForm.java
@@ -228,7 +228,7 @@ public class EditICSMetadataForm extends ProtocolForm
         }
 
         FieldKey sampleProperty = FieldKey.fromParts("FCSFile", "Sample");
-        ExpSampleType sampleType = getProtocol().getSampleType();
+        ExpSampleType sampleType = getProtocol().getSampleType(getUser());
         if (sampleType != null)
         {
             if (sampleType.hasNameAsIdCol())

--- a/flow/src/org/labkey/flow/controllers/protocol/JoinSampleTypeForm.java
+++ b/flow/src/org/labkey/flow/controllers/protocol/JoinSampleTypeForm.java
@@ -69,7 +69,7 @@ public class JoinSampleTypeForm extends ProtocolForm
     {
         LinkedHashMap<String,String> ret = new LinkedHashMap<>();
         ret.put("", "");
-        ExpSampleType sampleType = getProtocol().getSampleType();
+        ExpSampleType sampleType = getProtocol().getSampleType(getUser());
         if (sampleType != null)
         {
             if (sampleType.hasNameAsIdCol())

--- a/flow/src/org/labkey/flow/controllers/protocol/joinSampleType.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/joinSampleType.jsp
@@ -24,7 +24,7 @@
 <%
     JoinSampleTypeForm form = (JoinSampleTypeForm) __form;
 
-    if (form.getProtocol().getSampleType() == null)
+    if (form.getProtocol().getSampleType(getUser()) == null)
     {
         %>
         <p>You must first upload a sample type before specifying how to match samples to FCS files.</p>

--- a/flow/src/org/labkey/flow/controllers/protocol/showProtocol.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/showProtocol.jsp
@@ -21,22 +21,24 @@
 <%@ page import="org.labkey.flow.controllers.protocol.ProtocolForm" %>
 <%@ page import="org.labkey.flow.data.AttributeType" %>
 <%@ page import="org.labkey.flow.data.FlowProtocol" %>
+<%@ page import="org.labkey.api.exp.api.ExpSampleType" %>
 <%@ page extends="org.labkey.api.jsp.FormPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
     ProtocolForm form = (ProtocolForm) __form;
     FlowProtocol protocol = form.getProtocol();
+    ExpSampleType sampleType = protocol.getSampleType(getUser());
 %>
 <p>
     The Flow Protocol describes sample information and metadata about the experiment.
 </p>
 <p><b>Samples</b><br>
     Upload sample information and match samples with FCSFiles.<br>
-    <% if (protocol.getSampleType() == null) { %>
+    <% if (sampleType == null) { %>
         No samples have been uploaded in this folder.<br>
         <%=link("Create new sample type").href(protocol.urlCreateSampleType())%><br>
     <% } else { %>
-        <%=link("Show sample type").href(protocol.getSampleType().detailsURL())%><br>
+        <%=link("Show sample type").href(protocol.getSampleTypeDetailsURL(sampleType, getContainer()))%><br>
         <%=link("Show samples joined to FCS Files").href(protocol.urlShowSamples())%><br>
         <%=link("Upload more samples from a spreadsheet").href(protocol.urlUploadSamples())%><br>
         <% if (protocol.getSampleTypeJoinFields().size() != 0) { %>

--- a/flow/src/org/labkey/flow/controllers/protocol/showSamples2.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/showSamples2.jsp
@@ -19,28 +19,25 @@
 <%@ page import="org.labkey.api.exp.api.ExperimentUrls" %>
 <%@ page import="org.labkey.api.query.FieldKey" %>
 <%@ page import="org.labkey.api.query.QueryAction" %>
-<%@ page import="org.labkey.api.util.Pair" %>
 <%@ page import="org.labkey.api.util.URLHelper" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.flow.controllers.FlowParam" %>
 <%@ page import="org.labkey.flow.controllers.protocol.ProtocolController.JoinSampleTypeAction" %>
 <%@ page import="org.labkey.flow.controllers.protocol.ProtocolForm" %>
+<%@ page import="org.labkey.flow.controllers.run.RunController" %>
 <%@ page import="org.labkey.flow.controllers.well.WellController" %>
 <%@ page import="org.labkey.flow.data.FlowProtocol" %>
 <%@ page import="org.labkey.flow.data.FlowProtocol.FCSFilesGroupedBySample" %>
 <%@ page import="org.labkey.flow.query.FlowTableType" %>
-<%@ page import="java.util.ArrayList" %>
-<%@ page import="java.util.LinkedHashMap" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="static org.labkey.api.data.CompareType.IN" %>
-<%@ page import="org.labkey.flow.controllers.run.RunController" %>
-<%@ page import="org.labkey.flow.controllers.FlowParam" %>
 <%@ page extends="org.labkey.api.jsp.FormPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
     ProtocolForm form = (ProtocolForm) __form;
     FlowProtocol protocol = form.getProtocol();
-    ExpSampleType st = protocol.getSampleType();
+    ExpSampleType st = protocol.getSampleType(getUser());
 
     ExperimentUrls expUrls = urlProvider(ExperimentUrls.class);
 
@@ -81,7 +78,7 @@
     <%=link("Create sample type").href(protocol.urlCreateSampleType())%><br>
 <% } else { %>
 <p>
-There are <a id="all-samples" href="<%=h(st.detailsURL())%>"><%=sampleCount%> sample descriptions</a> in this folder.<br>
+There are <a id="all-samples" href="<%=h(protocol.getSampleTypeDetailsURL(st, getContainer()))%>"><%=sampleCount%> sample descriptions</a> in this folder.<br>
 
 <% if (sampleTypeJoinFields.size() == 0) { %>
 <p>

--- a/flow/src/org/labkey/flow/controllers/protocol/updateSamples.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/updateSamples.jsp
@@ -25,5 +25,5 @@
     <%= form.fileCount%> FCS files were linked to samples in this sample type.
 </p>
 <p><a href="<%=h(form.getProtocol().urlShowSamples())%>">Show linked samples</a><br>
-<a href="<%=h(form.getProtocol().getSampleType().detailsURL())%>">Show all samples</a><br>
+<a href="<%=h(form.getProtocol().getSampleType(getUser()).detailsURL())%>">Show all samples</a><br>
 <a href="<%=h(form.getProtocol().urlFor(ProtocolController.JoinSampleTypeAction.class))%>">Edit join properties</a></p>

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -1483,7 +1483,7 @@ public class FlowManager
         FlowProtocol protocol = FlowProtocol.getForContainer(c);
         if (protocol != null)
         {
-            ExpSampleType st = protocol.getSampleType();
+            ExpSampleType st = protocol.getSampleType(user);
             if (st != null)
             {
                 // put sample count at top-level since it isn't really specific to the protocol

--- a/flow/src/org/labkey/flow/query/FlowSchema.java
+++ b/flow/src/org/labkey/flow/query/FlowSchema.java
@@ -1556,7 +1556,7 @@ public class FlowSchema extends UserSchema
         ExpSampleType st = null;
         if (_protocol != null)
         {
-            st = _protocol.getSampleType();
+            st = _protocol.getSampleType(getUser());
         }
         var colMaterialInput = ret.addMaterialInputColumn("Sample", new SamplesSchema(getUser(), getContainer()), ExpMaterialRunInput.DEFAULT_ROLE, st);
         if (st == null)

--- a/flow/src/org/labkey/flow/reports/statPicker.jsp
+++ b/flow/src/org/labkey/flow/reports/statPicker.jsp
@@ -65,7 +65,7 @@
 
     Collection<String> sampleTypeProperties = new ArrayList<>();
     FlowProtocol protocol = FlowProtocol.ensureForContainer(getUser(), getContainer());
-    ExpSampleType sampleType = protocol.getSampleType();
+    ExpSampleType sampleType = protocol.getSampleType(getUser());
     if (sampleType != null)
     {
         for (DomainProperty dp : sampleType.getDomain().getProperties())

--- a/flow/src/org/labkey/flow/webparts/FlowOverview.java
+++ b/flow/src/org/labkey/flow/webparts/FlowOverview.java
@@ -413,11 +413,11 @@ public class FlowOverview extends Overview
         Step ret = new Step("Assign additional meanings to keywords", status);
         if (protocol != null)
         {
-            ExpSampleType st = protocol.getSampleType();
+            ExpSampleType st = protocol.getSampleType(getUser());
             if (st != null)
             {
                 StringBuilder sb = new StringBuilder();
-                sb.append("There are <a href=\"").append(h(protocol.urlShowSamples())).append("\">").append(st.getSamples(getContainer()).size()).append(" sample descriptions</a> in this folder.");
+                sb.append("There are <a href=\"").append(h(protocol.urlShowSamples())).append("\">").append(protocol.getSamples(st, getUser()).size()).append(" sample descriptions</a> in this folder.");
 
                 ret.setStatusHTML(sb.toString());
 

--- a/flow/src/org/labkey/flow/webparts/FlowSummary.jsp
+++ b/flow/src/org/labkey/flow/webparts/FlowSummary.jsp
@@ -76,8 +76,9 @@
     //int _flaggedCount = FlowManager.get().getFlaggedCount(c);
 
     FlowProtocol _protocol = FlowProtocol.getForContainer(c);
-    ExpSampleType _sampleType = _protocol != null ? _protocol.getSampleType() : null;
-    List<? extends ExpMaterial> _sampleTypeSamples = _sampleType == null ? null : _sampleType.getSamples(_sampleType.getContainer());
+    ExpSampleType _sampleType = _protocol != null ? _protocol.getSampleType(getUser()) : null;
+    List<? extends ExpMaterial> _sampleTypeSamples = _sampleType == null ? null : _protocol.getSamples(_sampleType, user);
+    ActionURL _sampleTypeDetailsUrl = _sampleType != null ? _protocol.getSampleTypeDetailsURL(_sampleType, getContainer()) : null;
 
     FlowScript[] _scripts = FlowScript.getAnalysisScripts(c);
     Arrays.sort(_scripts);
@@ -247,7 +248,7 @@
                          {
                       %>
                             "<tr>" +
-                            "<td colspan=2><a href='<%=h(_sampleType.detailsURL())%>'>More...</a></td>" +
+                            "<td colspan=2><a href='<%=h(_sampleTypeDetailsUrl)%>'>More...</a></td>" +
                             "</tr>" +
                       <%
                          }
@@ -257,7 +258,7 @@
         });
         </script>
         <div id="samples-div">
-            <a title="<%=h(_sampleType.getDescription())%>" href="<%=h(_sampleType.detailsURL())%>">Samples (<%=_sampleType.getSamples(_sampleType.getContainer()).size()%>)</a>
+            <a title="<%=h(_sampleType.getDescription())%>" href="<%=h(_sampleTypeDetailsUrl)%>">Samples (<%=_sampleTypeSamples.size()%>)</a>
         </div>
     <% } %>
 


### PR DESCRIPTION
#### Rationale
To support this feature request, we want to allow flow data to be integrated with sample metadata that is either scoped to the current folder or at the project level:

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=33109

#### Changes
- Flow folders can integrate with sample data that is scoped to either the current folder or the parent project level (assuming the user has read access)
- If in a sub folder and the sample definition is at the project level, new sample data will be added at the folder level
