### PR TITLE
Item 10203: Support sample type and data class renaming

### DIFF
--- a/flow/src/org/labkey/flow/data/FlowProtocol.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocol.java
@@ -307,7 +307,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
         if (propValue != null)
             return propValue;
 
-        // get sample type lsid for sample with name "Samples"
+        // get lsid for sample type with name "Samples"
         ExpSampleType sampleType = getSampleType(user);
         if (sampleType != null)
             return sampleType.getLSID();

--- a/flow/src/org/labkey/flow/data/FlowProtocol.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocol.java
@@ -301,13 +301,18 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
         return ret;
     }
 
-    public String getSampleTypeLSID()
+    public String getSampleTypeLSID(User user)
     {
         String propValue = (String) getProperty(ExperimentProperty.SampleTypeLSID.getPropertyDescriptor());
         if (propValue != null)
             return propValue;
 
-        return ExperimentService.get().generateLSID(getContainer(), ExpSampleType.class, SAMPLETYPE_NAME);
+        // get sample type lsid for sample with name "Samples"
+        ExpSampleType sampleType = getSampleType(user);
+        if (sampleType != null)
+            return sampleType.getLSID();
+
+        return null;
     }
 
     public void setSampleTypeJoinFields(User user, Map<String, FieldKey> values) throws Exception
@@ -319,7 +324,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
         }
         String value = StringUtils.join(strings.iterator(), "&");
         setProperty(user, FlowProperty.SampleTypeJoin.getPropertyDescriptor(), value);
-        setProperty(user, ExperimentProperty.SampleTypeLSID.getPropertyDescriptor(), getSampleTypeLSID());
+        setProperty(user, ExperimentProperty.SampleTypeLSID.getPropertyDescriptor(), getSampleTypeLSID(user));
         FlowManager.get().flowObjectModified();
     }
 
@@ -1008,17 +1013,10 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
             assertEquals(0, fcsFiles[0].getSamples().size());
             assertEquals(0, fcsFiles[1].getSamples().size());
 
-            // add join fields
-            assertEquals(0, protocol.getSampleTypeJoinFields().size());
-            protocol.setSampleTypeJoinFields(user, Map.of(
-                    "ExprName", FieldKey.fromParts("Keyword", "EXPERIMENT NAME"),
-                    "WellId", FieldKey.fromParts("Keyword", "WELL ID")
-            ));
-
             // create sample type
             assertNull(protocol.getSampleType(user));
-            String sampleTypeLSID = protocol.getSampleTypeLSID();
-            assertNull(SampleTypeService.get().getSampleType(sampleTypeLSID));
+            String sampleTypeLSID = protocol.getSampleTypeLSID(user);
+            assertNull(sampleTypeLSID);
 
             List<GWTPropertyDescriptor> props = List.of(
                     new GWTPropertyDescriptor("Name", "string"),
@@ -1029,6 +1027,16 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
             ExpSampleType st = SampleTypeService.get().createSampleType(c, user, SAMPLETYPE_NAME, null,
                     props, List.of(), -1,-1,-1,-1,null);
             assertNotNull(protocol.getSampleType(user));
+
+            sampleTypeLSID = protocol.getSampleTypeLSID(user);
+            assertNotNull(sampleTypeLSID);
+
+            // add join fields
+            assertEquals(0, protocol.getSampleTypeJoinFields().size());
+            protocol.setSampleTypeJoinFields(user, Map.of(
+                    "ExprName", FieldKey.fromParts("Keyword", "EXPERIMENT NAME"),
+                    "WellId", FieldKey.fromParts("Keyword", "WELL ID")
+            ));
 
             // import samples:
             //   Name  PTID  WellId  ExprName

--- a/flow/src/org/labkey/flow/script/ScriptJob.java
+++ b/flow/src/org/labkey/flow/script/ScriptJob.java
@@ -321,7 +321,7 @@ abstract public class ScriptJob extends FlowExperimentJob
         }
         for (Map.Entry<String, StartingInput> input : _runData._startingMaterialInputs.entrySet())
         {
-            inputRefs.addNewMaterialLSID().setStringValue(input.getKey()); //
+            inputRefs.addNewMaterialLSID().setStringValue(input.getKey());
         }
         ProtocolApplicationBaseType appOutput = addProtocolApplication(run);
         appOutput.setName("Mark run outputs");

--- a/flow/src/org/labkey/flow/script/ScriptJob.java
+++ b/flow/src/org/labkey/flow/script/ScriptJob.java
@@ -321,7 +321,7 @@ abstract public class ScriptJob extends FlowExperimentJob
         }
         for (Map.Entry<String, StartingInput> input : _runData._startingMaterialInputs.entrySet())
         {
-            inputRefs.addNewMaterialLSID().setStringValue(input.getKey());
+            inputRefs.addNewMaterialLSID().setStringValue(input.getKey()); //
         }
         ProtocolApplicationBaseType appOutput = addProtocolApplication(run);
         appOutput.setName("Mark run outputs");


### PR DESCRIPTION
#### Rationale
Sample type LSID used to be deterministic for a given container and a specific name. With the change to support sample type rename, sample type lsid is switched to be DBSequence based, which means we don't know a sample type's lsid from its name beforehand. Flow joins to "Samples" sample type, and has been using the pre calculated name based lsid for linking. This PR changes the implementation so the linking can only be done on existing "Samples" type, by querying its lsid from DB, rather than guess it. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/808
* https://github.com/LabKey/platform/pull/3256
* https://github.com/LabKey/commonAssays/pull/458
* https://github.com/LabKey/sampleManagement/pull/922
* https://github.com/LabKey/biologics/pull/1255

#### Changes
* change to query lsid from existing sample type with name "Samples", instead of detemining lsid with fixed substitution
* update flow test to create "Samples" sample type before define join fields
