### PR TITLE
Fix bootstrap of elispotassay and MS2 after module+schema delete

### DIFF
--- a/elispotassay/resources/schemas/dbscripts/postgresql/elispotlk-0.00-18.30.sql
+++ b/elispotassay/resources/schemas/dbscripts/postgresql/elispotlk-0.00-18.30.sql
@@ -17,6 +17,9 @@
 /* elispotlk-15.10-15.20.sql */
 
 CREATE SCHEMA elispotlk;
+-- Until 21.11.5, the elispotassay module did not claim ownership of the "elispotantigen" schema. So, deleting that
+-- module and its schema would leave "elispotantigen" behind and any subsequent bootstrap would fail. See #44610.
+SELECT core.fn_dropIfExists('*', 'elispotantigen', 'SCHEMA', NULL);
 CREATE SCHEMA elispotantigen;
 
 CREATE TABLE elispotlk.rundata

--- a/elispotassay/resources/schemas/dbscripts/sqlserver/elispotlk-0.00-18.30.sql
+++ b/elispotassay/resources/schemas/dbscripts/sqlserver/elispotlk-0.00-18.30.sql
@@ -18,6 +18,10 @@
 
 CREATE SCHEMA elispotlk;
 GO
+-- Until 21.11.5, the elispotassay module did not claim ownership of the "elispotantigen" schema. So, deleting that
+-- module and its schema would leave "elispotantigen" behind and any subsequent bootstrap would fail. See #44610.
+EXEC core.fn_dropIfExists '*', 'elispotantigen', 'SCHEMA';
+GO
 CREATE SCHEMA elispotantigen;
 GO
 

--- a/elispotassay/src/org/labkey/elispot/ElispotModule.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotModule.java
@@ -18,15 +18,14 @@ package org.labkey.elispot;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AssayService;
+import org.labkey.api.assay.plate.PlateBasedAssayProvider;
+import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.pipeline.PipelineService;
-import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.AssayService;
-import org.labkey.api.assay.plate.PlateBasedAssayProvider;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.elispot.pipeline.ElispotPipelineProvider;
 import org.labkey.elispot.query.ElispotAntigenDomainKind;
@@ -73,7 +72,16 @@ public class ElispotModule extends DefaultModule
     @Override
     public Set<String> getSchemaNames()
     {
-        return PageFlowUtil.set(ElispotProtocolSchema.ELISPOT_DBSCHEMA_NAME);
+        return Set.of(
+            ElispotProtocolSchema.ELISPOT_DBSCHEMA_NAME,
+            ElispotProtocolSchema.ELISPOT_ANTIGEN_SCHEMA_NAME
+        );
+    }
+
+    @Override
+    public @NotNull Collection<String> getProvisionedSchemaNames()
+    {
+        return Set.of(ElispotProtocolSchema.ELISPOT_ANTIGEN_SCHEMA_NAME);
     }
 
     @Override

--- a/ms2/resources/schemas/dbscripts/postgresql/ms2-0.00-19.10.sql
+++ b/ms2/resources/schemas/dbscripts/postgresql/ms2-0.00-19.10.sql
@@ -1045,13 +1045,6 @@ ALTER TABLE ms2.peptidesdata
 SELECT core.fn_dropifexists('PeptidesData','ms2', 'INDEX','UQ_MS2PeptidesData_FractionScanCharge');
 CREATE UNIQUE INDEX UQ_MS2PeptidesData_FractionScanCharge ON ms2.PeptidesData(Fraction, Scan, EndScan, Charge, HitRank, Decoy, QueryNumber);
 
--- Create a new set of properties for Mascot settings
-INSERT INTO prop.propertysets (category, objectid, userid) SELECT 'MascotConfig' AS Category, EntityId, -1 AS UserId FROM core.containers WHERE parent IS NULL;
-
--- Migrate existing Mascot settings
-UPDATE prop.properties SET "set" = (SELECT MAX("set") FROM prop.propertysets)
-  WHERE name LIKE 'Mascot%' AND "set" = (SELECT "set" FROM prop.propertysets WHERE category = 'SiteConfig' AND userid = -1 AND objectid = (SELECT entityid FROM core.containers WHERE parent IS NULL));
-
 CREATE TABLE ms2.FastaRunMapping (
   Run INT NOT NULL,
   FastaId INT NOT NULL,

--- a/ms2/resources/schemas/dbscripts/sqlserver/ms2-0.00-19.10.sql
+++ b/ms2/resources/schemas/dbscripts/sqlserver/ms2-0.00-19.10.sql
@@ -1120,13 +1120,6 @@ ALTER TABLE ms2.peptidesdata
 EXEC core.fn_dropifexists 'PeptidesData', 'ms2', 'INDEX', 'UQ_MS2PeptidesData_FractionScanCharge';
 CREATE UNIQUE CLUSTERED INDEX UQ_MS2PeptidesData_FractionScanCharge ON ms2.PeptidesData(Fraction, Scan, EndScan, Charge, HitRank, Decoy, QueryNumber);
 
--- Create a new set of properties for Mascot settings
-INSERT INTO prop.propertysets (category, objectid, userid) SELECT 'MascotConfig' AS Category, EntityId, -1 AS UserId FROM core.containers WHERE parent IS NULL;
-
--- Migrate existing Mascot settings
-UPDATE prop.properties SET "set" = (SELECT MAX("set") FROM prop.propertysets)
-  WHERE name LIKE 'Mascot%' AND "set" = (SELECT "set" FROM prop.propertysets WHERE category = 'SiteConfig' AND userid = -1 AND objectid = (SELECT entityid FROM core.containers WHERE parent IS NULL));
-
 CREATE TABLE ms2.FastaRunMapping (
   Run INT NOT NULL,
   FastaId INT NOT NULL,


### PR DESCRIPTION
#### Rationale
Deleting the elispotassay module (and schema) or the MS2 module (and schemas) followed by a re-bootstrap of either module resulted in an upgrade failure. See [#44610](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44610).
