### PR TITLE
Close DataLoaders when done with them

### DIFF
--- a/elisa/src/org/labkey/elisa/ElisaSampleFilePropertyHelper.java
+++ b/elisa/src/org/labkey/elisa/ElisaSampleFilePropertyHelper.java
@@ -47,11 +47,9 @@ public class ElisaSampleFilePropertyHelper extends PlateSampleFilePropertyHelper
             throw new ExperimentException("No metadata or data file provided");
 
         Map<String, Map<DomainProperty, String>> allProperties = new HashMap<>();
-        try
+        DataLoaderFactory factory = DataLoaderService.get().findFactory(metadataFile, null);
+        try (DataLoader loader = factory.createLoader(metadataFile, true))
         {
-            DataLoaderFactory factory = DataLoaderService.get().findFactory(metadataFile, null);
-            DataLoader loader = factory.createLoader(metadataFile, true);
-
             validateRequiredColumns(loader.getColumns());
 
             for (Map<String, Object> row : loader)

--- a/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
+++ b/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
@@ -46,11 +46,10 @@ public class HighThroughputImportHelper extends AbstractElisaImportHelper
 
     private void ensureData() throws ExperimentException
     {
-        try
+        _plateTemplate = _provider.getPlateTemplate(_protocol.getContainer(), _protocol);
+        DataLoaderFactory factory = DataLoaderService.get().findFactory(_dataFile, null);
+        try (DataLoader loader = factory.createLoader(_dataFile, true))
         {
-            _plateTemplate = _provider.getPlateTemplate(_protocol.getContainer(), _protocol);
-            DataLoaderFactory factory = DataLoaderService.get().findFactory(_dataFile, null);
-            DataLoader loader = factory.createLoader(_dataFile, true);
             String signalColumnName = "Signal";
 
             ElisaSampleFilePropertyHelper.validateRequiredColumns(loader.getColumns());

--- a/elispotassay/src/org/labkey/elispot/plate/AIDPlateReader.java
+++ b/elispotassay/src/org/labkey/elispot/plate/AIDPlateReader.java
@@ -15,13 +15,13 @@
  */
 package org.labkey.elispot.plate;
 
+import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.PlateUtils;
+import org.labkey.api.assay.plate.TextPlateReader;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.DataLoader;
 import org.labkey.api.reader.DataLoaderFactory;
-import org.labkey.api.assay.plate.PlateTemplate;
-import org.labkey.api.assay.plate.PlateUtils;
-import org.labkey.api.assay.plate.TextPlateReader;
 
 import java.io.File;
 import java.io.IOException;
@@ -60,11 +60,9 @@ public class AIDPlateReader extends TextPlateReader
         String fileName = dataFile.getName().toLowerCase();
         if (fileName.endsWith(".xls") || fileName.endsWith(".xlsx"))
         {
-            try
+            DataLoaderFactory factory = DataLoader.get().findFactory(dataFile, null);
+            try (DataLoader loader = factory.createLoader(dataFile, false))
             {
-                DataLoaderFactory factory = DataLoader.get().findFactory(dataFile, null);
-                DataLoader loader = factory.createLoader(dataFile, false);
-
                 return PlateUtils.parseGrid(dataFile, loader.load(), template.getRows(), template.getColumns(), this);
             }
             catch (IOException ioe)
@@ -84,11 +82,9 @@ public class AIDPlateReader extends TextPlateReader
         String fileName = dataFile.getName().toLowerCase();
         if (fileName.endsWith(".xls") || fileName.endsWith(".xlsx"))
         {
-            try
+            DataLoaderFactory factory = DataLoader.get().findFactory(dataFile, null);
+            try (DataLoader loader = factory.createLoader(dataFile, false))
             {
-                DataLoaderFactory factory = DataLoader.get().findFactory(dataFile, null);
-                DataLoader loader = factory.createLoader(dataFile, false);
-
                 return PlateUtils.parseAllGrids(dataFile, loader.load(), template.getRows(), template.getColumns(), this);
             }
             catch (IOException ioe)

--- a/luminex/src/org/labkey/luminex/LuminexExcelParser.java
+++ b/luminex/src/org/labkey/luminex/LuminexExcelParser.java
@@ -105,9 +105,8 @@ public class LuminexExcelParser
 
             analyteNames.clear();
 
-            try
+            try (Workbook workbook = ExcelFactory.create(dataFile))
             {
-                Workbook workbook = ExcelFactory.create(dataFile);
 
                 for (int sheetIndex = 0; sheetIndex < workbook.getNumberOfSheets(); sheetIndex++)
                 {

--- a/nab/src/org/labkey/nab/multiplate/HighThroughputNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/HighThroughputNabDataHandler.java
@@ -17,10 +17,16 @@ package org.labkey.nab.multiplate;
 
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
+import org.labkey.api.assay.AssayRunUploadContext;
 import org.labkey.api.assay.dilution.DilutionManager;
 import org.labkey.api.assay.dilution.SampleProperty;
 import org.labkey.api.assay.dilution.WellDataRow;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateService;
+import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.WellData;
+import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.XarContext;
@@ -35,13 +41,6 @@ import org.labkey.api.reader.ColumnDescriptor;
 import org.labkey.api.reader.DataLoader;
 import org.labkey.api.reader.ExcelLoader;
 import org.labkey.api.reader.TabLoader;
-import org.labkey.api.assay.plate.Plate;
-import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.PlateTemplate;
-import org.labkey.api.assay.plate.WellData;
-import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.plate.WellGroupTemplate;
-import org.labkey.api.assay.AssayRunUploadContext;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.nab.NabAssayProvider;
 import org.labkey.nab.NabDataHandler;
@@ -73,7 +72,7 @@ public abstract class HighThroughputNabDataHandler extends NabDataHandler implem
     @Override
     protected List<Plate> createPlates(File dataFile, PlateTemplate template) throws ExperimentException
     {
-        DataLoader loader;
+        DataLoader loader = null;
         try
         {
             if (dataFile.getName().toLowerCase().endsWith(".csv"))
@@ -101,6 +100,13 @@ public abstract class HighThroughputNabDataHandler extends NabDataHandler implem
         catch (IOException e)
         {
             throw createParseError(dataFile, null, e);
+        }
+        finally
+        {
+            if (loader != null)
+            {
+                loader.close();
+            }
         }
     }
 

--- a/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabDataHandler.java
@@ -15,9 +15,15 @@
  */
 package org.labkey.nab.multiplate;
 
+import org.labkey.api.assay.AssayDataType;
 import org.labkey.api.assay.dilution.DilutionAssayProvider;
 import org.labkey.api.assay.dilution.DilutionAssayRun;
 import org.labkey.api.assay.dilution.DilutionSummary;
+import org.labkey.api.assay.nab.NabSpecimen;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateService;
+import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
@@ -32,16 +38,10 @@ import org.labkey.api.reader.DataLoader;
 import org.labkey.api.reader.ExcelLoader;
 import org.labkey.api.reader.TabLoader;
 import org.labkey.api.security.User;
-import org.labkey.api.assay.plate.Plate;
-import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.PlateTemplate;
-import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.AssayDataType;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.Pair;
 import org.labkey.nab.NabAssayProvider;
 import org.labkey.nab.NabManager;
-import org.labkey.api.assay.nab.NabSpecimen;
 
 import java.io.File;
 import java.io.IOException;
@@ -68,7 +68,7 @@ public class SinglePlateDilutionNabDataHandler extends HighThroughputNabDataHand
     @Override
     protected List<Plate> createPlates(File dataFile, PlateTemplate template) throws ExperimentException
     {
-        DataLoader loader;
+        DataLoader loader = null;
         try
         {
             if (dataFile.getName().toLowerCase().endsWith(".csv"))
@@ -156,6 +156,13 @@ public class SinglePlateDilutionNabDataHandler extends HighThroughputNabDataHand
         catch (IOException e)
         {
             throw createParseError(dataFile, null, e);
+        }
+        finally
+        {
+            if (loader != null)
+            {
+                loader.close();
+            }
         }
     }
 

--- a/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionSamplePropertyHelper.java
+++ b/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionSamplePropertyHelper.java
@@ -15,15 +15,15 @@
  */
 package org.labkey.nab.multiplate;
 
+import org.labkey.api.assay.plate.PlateSampleFilePropertyHelper;
+import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.reader.ColumnDescriptor;
 import org.labkey.api.reader.ExcelLoader;
-import org.labkey.api.assay.plate.PlateTemplate;
-import org.labkey.api.assay.plate.WellGroupTemplate;
-import org.labkey.api.assay.plate.PlateSampleFilePropertyHelper;
 import org.labkey.api.study.assay.SampleMetadataInputFormat;
 import org.labkey.nab.NabAssayProvider;
 
@@ -60,11 +60,10 @@ public class SinglePlateDilutionSamplePropertyHelper extends PlateSampleFileProp
             return null;
 
         Map<String, Map<DomainProperty, String>> allProperties = new HashMap<>();
-        try
+        try (ExcelLoader loader = new ExcelLoader(metadataFile, true))
         {
             Map<String, WellGroupTemplate> sampleGroupNames = getSampleWellGroupNameMap();
 
-            ExcelLoader loader = new ExcelLoader(metadataFile, true);
             // issue #19539 -- now addressed by larger default value for _scanAheadLineCount
 
             boolean hasSampleNameCol = false;


### PR DESCRIPTION
#### Rationale
Failing to close DataLoaders is causing some imports to fail on Windows when attempting to clean up temp files.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3131

#### Changes
* Close DataLoaders when done with them
* Use try-with-resources when able
