### PR TITLE
Item 9758: Field editor "Text Choice" data type and UI to create, update, delete field options/values

### DIFF
--- a/luminex/src/org/labkey/luminex/LuminexAnalyteDomainKind.java
+++ b/luminex/src/org/labkey/luminex/LuminexAnalyteDomainKind.java
@@ -60,4 +60,10 @@ public class LuminexAnalyteDomainKind extends AssayDomainKind
         result.add(LuminexDataHandler.NEGATIVE_BEAD_DISPLAY_NAME);
         return result;
     }
+
+    @Override
+    public boolean allowTextChoiceProperties()
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
#### Rationale
The previous story in this epic added a TextChoiceValidator to the server side and updated the UI for the field insert/update forms to show a select input of the values. This set of PRs are part 1 of updating the field editor UI to add the new "Text Choice" data type and the UI in the field editor expanded row to define the set of values / choices for that field. This PR is just an update to not allow the Text Choice data type in the field editor for the Luminex assay analyte domain.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/692
* https://github.com/LabKey/platform/pull/2876
* https://github.com/LabKey/sampleManagement/pull/784
* https://github.com/LabKey/biologics/pull/1098
* https://github.com/LabKey/commonAssays/pull/400

#### Changes
* LuminexAnalyteDomainKind override for allowTextChoiceProperties() to return false
