### PR TITLE
Issue 44093: Admin option to update paths in the DB, separate from mo…

### DIFF
--- a/ms2/src/org/labkey/ms2/MS2Module.java
+++ b/ms2/src/org/labkey/ms2/MS2Module.java
@@ -264,10 +264,11 @@ public class MS2Module extends SpringModule implements ProteomicsModule
         FileContentService.get().addFileListener(new TableUpdaterFileListener(MS2Manager.getTableInfoRuns(), "Path", TableUpdaterFileListener.Type.filePathForwardSlash, "Run")
         {
             @Override
-            public void fileMoved(@NotNull File srcFile, @NotNull File destFile, @Nullable User user, @Nullable Container container)
+            public int fileMoved(@NotNull File srcFile, @NotNull File destFile, @Nullable User user, @Nullable Container container)
             {
-                super.fileMoved(srcFile, destFile, user, container);
+                int result = super.fileMoved(srcFile, destFile, user, container);
                 MS2Manager.clearRunCache();
+                return result;
             }
         });
 
@@ -279,10 +280,11 @@ public class MS2Module extends SpringModule implements ProteomicsModule
         FileContentService.get().addFileListener(new TableUpdaterFileListener(MS2Manager.getTableInfoFractions(), "MzXMLURL", TableUpdaterFileListener.Type.uri, "Fraction", containerFrag)
         {
             @Override
-            public void fileMoved(@NotNull File srcFile, @NotNull File destFile, @Nullable User user, @Nullable Container container)
+            public int fileMoved(@NotNull File srcFile, @NotNull File destFile, @Nullable User user, @Nullable Container container)
             {
-                super.fileMoved(srcFile, destFile, user, container);
+                int result = super.fileMoved(srcFile, destFile, user, container);
                 MS2Manager.clearFractionCache();
+                return result;
             }
         });
         FileContentService.get().addFileListener(new TableUpdaterFileListener(MS2Manager.getTableInfoProteinProphetFiles(), "FilePath", TableUpdaterFileListener.Type.filePath, "RowId", containerFrag));


### PR DESCRIPTION
#### Rationale
It's a pain to fix up paths stored in the DB when they've been moved by something external to LabKey Server.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2886

#### Changes
* Return the number of DB rows touched when making an update
