### PR TITLE
Improve setFolderType() method signatures

### DIFF
--- a/flow/src/org/labkey/flow/controllers/FlowController.java
+++ b/flow/src/org/labkey/flow/controllers/FlowController.java
@@ -253,7 +253,7 @@ public class FlowController extends BaseFlowController
 
             destContainer = ContainerManager.createContainer(parent, folderName);
             destContainer.setActiveModules(getContainer().getActiveModules(), getUser());
-            destContainer.setFolderType(getContainer().getFolderType(), getUser());
+            destContainer.setFolderType(getContainer().getFolderType(), getUser(), errors);
             destContainer.setDefaultModule(flowModule);
             FlowProtocol srcProtocol = FlowProtocol.getForContainer(getContainer());
             if (srcProtocol != null)


### PR DESCRIPTION
#### Rationale
We don't need so many overloads of Container.setFolderType()

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3335

#### Changes
* Consolidate to a more reasonable setFolderType() variants
