### PR TITLE
Formats are not thread safe.  Get rid of static.

### DIFF
--- a/flow/enginesrc/org/labkey/flow/analysis/chart/FlowLinearAxis.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/chart/FlowLinearAxis.java
@@ -10,16 +10,12 @@ import java.util.Locale;
  */
 public class FlowLinearAxis extends NumberAxis
 {
-    private static final NumberFormat TICK_FORMAT;
-
-    static {
-        TICK_FORMAT = NumberFormat.getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
-        TICK_FORMAT.setMaximumFractionDigits(2);
-    }
-
     public FlowLinearAxis(String label)
     {
         super(label);
-        setNumberFormatOverride(TICK_FORMAT);
+
+        var format = NumberFormat.getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
+        format.setMaximumFractionDigits(2);
+        setNumberFormatOverride(format);
     }
 }


### PR DESCRIPTION
#### Rationale
Don't use static number formats

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
