### PR TITLE
Remove unnecessary ids to avoid collisions

### DIFF
--- a/ms2/src/org/labkey/ms2/compare/comparePeptideQueryOptions.jsp
+++ b/ms2/src/org/labkey/ms2/compare/comparePeptideQueryOptions.jsp
@@ -41,7 +41,7 @@ String peptideViewName = form.getPeptideCustomViewName(getViewContext());
     <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.peptideFilterType %>" id="<%= text(FilterView.PEPTIDES_CUSTOM_VIEW_RADIO_BUTTON) %>" value="<%= MS2Controller.ProphetFilterType.customView %>"<%=checked(form.isCustomViewPeptideFilter())%>/>
         Peptides that meet the filter criteria in a custom grid:
         <% String peptideViewSelectId = bean.getPeptideView().renderViewList(request, out, peptideViewName); %>
-        <%=link("Create or Edit").onClick("showViewDesigner('" + org.labkey.ms2.query.MS2Schema.HiddenTableType.PeptidesFilter + "', 'peptidesCustomizeView', " + PageFlowUtil.jsString(peptideViewSelectId) + "); return false;").id("editPeptidesViewLink") %>
+        <%=link("Create or Edit").onClick("showViewDesigner('" + org.labkey.ms2.query.MS2Schema.HiddenTableType.PeptidesFilter + "', 'peptidesCustomizeView', " + PageFlowUtil.jsString(peptideViewSelectId) + "); return false;") %>
 
         <br/>
         <br/>

--- a/ms2/src/org/labkey/ms2/compare/compareProteinProphetQueryOptions.jsp
+++ b/ms2/src/org/labkey/ms2/compare/compareProteinProphetQueryOptions.jsp
@@ -58,7 +58,7 @@ String proteinGroupViewName = form.getProteinGroupCustomViewName(getViewContext(
     <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.peptideFilterType %>" id="<%= text(FilterView.PEPTIDES_CUSTOM_VIEW_RADIO_BUTTON) %>" value="<%= MS2Controller.ProphetFilterType.customView %>"<%=checked(form.isCustomViewPeptideFilter())%>/>
         Peptides that meet the filter criteria in a custom view:
         <% String peptideViewSelectId = bean.getPeptideView().renderViewList(request, out, peptideViewName); %>
-        <%=link("Create or Edit View").onClick("showViewDesigner('" + org.labkey.ms2.query.MS2Schema.HiddenTableType.PeptidesFilter + "', 'peptidesCustomizeView', " + PageFlowUtil.jsString(peptideViewSelectId) + "); return false;").id("editPeptidesViewLink") %>
+        <%=link("Create or Edit View").onClick("showViewDesigner('" + org.labkey.ms2.query.MS2Schema.HiddenTableType.PeptidesFilter + "', 'peptidesCustomizeView', " + PageFlowUtil.jsString(peptideViewSelectId) + "); return false;") %>
 
         <br/>
         <br/>

--- a/ms2/src/org/labkey/ms2/compare/spectraCountOptions.jsp
+++ b/ms2/src/org/labkey/ms2/compare/spectraCountOptions.jsp
@@ -99,7 +99,7 @@
         </script>
 
 
-        <%=link("Create or Edit View").onClick("showViewDesigner('" + org.labkey.ms2.query.MS2Schema.HiddenTableType.PeptidesFilter + "', 'peptidesCustomizeView', " + PageFlowUtil.jsString(peptideViewSelectId) + ", viewSavedCallback); return false;").id("editPeptidesViewLink") %>
+        <%=link("Create or Edit View").onClick("showViewDesigner('" + org.labkey.ms2.query.MS2Schema.HiddenTableType.PeptidesFilter + "', 'peptidesCustomizeView', " + PageFlowUtil.jsString(peptideViewSelectId) + ", viewSavedCallback); return false;") %>
 
         <br/>
         <br/>

--- a/ms2/src/org/labkey/ms2/search/searchProteins.jsp
+++ b/ms2/src/org/labkey/ms2/search/searchProteins.jsp
@@ -70,7 +70,7 @@
                 <div style="padding-top: 5px"><input type="radio" name="<%=PeptideFilteringFormElements.peptideFilterType%>" id="peptideProphetRadioButton" value="<%=MS2Controller.ProphetFilterType.probability%>" <%=checked(bean.getForm().isPeptideProphetFilter())%>/>Minimum PeptideProphet prob <input onfocus="document.getElementById('peptideProphetRadioButton').checked=true;" type="text" size="4" name="<%=PeptideFilteringFormElements.peptideProphetProbability%>" value="<%=h(bean.getForm().getPeptideProphetProbability() == null ? "" : bean.getForm().getPeptideProphetProbability())%>" /></div>
                 <div style="padding-top: 5px"><input type="radio" name="<%=PeptideFilteringFormElements.peptideFilterType%>" id="customViewRadioButton" value="<%=MS2Controller.ProphetFilterType.customView%>"<%=checked(bean.getForm().isCustomViewPeptideFilter())%>/>Custom filter:
                     <% String peptideViewSelectId = bean.getPeptideView(ctx).renderViewList(request, out, viewName); %>
-                    <%=link("Create or Edit View").onClick("showViewDesigner('" + org.labkey.ms2.query.MS2Schema.HiddenTableType.PeptidesFilter + "', 'peptidesCustomizeView', " + PageFlowUtil.jsString(peptideViewSelectId) + "); return false;").id("editPeptidesViewLink") %>
+                    <%=link("Create or Edit View").onClick("showViewDesigner('" + org.labkey.ms2.query.MS2Schema.HiddenTableType.PeptidesFilter + "', 'peptidesCustomizeView', " + PageFlowUtil.jsString(peptideViewSelectId) + "); return false;") %>
                 </div>
                 <span id="peptidesCustomizeView"></span>
             </td>


### PR DESCRIPTION
#### Rationale
The `platform` change that checks for overlapping event handlers flagged these ids. Nothing else references them by ID, so there's not much point in explicitly defining the ids.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3260

#### Changes
* Remove unnecessary link ids to avoid collisions
