### PR TITLE
createRunsTable() should return a writable TableInfo

### DIFF
--- a/flow/src/org/labkey/flow/data/FlowProtocolSchema.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocolSchema.java
@@ -55,7 +55,7 @@ public class FlowProtocolSchema extends AssayProtocolSchema
     {
         FlowSchema flowSchema = new FlowSchema(getUser(), getContainer());
         //assert protocol == flowSchema.getProtocol();
-        return (ExpRunTable)flowSchema.getTable(FlowTableType.Runs, cf);
+        return (ExpRunTable)flowSchema.getTable(FlowTableType.Runs.name(), cf, true, true);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
AssayProtocolSchema.fixupRenderers() requires a writable table.  This is consistent with createDataTable().

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
