### PR TITLE
Don't violate `@NotNull` contract in flow container listener

### DIFF
--- a/flow/src/org/labkey/flow/query/FlowSchema.java
+++ b/flow/src/org/labkey/flow/query/FlowSchema.java
@@ -2024,7 +2024,7 @@ public class FlowSchema extends UserSchema implements UserSchema.HasContextualRo
 
         @Override public void containerCreated(Container c, User user) { }
         @Override public void containerMoved(Container c, Container oldParent, User user) { }
-        @NotNull @Override public Collection<String> canMove(Container c, Container newParent, User user) { return null; }
+        @NotNull @Override public Collection<String> canMove(Container c, Container newParent, User user) { return Collections.emptyList(); }
         @Override public void propertyChange(PropertyChangeEvent evt) { }
     };
 


### PR DESCRIPTION
#### Rationale
`ContainerListener.canMove` shouldn't return `null`
```
java.lang.IllegalStateException: org.labkey.flow.query.FlowSchema$9.canMove() threw an exception or violated @NotNull contract
	at org.labkey.api.data.ContainerManager.move(ContainerManager.java:1521) ~[api-22.7-SNAPSHOT.jar:?]
	at org.labkey.core.CoreController$MoveContainerAction.execute(CoreController.java:935) ~[core-22.7-SNAPSHOT.jar:?]
```

#### Related Pull Requests
* #475 

#### Changes
* Return an empty list from `canMove` instead of null
