### PR TITLE
Don't use HashSet for column lists

### DIFF
--- a/flow/src/org/labkey/flow/query/FlowSchema.java
+++ b/flow/src/org/labkey/flow/query/FlowSchema.java
@@ -19,6 +19,10 @@ package org.labkey.flow.query;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AbstractAssayProvider;
+import org.labkey.api.assay.AssayProtocolSchema;
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssayService;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.*;
@@ -54,20 +58,14 @@ import org.labkey.api.query.QueryView;
 import org.labkey.api.query.RowIdForeignKey;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.security.SecurityLogger;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
-import org.labkey.api.assay.AbstractAssayProvider;
-import org.labkey.api.assay.AssayProtocolSchema;
-import org.labkey.api.assay.AssayProvider;
-import org.labkey.api.assay.AssayService;
 import org.labkey.api.study.assay.FileLinkDisplayColumn;
 import org.labkey.api.study.assay.SpecimenForeignKey;
 import org.labkey.api.study.publish.StudyPublishService;
@@ -142,7 +140,7 @@ public class FlowSchema extends UserSchema implements UserSchema.HasContextualRo
     private FlowExperiment _experiment;
     private FlowRun _run;
     private final FlowProtocol _protocol;
-    private Set<Role> _contextualRoles = new HashSet<>();
+    private final Set<Role> _contextualRoles = new HashSet<>();
 
     public FlowSchema(User user, Container container)
     {
@@ -2027,7 +2025,7 @@ public class FlowSchema extends UserSchema implements UserSchema.HasContextualRo
 //            return eldest.getValue().lastUsed + CacheManager.MINUTE < HeartBeat.currentTimeMillis();
 //        }
 //    };
-    private static final Cache<String, MaterializedQueryHelper> fastflowCache = CacheManager.getStringKeyCache(100_000, CacheManager.HOUR, "fast flow objects");
+    private static final Cache<String, MaterializedQueryHelper> fastflowCache = CacheManager.getStringKeyCache(100_000, CacheManager.HOUR, "Fast flow objects");
 
     private static final ContainerManager.ContainerListener containerListener = new ContainerManager.ContainerListener()
     {

--- a/ms2/src/org/labkey/ms2/MS2Manager.java
+++ b/ms2/src/org/labkey/ms2/MS2Manager.java
@@ -17,8 +17,8 @@
 package org.labkey.ms2;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.fhcrc.cpas.exp.xml.ExperimentArchiveDocument;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.cache.Cache;
@@ -1302,11 +1302,11 @@ public class MS2Manager
 
     private static class PeptideIndexCache extends DatabaseCache<String, long[]>
     {
-        private static int CACHE_SIZE = 10;
+        private static final int CACHE_SIZE = 10;
 
         public PeptideIndexCache()
         {
-            super(getSchema().getScope(), CACHE_SIZE, CacheManager.HOUR, "Peptide Index");
+            super(getSchema().getScope(), CACHE_SIZE, CacheManager.HOUR, "Peptide index");
         }
     }
 

--- a/viability/src/org/labkey/viability/ViabilityManager.java
+++ b/viability/src/org/labkey/viability/ViabilityManager.java
@@ -16,14 +16,17 @@
 
 package org.labkey.viability;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.labkey.api.assay.AbstractAssayProvider;
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssayService;
 import org.labkey.api.data.BaseSelector;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
@@ -53,9 +56,6 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
-import org.labkey.api.assay.AbstractAssayProvider;
-import org.labkey.api.assay.AssayProvider;
-import org.labkey.api.assay.AssayService;
 import org.labkey.api.util.CPUTimer;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.PageFlowUtil;
@@ -70,7 +70,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -525,7 +525,7 @@ public class ViabilityManager
                 dataIDs.add(data.getRowId());
 
             TableSelector ts = new TableSelector(ViabilitySchema.getTableInfoResults(),
-                    new HashSet<String>(Arrays.asList("RowID", "ObjectID")),
+                    new LinkedHashSet<>(Arrays.asList("RowID", "ObjectID")),
                     new SimpleFilter(FieldKey.fromParts("DataID"), dataIDs, CompareType.IN), null);
 
             ts.forEachMapBatch(1000, (rows) -> {
@@ -604,7 +604,7 @@ public class ViabilityManager
 
             Map<String, Object>[] rows = new TableSelector(
                     ViabilitySchema.getTableInfoResults(),
-                    new HashSet<String>(Arrays.asList("RowID", "ObjectID")),
+                    PageFlowUtil.set("RowID", "ObjectID"),
                     new SimpleFilter(FieldKey.fromParts("PoolID"), "xxx-", CompareType.STARTS_WITH), null).getMapArray();
 
             for (Map<String, Object> row : rows)

--- a/viability/src/org/labkey/viability/ViabilityManager.java
+++ b/viability/src/org/labkey/viability/ViabilityManager.java
@@ -70,7 +70,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -498,7 +497,7 @@ public class ViabilityManager
     /**
      * Get the ExpData for the viability result row or null.
      * @param resultRowId The row id of the result.
-     * @return The ExpData of the viabilty result row or null.
+     * @return The ExpData of the viability result row or null.
      */
     /*package*/ static ExpData getResultExpData(int resultRowId)
     {
@@ -525,8 +524,8 @@ public class ViabilityManager
                 dataIDs.add(data.getRowId());
 
             TableSelector ts = new TableSelector(ViabilitySchema.getTableInfoResults(),
-                    new LinkedHashSet<>(Arrays.asList("RowID", "ObjectID")),
-                    new SimpleFilter(FieldKey.fromParts("DataID"), dataIDs, CompareType.IN), null);
+                PageFlowUtil.set("RowID", "ObjectID"),
+                new SimpleFilter(FieldKey.fromParts("DataID"), dataIDs, CompareType.IN), null);
 
             ts.forEachMapBatch(1000, (rows) -> {
 
@@ -603,9 +602,10 @@ public class ViabilityManager
             TestContext context = TestContext.get();
 
             Map<String, Object>[] rows = new TableSelector(
-                    ViabilitySchema.getTableInfoResults(),
-                    PageFlowUtil.set("RowID", "ObjectID"),
-                    new SimpleFilter(FieldKey.fromParts("PoolID"), "xxx-", CompareType.STARTS_WITH), null).getMapArray();
+                ViabilitySchema.getTableInfoResults(),
+                PageFlowUtil.set("RowID", "ObjectID"),
+                new SimpleFilter(FieldKey.fromParts("PoolID"), "xxx-", CompareType.STARTS_WITH), null
+            ).getMapArray();
 
             for (Map<String, Object> row : rows)
             {
@@ -624,7 +624,7 @@ public class ViabilityManager
             Container c = JunitUtil.getTestContainer();
             TestContext context = TestContext.get();
             User user = context.getUser();
-            assertTrue("login before running this test", null != user);
+            assertNotNull("login before running this test", user);
             assertFalse("login before running this test", user.isGuest());
 
             int resultId;


### PR DESCRIPTION
#### Rationale
We're getting stricter about requiring stable-ordered column lists. See related PR for details. Fix up some cache names.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3158