### PR TITLE
Fix logging when using lookup to non-existent statistic

### DIFF
--- a/flow/src/org/labkey/flow/FlowModule.java
+++ b/flow/src/org/labkey/flow/FlowModule.java
@@ -72,6 +72,7 @@ import org.labkey.flow.persist.FlowDataHandler;
 import org.labkey.flow.persist.FlowKeywordAuditProvider;
 import org.labkey.flow.persist.FlowManager;
 import org.labkey.flow.persist.PersistTests;
+import org.labkey.flow.query.FlowPropertySet;
 import org.labkey.flow.query.FlowSchema;
 import org.labkey.flow.reports.ControlsQCReport;
 import org.labkey.flow.reports.ControlsQCReportUIProvider;
@@ -321,7 +322,8 @@ public class FlowModule extends SpringModule
             StatisticSpec.TestCase.class,
             SubsetParser.TestLexer.class,
             SubsetTests.class,
-            LogicleRangeFunction.TestCase.class
+            LogicleRangeFunction.TestCase.class,
+            FlowPropertySet.TestCase.class
         );
     }
 

--- a/flow/src/org/labkey/flow/data/FlowProtocolSchema.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocolSchema.java
@@ -62,8 +62,10 @@ public class FlowProtocolSchema extends AssayProtocolSchema
     public TableInfo createDataTable(ContainerFilter cf, boolean includeLinkedToStudyColumns)
     {
         FlowSchema flowSchema = new FlowSchema(getUser(), getContainer());
-        // AssayProtocolSchema.createDataTable() hacks on returned TableInfo therefore forWrite==true
-        return flowSchema.getTable(FlowTableType.FCSAnalyses.name(), cf, true, true);
+        //assert protocol == flowSchema.getProtocol();
+        ExpDataTable ti;
+        ti = flowSchema.createFCSAnalysisTable(FlowTableType.FCSAnalyses.name(), cf, FlowDataType.FCSAnalysis, includeLinkedToStudyColumns);
+        return ti;
     }
 
     @Nullable

--- a/flow/src/org/labkey/flow/data/FlowProtocolSchema.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocolSchema.java
@@ -62,10 +62,8 @@ public class FlowProtocolSchema extends AssayProtocolSchema
     public TableInfo createDataTable(ContainerFilter cf, boolean includeLinkedToStudyColumns)
     {
         FlowSchema flowSchema = new FlowSchema(getUser(), getContainer());
-        //assert protocol == flowSchema.getProtocol();
-        ExpDataTable ti;
-        ti = flowSchema.createFCSAnalysisTable(FlowTableType.FCSAnalyses.name(), cf, FlowDataType.FCSAnalysis, includeLinkedToStudyColumns);
-        return ti;
+        // AssayProtocolSchema.createDataTable() hacks on returned TableInfo therefore forWrite==true
+        return flowSchema.getTable(FlowTableType.FCSAnalyses.name(), cf, true, true);
     }
 
     @Nullable


### PR DESCRIPTION
#### Rationale
I tracked down a long standing mystery as to why FlowPropertySets.simplifySubset() sometimes logs errors.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
Don't try to simplify a SubsetSpec that is not part of this flow protocol.  It can cause errors!
