### PR TITLE
ELISA test fix - add null check for specimenColumn now that assay domain kind returns a TableInfo for base domains

### DIFF
--- a/elisa/src/org/labkey/elisa/query/ElisaResultsTable.java
+++ b/elisa/src/org/labkey/elisa/query/ElisaResultsTable.java
@@ -64,30 +64,33 @@ public class ElisaResultsTable extends AssayResultTable
 
         // add a lookup to the material table
         BaseColumnInfo specimenColumn = (BaseColumnInfo)_columnMap.get(ElisaDataHandler.ELISA_INPUT_MATERIAL_DATA_PROPERTY);
-        specimenColumn.setLabel("Specimen");
-        specimenColumn.setHidden(false);
-
-        specimenColumn.setFk(new LookupForeignKey(getContainerFilter(), "LSID", null)
+        if (specimenColumn != null)
         {
-            @Override
-            public TableInfo getLookupTableInfo()
-            {
-                ExpMaterialTable materials = ExperimentService.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), schema, getLookupContainerFilter());
-                if (sampleType != null)
-                {
-                    materials.setSampleType(sampleType, true);
-                }
-                var propertyCol = materials.addColumn(ExpMaterialTable.Column.Property);
-                if (propertyCol.getFk() instanceof PropertyForeignKey)
-                {
-                    ((PropertyForeignKey) propertyCol.getFk()).addDecorator(new SpecimenPropertyColumnDecorator(_provider, _protocol, schema));
-                }
-                propertyCol.setHidden(false);
-                materials.addColumn(ExpMaterialTable.Column.LSID).setHidden(true);
+            specimenColumn.setLabel("Specimen");
+            specimenColumn.setHidden(false);
 
-                return materials;
-            }
-        });
+            specimenColumn.setFk(new LookupForeignKey(getContainerFilter(), "LSID", null)
+            {
+                @Override
+                public TableInfo getLookupTableInfo()
+                {
+                    ExpMaterialTable materials = ExperimentService.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), schema, getLookupContainerFilter());
+                    if (sampleType != null)
+                    {
+                        materials.setSampleType(sampleType, true);
+                    }
+                    var propertyCol = materials.addColumn(ExpMaterialTable.Column.Property);
+                    if (propertyCol.getFk() instanceof PropertyForeignKey)
+                    {
+                        ((PropertyForeignKey) propertyCol.getFk()).addDecorator(new SpecimenPropertyColumnDecorator(_provider, _protocol, schema));
+                    }
+                    propertyCol.setHidden(false);
+                    materials.addColumn(ExpMaterialTable.Column.LSID).setHidden(true);
+
+                    return materials;
+                }
+            });
+        }
 
         visibleColumns.addAll(getDefaultVisibleColumns());
         setDefaultVisibleColumns(visibleColumns);


### PR DESCRIPTION
#### Rationale
The related PR for adding the "Text Choice" data type for field editors included a platform change so that more domain kinds would return TableInfo objects for their domain from the getTableInfo() method. This resulted in some NPE errors in the ELISA results table / domain since it is now being called earlier in the process of saving the domain/assay definition. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2876

#### Changes
* ElisaResultsTable update to add null check on the specimenColumn
