### PR TITLE
Issue 45272: Update AssayProvider.getDescription() to not return HTML

### DIFF
--- a/nab/src/org/labkey/nab/NabAssayProvider.java
+++ b/nab/src/org/labkey/nab/NabAssayProvider.java
@@ -264,10 +264,6 @@ public class NabAssayProvider extends AbstractDilutionAssayProvider<NabRunUpload
         return "Imports a specially formatted TSV, CSV or Excel file. " +
                 "Measures neutralization in TZM-bl cells as a function of a reduction in Tat-induced luciferase (Luc) " +
                 "reporter gene expression after a single round of infection. Montefiori, D.C. 2004";
-/*                PageFlowUtil.helpPopup("NAb", "<a href=\"http://www.ncbi.nlm.nih.gov/pubmed/18432938\">" +
-                        "Evaluating neutralizing antibodies against HIV, SIV and SHIV in luciferase " +
-                        "reporter gene assays</a>.  Current Protocols in Immunology, (Coligan, J.E., " +
-                        "A.M. Kruisbeek, D.H. Margulies, E.M. Shevach, W. Strober, and R. Coico, eds.), John Wiley & Sons, 12.11.1-12.11.15.", true); */
     }
 
     @Override

--- a/nab/src/org/labkey/nab/multiplate/CrossPlateDilutionNabAssayProvider.java
+++ b/nab/src/org/labkey/nab/multiplate/CrossPlateDilutionNabAssayProvider.java
@@ -64,10 +64,6 @@ public class CrossPlateDilutionNabAssayProvider extends HighThroughputNabAssayPr
                 "assay differs from the standard NAb assay in that dilutions are assumed to occur across plates, rather than " +
                 "within a single plate.  Both NAb assay types measure neutralization in TZM-bl cells as a function of a " +
                 "reduction in Tat-induced luciferase (Luc) reporter gene expression after a single round of infection. Montefiori, D.C. 2004";
-/*                PageFlowUtil.helpPopup("NAb", "<a href=\"http://www.ncbi.nlm.nih.gov/pubmed/18432938\">" +
-                        "Evaluating neutralizing antibodies against HIV, SIV and SHIV in luciferase " +
-                        "reporter gene assays</a>.  Current Protocols in Immunology, (Coligan, J.E., " +
-                        "A.M. Kruisbeek, D.H. Margulies, E.M. Shevach, W. Strober, and R. Coico, eds.), John Wiley & Sons, 12.11.1-12.11.15.", true); */
     }
 
     @Override

--- a/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabAssayProvider.java
+++ b/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabAssayProvider.java
@@ -77,10 +77,6 @@ public class SinglePlateDilutionNabAssayProvider extends HighThroughputNabAssayP
                 "assay differs from the standard NAb assay in that samples are identical across plates but with a different virus per plate. " +
                 "Dilutions are assumed to occur within a single plate.  Both NAb assay types measure neutralization in TZM-bl cells as a function of a " +
                 "reduction in Tat-induced luciferase (Luc) reporter gene expression after a single round of infection. Montefiori, D.C. 2004";
-/*                PageFlowUtil.popupHelp(HtmlString.unsafe("<a href=\"http://www.ncbi.nlm.nih.gov/pubmed/18432938\">" +
-                        "Evaluating neutralizing antibodies against HIV, SIV and SHIV in luciferase " +
-                        "reporter gene assays</a>.  Current Protocols in Immunology, (Coligan, J.E., " +
-                        "A.M. Kruisbeek, D.H. Margulies, E.M. Shevach, W. Strober, and R. Coico, eds.), John Wiley & Sons, 12.11.1-12.11.15."), "Nab").inlineScript().toString(); */
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We don't want to return HTML via JSON APIs

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3467

#### Changes
* Remove already commented out HTML descriptions. The module is no longer widely distributed so the link is not important anymore.
