### PR TITLE
Adjust logarithmic plots

### DIFF
--- a/flow/enginesrc/org/labkey/flow/analysis/chart/PlotFactory.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/chart/PlotFactory.java
@@ -107,7 +107,13 @@ public class PlotFactory
 
                 // TODO: support other: old simple Log, old LinLog, BiEx, ArcSinH, Hyperlog
                 // TODO: use FCSHeader.LogarithmicParameterDisplay display hint to set up Logicle
-                return new LogicleRangeFunction(min, max);
+
+                double minValue = 0;
+
+                // Issue 45300: the customer wants to see negative values in plot.
+                // However, we don't have a good answer on how to decide the min limit of the plot.
+                // max/1000 seems reasonable based on the limited example data we have.
+                return new LogicleRangeFunction(max/-1000.0, max);
             }
         }
         else

--- a/flow/enginesrc/org/labkey/flow/analysis/chart/PlotFactory.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/chart/PlotFactory.java
@@ -108,8 +108,6 @@ public class PlotFactory
                 // TODO: support other: old simple Log, old LinLog, BiEx, ArcSinH, Hyperlog
                 // TODO: use FCSHeader.LogarithmicParameterDisplay display hint to set up Logicle
 
-                double minValue = 0;
-
                 // Issue 45300: the customer wants to see negative values in plot.
                 // However, we don't have a good answer on how to decide the min limit of the plot.
                 // max/1000 seems reasonable based on the limited example data we have.

--- a/flow/enginesrc/org/labkey/flow/analysis/model/DataFrame.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/DataFrame.java
@@ -147,7 +147,7 @@ public class DataFrame
             for (int i = 0; i < cols; i ++)
             {
                 ScalingFunction fn = fields[i].getScalingFunction();
-                out.data[i].set(r, fn.constrain(b.get(i, 0)));
+                out.data[i].set(r, b.get(i, 0));
             }
         }
         return out;

--- a/flow/enginesrc/org/labkey/flow/analysis/model/ScalingFunction.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/ScalingFunction.java
@@ -186,7 +186,7 @@ public abstract class ScalingFunction implements Cloneable
 		@Override
         public NumberArray translate(NumberArray from)
 		{
-			return new ConstrainedNumberArray(from, getMinValue(), getMaxValue());
+			return from;
 		}
 	}
 


### PR DESCRIPTION
#### Rationale
Don't constrain data values to 'expected' range on load or compensate.
Extend plot low range for logarithmic plots
see issue 45300

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
