### PR TITLE
Issue 44391: MS2 tables fail to propagate ContainerFilter across lookups

### DIFF
--- a/ms2/src/org/labkey/ms2/query/CompareProteinProphetTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/CompareProteinProphetTableInfo.java
@@ -92,7 +92,7 @@ public class CompareProteinProphetTableInfo extends SequencesTableInfo<MS2Schema
                     @Override
                     public TableInfo getLookupTableInfo()
                     {
-                         return new ProteinGroupTableInfo(_userSchema, getLookupContainerFilter(), false);
+                         return new ProteinGroupTableInfo(_userSchema, getContainerFilter(), false);
                     }
                 };
                 if (!_forExport)
@@ -113,7 +113,7 @@ public class CompareProteinProphetTableInfo extends SequencesTableInfo<MS2Schema
                 @Override
                 public TableInfo getLookupTableInfo()
                 {
-                    return new ProteinGroupTableInfo(_userSchema, getLookupContainerFilter(), false);
+                    return new ProteinGroupTableInfo(_userSchema, getContainerFilter(), false);
                 }
             });
             addColumn(proteinGroupIdColumn);

--- a/ms2/src/org/labkey/ms2/query/ITraqProteinQuantitationTable.java
+++ b/ms2/src/org/labkey/ms2/query/ITraqProteinQuantitationTable.java
@@ -16,6 +16,7 @@
 
 package org.labkey.ms2.query;
 
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.ms2.MS2Manager;
 
@@ -25,9 +26,9 @@ import org.labkey.ms2.MS2Manager;
  */
 public class ITraqProteinQuantitationTable extends FilteredTable<MS2Schema>
 {
-    public ITraqProteinQuantitationTable(MS2Schema schema)
+    public ITraqProteinQuantitationTable(MS2Schema schema, ContainerFilter cf)
     {
-        super(MS2Manager.getTableInfoITraqProteinQuantitation(), schema);
+        super(MS2Manager.getTableInfoITraqProteinQuantitation(), schema, cf);
         wrapAllColumns(true);
         getMutableColumn("ProteinGroupId").setHidden(true);
     }

--- a/ms2/src/org/labkey/ms2/query/MS2Schema.java
+++ b/ms2/src/org/labkey/ms2/query/MS2Schema.java
@@ -507,7 +507,7 @@ public class MS2Schema extends UserSchema
     public ProteinGroupTableInfo createProteinGroupsForRunTable(ContainerFilter cf, boolean includeFirstProteinColumn)
     {
         ProteinGroupTableInfo result = new ProteinGroupTableInfo(this, cf, includeFirstProteinColumn);
-        result.addProteinsColumn();
+        result.addProteinsColumn(cf);
         List<FieldKey> defaultColumns = new ArrayList<>(result.getDefaultVisibleColumns());
         defaultColumns.add(FieldKey.fromParts("Proteins", "Protein"));
         defaultColumns.add(FieldKey.fromParts("Proteins", "Protein", "BestGeneName"));
@@ -706,7 +706,7 @@ public class MS2Schema extends UserSchema
                 sql.append(")");
                 addCondition(sql, containerFieldKey);
             }
-        };
+    };
         result.wrapAllColumns(true);
         result.setTitleColumn("FileName");
 
@@ -740,7 +740,7 @@ public class MS2Schema extends UserSchema
             @Override
             public TableInfo getLookupTableInfo()
             {
-                return new RunTableInfo(MS2Schema.this);
+                return new RunTableInfo(MS2Schema.this, cf);
             }
         });
 

--- a/ms2/src/org/labkey/ms2/query/PeptidesTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/PeptidesTableInfo.java
@@ -194,7 +194,7 @@ public class PeptidesTableInfo extends FilteredTable<MS2Schema>
             @Override
             public TableInfo getLookupTableInfo()
             {
-                return _userSchema.createPeptideMembershipsTable(getLookupContainerFilter());
+                return _userSchema.createPeptideMembershipsTable(getContainerFilter());
             }
         });
         proteinGroup.setKeyField(false);
@@ -222,7 +222,7 @@ public class PeptidesTableInfo extends FilteredTable<MS2Schema>
         showProteinURL.deleteParameter("protein");
         final String showProteinURLString = showProteinURL.getLocalURIString() + "&seqId=${SeqId}&protein=${Protein}";
 
-        setupProteinColumns(showProteinURLString);
+        setupProteinColumns(showProteinURLString, containerFilter);
 
         ActionURL showPeptideURL = url.clone();
         showPeptideURL.setAction(MS2Controller.ShowPeptideAction.class);
@@ -250,7 +250,7 @@ public class PeptidesTableInfo extends FilteredTable<MS2Schema>
             @Override
             public TableInfo getLookupTableInfo()
             {
-                return _userSchema.createFractionsTable(getLookupContainerFilter());
+                return _userSchema.createFractionsTable(getContainerFilter());
             }
         });
 
@@ -386,14 +386,14 @@ public class PeptidesTableInfo extends FilteredTable<MS2Schema>
         }
     }
 
-    private void setupProteinColumns(final String showProteinURLString)
+    private void setupProteinColumns(final String showProteinURLString, ContainerFilter containerFilter)
     {
         LookupForeignKey fk = new LookupForeignKey("SeqId")
         {
             @Override
             public TableInfo getLookupTableInfo()
             {
-                SequencesTableInfo sequenceTable = new SequencesTableInfo(ProteinManager.getTableInfoSequences().getName(), _userSchema);
+                SequencesTableInfo<MS2Schema> sequenceTable = new SequencesTableInfo<>(ProteinManager.getTableInfoSequences().getName(), _userSchema, containerFilter);
                 SQLFragment fastaNameSQL = new SQLFragment(getName() + ".Protein");
                 ExprColumn fastaNameColumn = new ExprColumn(sequenceTable, "Database Sequence Name", fastaNameSQL, JdbcType.VARCHAR);
                 sequenceTable.addColumn(fastaNameColumn);

--- a/ms2/src/org/labkey/ms2/query/ProteinGroupTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/ProteinGroupTableInfo.java
@@ -86,8 +86,7 @@ public class ProteinGroupTableInfo extends FilteredTable<MS2Schema>
             @Override
             public TableInfo getLookupTableInfo()
             {
-                // TODO ContainerFilter
-                return new ProteinQuantitationTable(_userSchema);
+                return new ProteinQuantitationTable(_userSchema, cf);
             }
         });
         quantitation.setKeyField(false);
@@ -101,8 +100,7 @@ public class ProteinGroupTableInfo extends FilteredTable<MS2Schema>
             @Override
             public TableInfo getLookupTableInfo()
             {
-                // TODO ContainerFilter
-                return new ITraqProteinQuantitationTable(_userSchema);
+                return new ITraqProteinQuantitationTable(_userSchema, cf);
             }
         });
         iTraqQuantitation.setKeyField(false);
@@ -121,8 +119,7 @@ public class ProteinGroupTableInfo extends FilteredTable<MS2Schema>
             @Override
             public TableInfo getLookupTableInfo()
             {
-                // TODO ContainerFilter
-                return new ProteinProphetFileTableInfo(_userSchema);
+                return new ProteinProphetFileTableInfo(_userSchema, cf);
             }
         };
         foreignKey.setPrefixColumnCaption(false);
@@ -204,7 +201,7 @@ public class ProteinGroupTableInfo extends FilteredTable<MS2Schema>
         addCondition(condition, FieldKey.fromParts("RowId"));
     }
 
-    public void addProteinsColumn()
+    public void addProteinsColumn(ContainerFilter cf)
     {
         var proteinGroup = wrapColumn("Proteins", getRealTable().getColumn("RowId"));
         LookupForeignKey fk = new LookupForeignKey(getContainerFilter(), "ProteinGroupId", null)
@@ -212,9 +209,8 @@ public class ProteinGroupTableInfo extends FilteredTable<MS2Schema>
             @Override
             public TableInfo getLookupTableInfo()
             {
-                // TODO ContainerFilter
                 TableInfo info = MS2Manager.getTableInfoProteinGroupMemberships();
-                FilteredTable result = new FilteredTable<>(info, getUserSchema());
+                FilteredTable<?> result = new FilteredTable<>(info, getUserSchema(), cf);
                 for (ColumnInfo col : info.getColumns())
                 {
                     var newColumn = result.addWrapColumn(col);

--- a/ms2/src/org/labkey/ms2/query/ProteinProphetFileTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/ProteinProphetFileTableInfo.java
@@ -16,6 +16,7 @@
 
 package org.labkey.ms2.query;
 
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.LookupForeignKey;
@@ -29,9 +30,9 @@ import org.labkey.ms2.MS2Controller;
  */
 public class ProteinProphetFileTableInfo extends FilteredTable<MS2Schema>
 {
-    public ProteinProphetFileTableInfo(MS2Schema schema)
+    public ProteinProphetFileTableInfo(MS2Schema schema, ContainerFilter cf)
     {
-        super(MS2Manager.getTableInfoProteinProphetFiles(), schema);
+        super(MS2Manager.getTableInfoProteinProphetFiles(), schema, cf);
         wrapAllColumns(true);
 
         ActionURL url = MS2Controller.getShowRunURL(_userSchema.getUser(), getContainer());
@@ -40,7 +41,7 @@ public class ProteinProphetFileTableInfo extends FilteredTable<MS2Schema>
             @Override
             public TableInfo getLookupTableInfo()
             {
-                return new RunTableInfo(_userSchema);
+                return new RunTableInfo(_userSchema, cf);
             }
         });
     }

--- a/ms2/src/org/labkey/ms2/query/ProteinQuantitationTable.java
+++ b/ms2/src/org/labkey/ms2/query/ProteinQuantitationTable.java
@@ -16,6 +16,7 @@
 
 package org.labkey.ms2.query;
 
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.ms2.MS2Manager;
 
@@ -25,9 +26,9 @@ import org.labkey.ms2.MS2Manager;
  */
 public class ProteinQuantitationTable extends FilteredTable<MS2Schema>
 {
-    public ProteinQuantitationTable(MS2Schema schema)
+    public ProteinQuantitationTable(MS2Schema schema, ContainerFilter cf)
     {
-        super(MS2Manager.getTableInfoProteinQuantitation(), schema);
+        super(MS2Manager.getTableInfoProteinQuantitation(), schema, cf);
         wrapAllColumns(true);
         getMutableColumn("ProteinGroupId").setHidden(true);
     }

--- a/ms2/src/org/labkey/ms2/query/RunTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/RunTableInfo.java
@@ -16,6 +16,7 @@
 
 package org.labkey.ms2.query;
 
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerForeignKey;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.query.ExpSchema;
@@ -34,9 +35,9 @@ import org.labkey.ms2.MS2Manager;
  */
 public class RunTableInfo extends FilteredTable<MS2Schema>
 {
-    public RunTableInfo(MS2Schema schema)
+    public RunTableInfo(MS2Schema schema, ContainerFilter cf)
     {
-        super(MS2Manager.getTableInfoRuns(), schema);
+        super(MS2Manager.getTableInfoRuns(), schema, cf);
 
         wrapAllColumns(true);
 

--- a/ms2/src/org/labkey/ms2/query/SequencesTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/SequencesTableInfo.java
@@ -24,6 +24,7 @@ import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.ForeignKey;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MultiValuedForeignKey;
 import org.labkey.api.data.SQLFragment;
@@ -32,7 +33,6 @@ import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
-import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
@@ -46,7 +46,6 @@ import org.labkey.ms2.protein.CustomAnnotationType;
 import org.labkey.ms2.protein.ProteinManager;
 import org.labkey.ms2.protein.query.CustomAnnotationSchema;
 import org.labkey.ms2.protein.query.CustomAnnotationSetsTable;
-import org.labkey.ms2.protein.query.CustomAnnotationTable;
 import org.labkey.ms2.protein.query.ProteinUserSchema;
 
 import java.util.ArrayList;
@@ -112,7 +111,7 @@ public class SequencesTableInfo<SchemaType extends UserSchema> extends FilteredT
                         SQLFragment sql = new SQLFragment();
 
                         sql.append("(SELECT MIN(CustomAnnotationId) FROM ");
-                        sql.append(ProteinManager.getTableInfoCustomAnnotation());
+                        sql.append(ProteinManager.getTableInfoCustomAnnotation(), "ca");
                         CustomAnnotationType type = annotationSet.lookupCustomAnnotationType();
                         sql.append(" WHERE CustomAnnotationSetId = ? AND LookupString IN (");
                         sql.append(type.getLookupStringSelect(parent));
@@ -121,14 +120,12 @@ public class SequencesTableInfo<SchemaType extends UserSchema> extends FilteredT
                         ExprColumn ret = new ExprColumn(parent.getParentTable(), displayField,
                             sql, JdbcType.INTEGER, parent);
                         ret.setLabel(annotationSet.getName());
-                        ret.setFk(new LookupForeignKey("CustomAnnotationId")
-                        {
-                            @Override
-                            public TableInfo getLookupTableInfo()
-                            {
-                                return new CustomAnnotationTable(annotationSet, new CustomAnnotationSchema(_userSchema.getUser(), _userSchema.getContainer(), false), cf, false);
-                            }
-                        });
+                        ForeignKey fk = new QueryForeignKey.Builder(schema, cf).
+                                schema(CustomAnnotationSchema.SCHEMA_WITHOUT_SEQUENCES_NAME).
+                                table(annotationSet.getName()).
+                                key("CustomAnnotationId").
+                                build();
+                        ret.setFk(fk);
                         return ret;
                     }
                 }
@@ -162,7 +159,7 @@ public class SequencesTableInfo<SchemaType extends UserSchema> extends FilteredT
         for (CustomAnnotationType type : CustomAnnotationType.values())
         {
             SQLFragment sql = new SQLFragment(type.getFirstSelectForSeqId());
-            ExprColumn firstIdentColumn = new ExprColumn(this, "First" + type.toString(), sql, JdbcType.VARCHAR);
+            ExprColumn firstIdentColumn = new ExprColumn(this, "First" + type, sql, JdbcType.VARCHAR);
             firstIdentColumn.setLabel("First " + type.getDescription());
             addColumn(firstIdentColumn);
         }
@@ -194,39 +191,24 @@ public class SequencesTableInfo<SchemaType extends UserSchema> extends FilteredT
     public void addPeptideAggregationColumns()
     {
         var aaColumn = wrapColumn("AACoverage", getRealTable().getColumn("ProtSequence"));
-        aaColumn.setDisplayColumnFactory(new DisplayColumnFactory()
-        {
-            @Override
-            public DisplayColumn createRenderer(ColumnInfo colInfo)
-            {
-                ColumnInfo peptideColumn = colInfo.getParentTable().getColumn("Peptide");
-                ColumnInfo seqIdColumn = colInfo.getParentTable().getColumn("SeqId");
-                return new QueryAACoverageColumn(colInfo, seqIdColumn, peptideColumn);
-            }
+        aaColumn.setDisplayColumnFactory(colInfo -> {
+            ColumnInfo peptideColumn = colInfo.getParentTable().getColumn("Peptide");
+            ColumnInfo seqIdColumn = colInfo.getParentTable().getColumn("SeqId");
+            return new QueryAACoverageColumn(colInfo, seqIdColumn, peptideColumn);
         });
         addColumn(aaColumn);
 
         var totalCount = wrapColumn("Peptides", getRealTable().getColumn("SeqId"));
-        totalCount.setDisplayColumnFactory(new DisplayColumnFactory()
-        {
-            @Override
-            public DisplayColumn createRenderer(ColumnInfo colInfo)
-            {
-                ColumnInfo peptideColumn = colInfo.getParentTable().getColumn("Peptide");
-                return new PeptideCountCoverageColumn(colInfo, peptideColumn, "Peptides");
-            }
+        totalCount.setDisplayColumnFactory(colInfo -> {
+            ColumnInfo peptideColumn = colInfo.getParentTable().getColumn("Peptide");
+            return new PeptideCountCoverageColumn(colInfo, peptideColumn, "Peptides");
         });
         addColumn(totalCount);
 
         var uniqueCount = wrapColumn("UniquePeptides", getRealTable().getColumn("SeqId"));
-        uniqueCount.setDisplayColumnFactory(new DisplayColumnFactory()
-        {
-            @Override
-            public DisplayColumn createRenderer(ColumnInfo colInfo)
-            {
-                ColumnInfo peptideColumn = colInfo.getParentTable().getColumn("Peptide");
-                return new UniquePeptideCountCoverageColumn(colInfo, peptideColumn, "Unique");
-            }
+        uniqueCount.setDisplayColumnFactory(colInfo -> {
+            ColumnInfo peptideColumn = colInfo.getParentTable().getColumn("Peptide");
+            return new UniquePeptideCountCoverageColumn(colInfo, peptideColumn, "Unique");
         });
         addColumn(uniqueCount);
     }

--- a/ms2/src/org/labkey/ms2/query/SequencesTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/SequencesTableInfo.java
@@ -62,14 +62,6 @@ import java.util.StringTokenizer;
  */
 public class SequencesTableInfo<SchemaType extends UserSchema> extends FilteredTable<SchemaType>
 {
-    // TODO ContainerFilter
-    @Deprecated
-    protected SequencesTableInfo(String name, SchemaType schema)
-    {
-        this(schema, null);
-        setName(name);
-    }
-
     protected SequencesTableInfo(String name, SchemaType schema, ContainerFilter cf)
     {
         this(schema, cf);
@@ -134,8 +126,7 @@ public class SequencesTableInfo<SchemaType extends UserSchema> extends FilteredT
                             @Override
                             public TableInfo getLookupTableInfo()
                             {
-                                // TODO ContainerFilter
-                                return new CustomAnnotationTable(annotationSet, new CustomAnnotationSchema(_userSchema.getUser(), _userSchema.getContainer(), false));
+                                return new CustomAnnotationTable(annotationSet, new CustomAnnotationSchema(_userSchema.getUser(), _userSchema.getContainer(), false), cf, false);
                             }
                         });
                         return ret;

--- a/ms2/src/org/labkey/ms2/query/SpectraCountTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/SpectraCountTableInfo.java
@@ -48,17 +48,17 @@ public class SpectraCountTableInfo extends VirtualTable<MS2Schema>
     private final SpectraCountConfiguration _config;
     private final ViewContext _context;
 
-    private List<PeptideAggregate> _aggregates = new ArrayList<>();
-    private MS2Controller.SpectraCountForm _form;
+    private final List<PeptideAggregate> _aggregates = new ArrayList<>();
+    private final MS2Controller.SpectraCountForm _form;
 
     private class PeptideAggregate
     {
         private final FieldKey _key;
-        private boolean _max;
-        private boolean _min;
-        private boolean _avg;
-        private boolean _stdDev;
-        private boolean _sum;
+        private final boolean _max;
+        private final boolean _min;
+        private final boolean _avg;
+        private final boolean _stdDev;
+        private final boolean _sum;
 
         private PeptideAggregate(FieldKey key, boolean max, boolean min, boolean avg, boolean stdDev, boolean sum)
         {

--- a/ms2/src/org/labkey/ms2/query/SpectraCountTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/SpectraCountTableInfo.java
@@ -135,12 +135,12 @@ public class SpectraCountTableInfo extends VirtualTable<MS2Schema>
         List<FieldKey> defaultCols = new ArrayList<>();
 
         ExprColumn runColumn = new ExprColumn(this, "Run", new SQLFragment(ExprColumn.STR_TABLE_ALIAS + ".Run"), JdbcType.INTEGER);
-        runColumn.setFk(new LookupForeignKey(/*TODO ContainerFilter,*/ MS2Controller.getShowRunURL(_userSchema.getUser(), _userSchema.getContainer()), "run", "MS2Details", "Name")
+        runColumn.setFk(new LookupForeignKey(MS2Controller.getShowRunURL(_userSchema.getUser(), _userSchema.getContainer()), "run", "MS2Details", "Name")
         {
             @Override
             public TableInfo getLookupTableInfo()
             {
-                ExpRunTable result = (ExpRunTable)MS2Schema.TableType.MS2SearchRuns.createTable(_userSchema, getLookupContainerFilter());
+                ExpRunTable result = (ExpRunTable)MS2Schema.TableType.MS2SearchRuns.createTable(_userSchema, getContainerFilter());
                 result.setContainerFilter(ContainerFilter.EVERYTHING);
                 return result;
             }
@@ -189,12 +189,12 @@ public class SpectraCountTableInfo extends VirtualTable<MS2Schema>
         }
         proteinColumn.setDescription("The protein associated with the peptide identification. Only available if a grouping by protein information, or a target protein has been specified.");
         addColumn(proteinColumn);
-        proteinColumn.setFk(new LookupForeignKey(/*TODO ContainerFilter,*/ new ActionURL(MS2Controller.ShowProteinAction.class, ContainerManager.getRoot()), "seqId", "SeqId", "BestName")
+        proteinColumn.setFk(new LookupForeignKey(new ActionURL(MS2Controller.ShowProteinAction.class, ContainerManager.getRoot()), "seqId", "SeqId", "BestName")
         {
             @Override
             public TableInfo getLookupTableInfo()
             {
-                return _userSchema.createSequencesTable(getLookupContainerFilter());
+                return _userSchema.createSequencesTable(getContainerFilter());
             }
         });
 


### PR DESCRIPTION
#### Rationale
The big ContainerFilter refactor left some TODOs behind in MS2 where they're not propagated through lookups. We need to make them work.

#### Changes
* Push the right ContainerFilter through lookups and into table constructors