### PR TITLE
Issue 44015: Migrate remaining log4j 1.2 usages to 2.x

### DIFF
--- a/elisa/src/org/labkey/elisa/ElisaUpgradeCode.java
+++ b/elisa/src/org/labkey/elisa/ElisaUpgradeCode.java
@@ -1,6 +1,7 @@
 package org.labkey.elisa;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
@@ -29,7 +30,7 @@ import java.util.Set;
 
 public class ElisaUpgradeCode implements UpgradeCode
 {
-    private static final Logger _log = Logger.getLogger(ElisaUpgradeCode.class);
+    private static final Logger _log = LogManager.getLogger(ElisaUpgradeCode.class);
 
     // Invoked by elisa-0.000-20.000.sql
     @SuppressWarnings({"UnusedDeclaration"})

--- a/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
+++ b/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
@@ -1,6 +1,7 @@
 package org.labkey.elisa;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.assay.AssayUploadXarContext;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateBasedAssayProvider;
@@ -32,7 +33,8 @@ import java.util.Set;
 
 public class HighThroughputImportHelper extends AbstractElisaImportHelper
 {
-    private static final Logger LOG = Logger.getLogger(HighThroughputImportHelper.class);
+    private static final Logger LOG = LogManager.getLogger(HighThroughputImportHelper.class);
+
     private Map<String, AnalytePlate> _plateMap = new HashMap<>();
     private PlateTemplate _plateTemplate;
 


### PR DESCRIPTION
#### Rationale
Recent events notwithstanding, we prefer log4j 2.x. Migrate 1.2 usages that were never converted or that snuck in after our big migration.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2899