### PR TITLE
fromScript() should check null==getExpdData(), see fromLSID()

### DIFF
--- a/flow/src/org/labkey/flow/data/FlowScript.java
+++ b/flow/src/org/labkey/flow/data/FlowScript.java
@@ -60,7 +60,10 @@ public class FlowScript extends FlowDataObject
     {
         if (id == 0)
             return null;
-        return new FlowScript(ExperimentService.get().getExpData(id));
+        ExpData expData = ExperimentService.get().getExpData(id);
+        if (null == expData)
+            return null;
+        return new FlowScript(expData);
     }
 
     static public FlowScript fromLSID(String lsid)


### PR DESCRIPTION
#### Rationale
Add null check for non-existent scriptId

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
