### PR TITLE
Issue 45498: Show cross-linked peptide sequence info

### DIFF
--- a/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
+++ b/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.protein.ProteinFeature;
 import org.labkey.api.protein.ProteinService;
 import org.labkey.api.query.QueryViewProvider;
@@ -210,6 +211,12 @@ public class ProteinServiceImpl implements ProteinService
                 .stream()
                 .map(org.labkey.ms2.Protein::getSeqId)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public TableInfo getSequencesTable()
+    {
+        return ProteinManager.getTableInfoSequences();
     }
 
     public List<QueryViewProvider<ProteinSearchForm>> getProteinSearchViewProviders()


### PR DESCRIPTION
#### Changes
Expose the prot.sequences table to let TargetedMS module reliably reference it

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/537
* https://github.com/LabKey/platform/pull/3356