### PR TITLE
Luminex ManageGuideSetPanel update to add null check for grid store before trying to load data into it

### DIFF
--- a/luminex/webapp/luminex/ManageGuideSetPanel.js
+++ b/luminex/webapp/luminex/ManageGuideSetPanel.js
@@ -762,15 +762,13 @@ LABKEY.ManageGuideSetPanel = Ext.extend(Ext.FormPanel, {
                 guideRunSetStoreData.rows.push(row);    
         }
 
-        if (this.allRunsGrid)
-        {
+        if (this.allRunsGrid && this.allRunsGrid.getStore()) {
             this.allRunsGrid.getStore().loadData(allRunsStoreData);
             this.allRunsGrid.dataLoaded = true;
             this.allRunsGrid.getEl().unmask();
         }
 
-        if (this.guideRunSetGrid)
-        {
+        if (this.guideRunSetGrid && this.guideRunSetGrid.getStore()) {
             this.guideRunSetGrid.getStore().loadData(guideRunSetStoreData);
             this.guideRunSetGrid.dataLoaded = true;
             this.guideRunSetGrid.getEl().unmask();


### PR DESCRIPTION
#### Rationale
Some intermittent TeamCity test failiures with the LuminexGuideSetTesting test cases show a client side error: TypeError: this.allRunsGrid.getStore() is null. This PR adds a check for the grid store to the if statement that handles loading the data into that store.

#### Changes
* Luminex ManageGuideSetPanel update to add null check for grid store before trying to load data into it
