### PR TITLE
Exception reports - better handling for Uniprot timeouts, SQLite version

### DIFF
--- a/ms2/build.gradle
+++ b/ms2/build.gradle
@@ -30,6 +30,18 @@ dependencies {
                    "PATRICIA Trie data structure implementation"
            )
    )
+   BuildUtils.addExternalDependency(
+           project,
+           new ExternalDependency(
+                   "org.xerial:sqlite-jdbc:${sqliteJdbcVersion}",
+                   "SQLite JDBC Driver",
+                   "bitbucket.org",
+                   "https://bitbucket.org/xerial/sqlite-jdbc/wiki/Home",
+                   ExternalDependency.APACHE_2_LICENSE_NAME,
+                   ExternalDependency.APACHE_2_LICENSE_URL,
+                   "SQLite JDBC Driver"
+           )
+   )
    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
 


### PR DESCRIPTION
#### Rationale
Issue 45144: MS2 module doesn't declare dependency on SQLite

Sometimes Uniprot is slow for protein API calls - improve logging and don't fail page render

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/510

#### Changes
* Declare a dependency on our preferred SQLite version
* Fall back gracefully when we can't fetch protein features from Uniprot