### PR TITLE
Issue 45138: Adjust FolderXarImporterFactory to support unzipped XARs

### DIFF
--- a/flow/src/org/labkey/flow/script/ScriptXarSource.java
+++ b/flow/src/org/labkey/flow/script/ScriptXarSource.java
@@ -71,15 +71,9 @@ public class ScriptXarSource extends XarSource
     }
 
     @Override
-    public File getRoot()
-    {
-        return _root;
-    }
-
-    @Override
     public Path getRootPath()
     {
-        return null != getRoot() ? getRoot().toPath() : null;
+        return null != _root ? _root.toPath() : null;
     }
 
     @Override
@@ -94,9 +88,10 @@ public class ScriptXarSource extends XarSource
         return _doc;
     }
 
+
     @Override
-    public File getLogFile()
+    public Path getLogFilePath()
     {
-        return _logFile;
+        return _logFile.toPath();
     }
 }

--- a/ms2/src/org/labkey/ms2/MS2Manager.java
+++ b/ms2/src/org/labkey/ms2/MS2Manager.java
@@ -371,21 +371,15 @@ public class MS2Manager
             XarSource source = new AbstractFileXarSource("Wrap MS2 Run", container, user)
             {
                 @Override
-                public File getLogFile()
+                public Path getLogFilePath()
                 {
                     throw new UnsupportedOperationException();
                 }
 
                 @Override
-                public File getRoot()
-                {
-                    return pepXMLFile.getParentFile(); 
-                }
-
-                @Override
                 public Path getRootPath()
                 {
-                    return Objects.requireNonNull(getRoot()).toPath();
+                    return pepXMLFile.getParentFile().toPath();
                 }
 
                 @Override


### PR DESCRIPTION
#### Rationale
Checking in zipped files (like .xar files) makes it hard to edit and view diffs. We can easily handle importing .xar.xml files in folder archives, even if we always export in the compressed form

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3187

#### Changes
* Check for both .xar and .xar.xml files in folder archives
* Remove deprecated File method variants in favor of Path
