### PR TITLE
Issue 550 - Show modified peptide forms in sequence view

### DIFF
--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -4216,6 +4216,7 @@ public class MS2Controller extends SpringActionController
         public String showRunUrl;
         public boolean enableAllPeptidesFeature;
         public boolean showViewSettings;
+        public boolean showLegendAndLabel = true;
         public static final String ALL_PEPTIDES_URL_PARAM = "allPeps";
         public int aaRowWidth;
         public List<ProteinFeature> features = Collections.emptyList();

--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -4215,6 +4215,7 @@ public class MS2Controller extends SpringActionController
         public MS2Run run;
         public String showRunUrl;
         public boolean enableAllPeptidesFeature;
+        public boolean showViewSettings;
         public static final String ALL_PEPTIDES_URL_PARAM = "allPeps";
         public int aaRowWidth;
         public List<ProteinFeature> features = Collections.emptyList();

--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -4273,7 +4273,7 @@ public class MS2Controller extends SpringActionController
                         pep.setSequence(peptide);
                         peptideCharacteristics.add(pep);
                     }
-                    protein.setPeptideCharacteristics(peptideCharacteristics);
+                    protein.setCombinedPeptideCharacteristics(peptideCharacteristics);
                 }
                 protein.setShowEntireFragmentInCoverage(stringSearch);
                 bean.protein = protein;
@@ -4557,7 +4557,7 @@ public class MS2Controller extends SpringActionController
                         pepCharacteristic.setSequence(pep);
                         peptideCharacteristics.add(pepCharacteristic);
                     }
-                    protein.setPeptideCharacteristics(peptideCharacteristics);
+                    protein.setCombinedPeptideCharacteristics(peptideCharacteristics);
                     pcm.setAllPeptideCounts();
 
                     // add filter to get the total and distinct counts of peptides for the target protein to the ProteinCoverageMapBuilder

--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -50,6 +50,7 @@ import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.gwt.server.BaseRemoteService;
 import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.ms.Replicate;
 import org.labkey.api.ms2.MS2Service;
 import org.labkey.api.ms2.MS2Urls;
 import org.labkey.api.pipeline.PipeRoot;
@@ -4217,6 +4218,7 @@ public class MS2Controller extends SpringActionController
         public static final String ALL_PEPTIDES_URL_PARAM = "allPeps";
         public int aaRowWidth;
         public List<ProteinFeature> features = Collections.emptyList();
+        public List<Replicate> replicates = Collections.emptyList();
     }
 
 

--- a/ms2/src/org/labkey/ms2/Protein.java
+++ b/ms2/src/org/labkey/ms2/Protein.java
@@ -437,7 +437,7 @@ public class Protein
             {
                 if (colsCurrentRow >= colsNextRow)
                 {
-                    String linkText = String.format("%d ", counts.countScans );
+                    String linkText = String.format("%d ", counts.intensityRank );
                     if (colsPreviousRow>0)
                         continuationLeft= " &lt;&lt; ";
                     if (colsNextRow>0)
@@ -545,6 +545,7 @@ public class Protein
         @Getter Map<String , Integer> countModifications;
         @Getter @Setter int countInstances;
         @Getter @Setter String peptideColor;
+        @Getter @Setter int intensityRank;
         @Getter @Setter Double intensity;
         @Getter @Setter Double confidence;
         @Getter @Setter String foregroundColor;
@@ -812,6 +813,7 @@ public class Protein
             {
                 PeptideCounts peptideCounts = new PeptideCounts();
                 peptideCounts.setIntensity(peptide.getIntensity());
+                peptideCounts.setIntensityRank(peptide.getIntensityRank());
                 peptideCounts.setConfidence(peptide.getConfidence());
                 peptideCounts.setForegroundColor(peptide.getForegroundColor());
                 peptideCounts.setPeptideColor(peptide.getColor());

--- a/ms2/src/org/labkey/ms2/Protein.java
+++ b/ms2/src/org/labkey/ms2/Protein.java
@@ -453,6 +453,10 @@ public class Protein
                     {
                         txt = counts.confidenceRank;
                     }
+                    else
+                    {
+                        txt = counts.countScans;
+                    }
                     String linkText = String.format("%d ", txt);
                     if (colsPreviousRow>0)
                         continuationLeft= " &lt;&lt; ";
@@ -739,7 +743,7 @@ public class Protein
         List<Range> uncoalescedPeptideRanges = new ArrayList<>();
         if (!_modifiedPeptideCharacteristics.isEmpty())
         {
-            return getModifiedPeptideRanges();
+            return getModifiedPeptideRanges(run);
         }
         else
         {
@@ -868,11 +872,16 @@ public class Protein
         return uniquePeptides;
     }
 
-    public List<Range> getModifiedPeptideRanges()
+    public List<Range> getModifiedPeptideRanges(MS2Run run)
     {
         List<Range> modifiedPeptides = new ArrayList<>();
         if (null == _modifiedPeptideCharacteristics || _modifiedPeptideCharacteristics.size() <= 0)
             return modifiedPeptides;
+
+        // if called from old-style getCoverageRanges, the run value is 0 and we don't care about modifications
+        List<MS2Modification> mods = Collections.emptyList();
+        if (run != null && run.getRun() > -1)
+            mods = MS2Manager.getModifications(run);
 
         for (PeptideCharacteristic peptide : _modifiedPeptideCharacteristics)
         {
@@ -883,6 +892,7 @@ public class Protein
             peptideCounts.setConfidenceRank(peptide.getConfidenceRank());
             peptideCounts.setForegroundColor(peptide.getForegroundColor());
             peptideCounts.setPeptideColor(peptide.getColor());
+            peptideCounts.addPeptide(peptide.getSequence(), mods);
             Range range = new Range(peptide.getStartIndex(), peptide.getEndIndex() - peptide.getStartIndex(), peptideCounts);
             modifiedPeptides.add(range);
         }

--- a/ms2/src/org/labkey/ms2/Protein.java
+++ b/ms2/src/org/labkey/ms2/Protein.java
@@ -474,10 +474,16 @@ public class Protein
                     if (colsNextRow>0)
                         continuationRight=" &gt;&gt; ";
 
+                    details = new StringBuilder();
+
                     if(!_forCoverageMapExport)
                     {
                         mass = getSequenceMass(_sequence.substring(range.start,(range.start + range.length)));
-                        details = new StringBuilder(String.format("Mass: %.2f <br/> Total Scans: %d", mass, counts.countScans));
+                        details.append(String.format("Mass: %.2f ", mass));
+                        if (_combinedPeptideCharacteristics.isEmpty()) // ms2 usage
+                        {
+                            details.append(String.format("<br/> Total Scans: %d", counts.countScans));
+                        }
                     }
 
                     for (String modStr : counts.getCountModifications().keySet())
@@ -904,6 +910,31 @@ public class Protein
         }
     }
 
+    private PeptideCounts createPeptideCounts(PeptideCharacteristic peptide, boolean isCombinedPeptides)
+    {
+        PeptideCounts peptideCounts = new PeptideCounts();
+        peptideCounts.setIntensity(peptide.getIntensity());
+        peptideCounts.setIntensityRank(peptide.getIntensityRank());
+        peptideCounts.setRawIntensity(peptide.getRawIntensity());
+        peptideCounts.setConfidence(peptide.getConfidence());
+        peptideCounts.setRawConfidence(peptide.getRawConfidence());
+        peptideCounts.setConfidenceRank(peptide.getConfidenceRank());
+        peptideCounts.setForegroundColor(peptide.getForegroundColor());
+        peptideCounts.setPeptideColor(peptide.getColor());
+        peptideCounts.setStartIndex(peptide.getStartIndex());
+        peptideCounts.setEndIndex(peptide.getEndIndex());
+        peptideCounts.setSequence(peptide.getSequence());
+        if (isCombinedPeptides)
+        {
+            peptideCounts.setModifiedSequence(peptide.getSequence()); // intentionally setting to sequence for combined peptides
+        }
+        else
+        {
+            peptideCounts.setModifiedSequence(peptide.getModifiedSequence());
+        }
+        return peptideCounts;
+    }
+
     /*
          Method extracted from getCoverageRanges.
          Old style coverage list:  Get rid of variable modification chars and '.',
@@ -938,19 +969,7 @@ public class Protein
             cnt = uniquePeptides.get(peptideToMap);
             if (null == cnt)
             {
-                PeptideCounts peptideCounts = new PeptideCounts();
-                peptideCounts.setIntensity(peptide.getIntensity());
-                peptideCounts.setIntensityRank(peptide.getIntensityRank());
-                peptideCounts.setRawIntensity(peptide.getRawIntensity());
-                peptideCounts.setConfidence(peptide.getConfidence());
-                peptideCounts.setRawConfidence(peptide.getRawConfidence());
-                peptideCounts.setConfidenceRank(peptide.getConfidenceRank());
-                peptideCounts.setForegroundColor(peptide.getForegroundColor());
-                peptideCounts.setPeptideColor(peptide.getColor());
-                peptideCounts.setStartIndex(peptide.getStartIndex());
-                peptideCounts.setEndIndex(peptide.getEndIndex());
-                peptideCounts.setSequence(peptide.getSequence());
-                peptideCounts.setModifiedSequence(peptide.getSequence()); // intentionally setting to sequence for combined peptides
+                PeptideCounts peptideCounts = createPeptideCounts(peptide, true);
                 uniquePeptides.put(peptideToMap, peptideCounts);
                 cnt = uniquePeptides.get(peptideToMap);
             }
@@ -972,19 +991,7 @@ public class Protein
 
         for (PeptideCharacteristic peptide : _modifiedPeptideCharacteristics)
         {
-            PeptideCounts peptideCounts = new PeptideCounts();
-            peptideCounts.setIntensity(peptide.getIntensity());
-            peptideCounts.setRawIntensity(peptide.getRawIntensity());
-            peptideCounts.setIntensityRank(peptide.getIntensityRank());
-            peptideCounts.setConfidence(peptide.getConfidence());
-            peptideCounts.setRawConfidence(peptide.getRawConfidence());
-            peptideCounts.setConfidenceRank(peptide.getConfidenceRank());
-            peptideCounts.setForegroundColor(peptide.getForegroundColor());
-            peptideCounts.setPeptideColor(peptide.getColor());
-            peptideCounts.setStartIndex(peptide.getStartIndex());
-            peptideCounts.setEndIndex(peptide.getEndIndex());
-            peptideCounts.setSequence(peptide.getSequence());
-            peptideCounts.setModifiedSequence(peptide.getModifiedSequence());
+            PeptideCounts peptideCounts = createPeptideCounts(peptide, false);
             peptideCounts.addPeptide(peptide.getSequence(), mods);
             Range range = new Range(peptide.getStartIndex(), peptide.getEndIndex() - peptide.getStartIndex(), peptideCounts);
             modifiedPeptides.add(range);

--- a/ms2/src/org/labkey/ms2/Protein.java
+++ b/ms2/src/org/labkey/ms2/Protein.java
@@ -63,6 +63,7 @@ public class Protein
     private List<Range> _coverageRanges;
     private boolean _computeCoverage = true;
     private boolean _showEntireFragmentInCoverage = false;
+    private boolean _showStakedPeptides = false;
 
     private boolean _forCoverageMapExport = false;
 
@@ -184,6 +185,15 @@ public class Protein
         _bestGeneName = bestGeneName;
     }
 
+    public boolean isShowStakedPeptides()
+    {
+        return _showStakedPeptides;
+    }
+
+    public void setShowStakedPeptides(boolean showStakedPeptides)
+    {
+        _showStakedPeptides = showStakedPeptides;
+    }
 
     static final String startTag = "<font color=\"green\" ><u>";
     static final String endTag = "</u></font>";
@@ -811,6 +821,9 @@ public class Protein
                     _modifiedPeptides.get(pep.getSequence()).add(pep);
                 }
             }
+        }
+        if (_showStakedPeptides)
+        {
             return getModifiedPeptideRanges(run);
         }
         else
@@ -936,6 +949,8 @@ public class Protein
                 peptideCounts.setPeptideColor(peptide.getColor());
                 peptideCounts.setStartIndex(peptide.getStartIndex());
                 peptideCounts.setEndIndex(peptide.getEndIndex());
+                peptideCounts.setSequence(peptide.getSequence());
+                peptideCounts.setModifiedSequence(peptide.getSequence()); // intentionally setting to sequence for combined peptides
                 uniquePeptides.put(peptideToMap, peptideCounts);
                 cnt = uniquePeptides.get(peptideToMap);
             }

--- a/ms2/src/org/labkey/ms2/Protein.java
+++ b/ms2/src/org/labkey/ms2/Protein.java
@@ -437,7 +437,16 @@ public class Protein
             {
                 if (colsCurrentRow >= colsNextRow)
                 {
-                    String linkText = String.format("%d ", counts.intensityRank );
+                    var txt = counts.countInstances;
+                    if (counts.intensityRank != 0)
+                    {
+                        txt = counts.intensityRank;
+                    }
+                    else if (counts.confidenceRank != 0)
+                    {
+                        txt = counts.confidenceRank;
+                    }
+                    String linkText = String.format("%d ", txt);
                     if (colsPreviousRow>0)
                         continuationLeft= " &lt;&lt; ";
                     if (colsNextRow>0)
@@ -546,6 +555,7 @@ public class Protein
         @Getter @Setter int countInstances;
         @Getter @Setter String peptideColor;
         @Getter @Setter int intensityRank;
+        @Getter @Setter int confidenceRank;
         @Getter @Setter Double intensity;
         @Getter @Setter Double confidence;
         @Getter @Setter String foregroundColor;
@@ -815,6 +825,7 @@ public class Protein
                 peptideCounts.setIntensity(peptide.getIntensity());
                 peptideCounts.setIntensityRank(peptide.getIntensityRank());
                 peptideCounts.setConfidence(peptide.getConfidence());
+                peptideCounts.setConfidenceRank(peptide.getConfidenceRank());
                 peptideCounts.setForegroundColor(peptide.getForegroundColor());
                 peptideCounts.setPeptideColor(peptide.getColor());
                 uniquePeptides.put(peptideToMap, peptideCounts);

--- a/ms2/src/org/labkey/ms2/Protein.java
+++ b/ms2/src/org/labkey/ms2/Protein.java
@@ -516,7 +516,9 @@ public class Protein
                         }
                         if (range.pepcounts.modifiedSequence != null)
                         {
-                            if (!_modifiedPeptides.isEmpty() && _modifiedPeptides.get(range.pepcounts.getSequence()).size() > 1)
+                            if (_modifiedPeptides != null &&
+                                    !_modifiedPeptides.isEmpty() &&
+                                    _modifiedPeptides.get(range.pepcounts.getSequence()).size() > 1)
                             {
                                 details.append("<table class='modified-details-table'>");
                                 details.append("<tr>");
@@ -810,7 +812,7 @@ public class Protein
     private List<Range> getUncoalescedPeptideRanges(MS2Run run)
     {
         List<Range> uncoalescedPeptideRanges = new ArrayList<>();
-        if (!_modifiedPeptideCharacteristics.isEmpty())
+        if (_modifiedPeptideCharacteristics != null && !_modifiedPeptideCharacteristics.isEmpty())
         {
             _modifiedPeptides = new HashMap<>();
             // build the modifiedPeptideMap

--- a/ms2/src/org/labkey/ms2/ProteinCoverageMapBuilder.java
+++ b/ms2/src/org/labkey/ms2/ProteinCoverageMapBuilder.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.ms2;
 
-import lombok.Builder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -181,7 +180,7 @@ public class ProteinCoverageMapBuilder
             _protein.setShowEntireFragmentInCoverage(true);
             _protein.setForCoverageMapExport(true);
             _protein.setPeptides(peptides);
-            _protein.setPeptideCharacteristics(createPeptideCharacteristics(peptides));
+            _protein.setCombinedPeptideCharacteristics(createPeptideCharacteristics(peptides));
 
             String coverage = _protein.getCoverageMap(null, null).toString();
             String expectedHtml = "<div><table id=\"peptideMap\" border=\"1\"  >" +
@@ -203,7 +202,7 @@ public class ProteinCoverageMapBuilder
             String[] peptides2 = {"K.LC'TPTMPSNGTLK.T", "K.LC'TPTMPSNGTLK.T", "K.LIAYNEGSFFIR.G", "R.IINTASPAGLFGNFGQANYSAAK.M",
                     "R.VIGQLFEVGGGWC'GQTR.W", "R.VIGQLFEVGGGWC'GQTR.W", "R.VIGQLFEVGGGWC'GQTR.W"};
 
-            _protein.setPeptideCharacteristics(createPeptideCharacteristics(peptides1));
+            _protein.setCombinedPeptideCharacteristics(createPeptideCharacteristics(peptides1));
             ProteinCoverageMapBuilder pcm1 = new ProteinCoverageMapBuilder(null, _protein, _run, f, false);
 
             Set<String> distinct = new HashSet<>(Arrays.asList(peptides1));
@@ -237,7 +236,7 @@ public class ProteinCoverageMapBuilder
             // add some peptide filter conditions and check the header info line
             f.addCondition(FieldKey.fromParts("Scan"), 100, CompareType.NEQ_OR_NULL);
             f.addCondition(FieldKey.fromParts("PeptideProhet"), 0.9, CompareType.GTE);
-            _protein.setPeptideCharacteristics(createPeptideCharacteristics(peptides2));
+            _protein.setCombinedPeptideCharacteristics(createPeptideCharacteristics(peptides2));
             ProteinCoverageMapBuilder pcm2 = new ProteinCoverageMapBuilder(null, _protein, _run, f, false);
             distinct = new HashSet<>(Arrays.asList(peptides2));
             counts = new Pair<>(peptides2.length, distinct.size());

--- a/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
+++ b/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
@@ -197,6 +197,7 @@ public class ProteinServiceImpl implements ProteinService
         bean.features = getProteinFeatures(accessionForFeatures);
         bean.aaRowWidth = aaRowWidth;
         bean.replicates = replicates;
+        bean.showViewSettings = true;
         bean.protein.setModifiedPeptideCharacteristics(modifiedPeptideCharacteristics);
         bean.protein.setShowStakedPeptides(showStackedPeptides);
         return new JspView<>("/org/labkey/ms2/proteinCoverageMap.jsp", bean);

--- a/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
+++ b/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
@@ -24,6 +24,7 @@ import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.ms.Replicate;
 import org.labkey.api.protein.PeptideCharacteristic;
 import org.labkey.api.protein.ProteinFeature;
 import org.labkey.api.protein.ProteinService;
@@ -183,6 +184,19 @@ public class ProteinServiceImpl implements ProteinService
         bean.protein.setPeptideCharacteristics(peptideCharacteristics);
         bean.features = getProteinFeatures(accessionForFeatures);
         bean.aaRowWidth = aaRowWidth;
+        return new JspView<>("/org/labkey/ms2/proteinCoverageMap.jsp", bean);
+    }
+
+    @Override
+    public WebPartView<?> getProteinCoverageViewWithSettings(int seqId, List<PeptideCharacteristic> peptideCharacteristics, List<Replicate> replicates, int aaRowWidth, boolean showEntireFragmentInCoverage, @Nullable String accessionForFeatures)
+    {
+        MS2Controller.ProteinViewBean bean = new MS2Controller.ProteinViewBean();
+        bean.protein = ProteinManager.getProtein(seqId);
+        bean.protein.setShowEntireFragmentInCoverage(showEntireFragmentInCoverage);
+        bean.protein.setPeptideCharacteristics(peptideCharacteristics);
+        bean.features = getProteinFeatures(accessionForFeatures);
+        bean.aaRowWidth = aaRowWidth;
+        bean.replicates = replicates;
         return new JspView<>("/org/labkey/ms2/proteinCoverageMap.jsp", bean);
     }
 

--- a/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
+++ b/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
@@ -181,22 +181,23 @@ public class ProteinServiceImpl implements ProteinService
         MS2Controller.ProteinViewBean bean = new MS2Controller.ProteinViewBean();
         bean.protein = ProteinManager.getProtein(seqId);
         bean.protein.setShowEntireFragmentInCoverage(showEntireFragmentInCoverage);
-        bean.protein.setPeptideCharacteristics(peptideCharacteristics);
+        bean.protein.setCombinedPeptideCharacteristics(peptideCharacteristics);
         bean.features = getProteinFeatures(accessionForFeatures);
         bean.aaRowWidth = aaRowWidth;
         return new JspView<>("/org/labkey/ms2/proteinCoverageMap.jsp", bean);
     }
 
     @Override
-    public WebPartView<?> getProteinCoverageViewWithSettings(int seqId, List<PeptideCharacteristic> peptideCharacteristics, int aaRowWidth, boolean showEntireFragmentInCoverage, @Nullable String accessionForFeatures , List<Replicate> replicates)
+    public WebPartView<?> getProteinCoverageViewWithSettings(int seqId, List<PeptideCharacteristic> peptideCharacteristics, int aaRowWidth, boolean showEntireFragmentInCoverage, @Nullable String accessionForFeatures , List<Replicate> replicates, List<PeptideCharacteristic> modifiedPeptideCharacteristics)
     {
         MS2Controller.ProteinViewBean bean = new MS2Controller.ProteinViewBean();
         bean.protein = ProteinManager.getProtein(seqId);
         bean.protein.setShowEntireFragmentInCoverage(showEntireFragmentInCoverage);
-        bean.protein.setPeptideCharacteristics(peptideCharacteristics);
+        bean.protein.setCombinedPeptideCharacteristics(peptideCharacteristics);
         bean.features = getProteinFeatures(accessionForFeatures);
         bean.aaRowWidth = aaRowWidth;
         bean.replicates = replicates;
+        bean.protein.setModifiedPeptideCharacteristics(modifiedPeptideCharacteristics);
         return new JspView<>("/org/labkey/ms2/proteinCoverageMap.jsp", bean);
     }
 

--- a/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
+++ b/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
@@ -188,7 +188,7 @@ public class ProteinServiceImpl implements ProteinService
     }
 
     @Override
-    public WebPartView<?> getProteinCoverageViewWithSettings(int seqId, List<PeptideCharacteristic> peptideCharacteristics, int aaRowWidth, boolean showEntireFragmentInCoverage, @Nullable String accessionForFeatures , List<Replicate> replicates, List<PeptideCharacteristic> modifiedPeptideCharacteristics)
+    public WebPartView<?> getProteinCoverageViewWithSettings(int seqId, List<PeptideCharacteristic> peptideCharacteristics, int aaRowWidth, boolean showEntireFragmentInCoverage, @Nullable String accessionForFeatures , List<Replicate> replicates, List<PeptideCharacteristic> modifiedPeptideCharacteristics, boolean showStackedPeptides)
     {
         MS2Controller.ProteinViewBean bean = new MS2Controller.ProteinViewBean();
         bean.protein = ProteinManager.getProtein(seqId);
@@ -198,6 +198,7 @@ public class ProteinServiceImpl implements ProteinService
         bean.aaRowWidth = aaRowWidth;
         bean.replicates = replicates;
         bean.protein.setModifiedPeptideCharacteristics(modifiedPeptideCharacteristics);
+        bean.protein.setShowStakedPeptides(showStackedPeptides);
         return new JspView<>("/org/labkey/ms2/proteinCoverageMap.jsp", bean);
     }
 

--- a/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
+++ b/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
@@ -188,7 +188,7 @@ public class ProteinServiceImpl implements ProteinService
     }
 
     @Override
-    public WebPartView<?> getProteinCoverageViewWithSettings(int seqId, List<PeptideCharacteristic> peptideCharacteristics, List<Replicate> replicates, int aaRowWidth, boolean showEntireFragmentInCoverage, @Nullable String accessionForFeatures)
+    public WebPartView<?> getProteinCoverageViewWithSettings(int seqId, List<PeptideCharacteristic> peptideCharacteristics, int aaRowWidth, boolean showEntireFragmentInCoverage, @Nullable String accessionForFeatures , List<Replicate> replicates)
     {
         MS2Controller.ProteinViewBean bean = new MS2Controller.ProteinViewBean();
         bean.protein = ProteinManager.getProtein(seqId);

--- a/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
+++ b/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
@@ -45,7 +45,9 @@
     var peptideFormParam = currentURL.getParameter("peptideForm");
     var isIntensityView = viewByParam == null || viewByParam.equalsIgnoreCase("intensity");
     var isConfidenceView = viewByParam != null && viewByParam.equalsIgnoreCase("confidenceScore");
-    var isCombinedOrStacked = peptideFormParam == null || peptideFormParam.equalsIgnoreCase("combined") ? "combined" : peptideFormParam.equalsIgnoreCase("stacked") ? "stacked" : "combined";
+    var isCombined = peptideFormParam == null ||
+            peptideFormParam.equalsIgnoreCase(PeptideCharacteristic.COMBINED_PEPTIDE) ||
+            (!peptideFormParam.equalsIgnoreCase(PeptideCharacteristic.STACKED_PEPTIDE));
 
     // list to store values min, max and mean values displayed on legend
     List<Double> legendValues =  new ArrayList<>();
@@ -85,11 +87,11 @@
 
     <label>Modified forms:</label>
     <span class="peptideForms">
-        <input type="radio" name="combinedOrStacked" id="combined" value="combined" <%=checked(isCombinedOrStacked.equalsIgnoreCase("combined"))%> onclick="LABKEY.ms2.PeptideCharacteristicLegend.changeView('peptideForm', 'combined')"/>
+        <input type="radio" name="combinedOrStacked" id="combined" value="combined" <%=checked(isCombined)%> onclick="LABKEY.ms2.PeptideCharacteristicLegend.changeView('peptideForm', 'combined')"/>
         <label for="combined">Combined</label>
 
         <span class="stackedForm" >
-            <input type="radio" name="combinedOrStacked" id="stacked" value="stacked" <%=checked(isCombinedOrStacked.equalsIgnoreCase("stacked"))%> onclick="LABKEY.ms2.PeptideCharacteristicLegend.changeView('peptideForm', 'stacked')"/>
+            <input type="radio" name="combinedOrStacked" id="stacked" value="stacked" <%=checked(!isCombined)%> onclick="LABKEY.ms2.PeptideCharacteristicLegend.changeView('peptideForm', 'stacked')"/>
             <label for="stacked" >Stacked</label>
         </span>
     </span>
@@ -106,13 +108,13 @@
     var modifiedPeptideCharacteristics = bean.protein.getModifiedPeptideCharacteristics();
     List<PeptideCharacteristic> peptidesForSequenceMapDisplay;
 
-    if (isCombinedOrStacked.equalsIgnoreCase("stacked"))
+    if (isCombined)
     {
-        peptidesForSequenceMapDisplay = modifiedPeptideCharacteristics;
+        peptidesForSequenceMapDisplay = combinedPeptideCharacteristics;
     }
     else
     {
-        peptidesForSequenceMapDisplay = combinedPeptideCharacteristics;
+        peptidesForSequenceMapDisplay = modifiedPeptideCharacteristics;
     }
     Map<Double, String> heatMapColorHex = new HashMap<>();
     if (combinedPeptideCharacteristics != null)
@@ -268,8 +270,7 @@
             legendLabel = "Intensity";
             legendScale = "(Log 10 base)";
         }
-        else if (isConfidenceView)
-        {
+        else {
             legendLabel = "Confidence Score";
             legendScale = "-(Log 10 base)";
         }

--- a/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
+++ b/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
@@ -94,7 +94,7 @@
             for (int i = 0; i < peptideCharacteristics.size(); i++)
             {
                 var peptideCharacteristic = peptideCharacteristics.get(i);
-                if (peptideCharacteristic.getIntensity() != null)
+                if (peptideCharacteristic.getIntensity() != null && peptideCharacteristic.getIntensity() != 0)
                 {
                     peptideCharacteristic.setIntensityRank(i+1); // ranks are 1 based
                     iValues.add(peptideCharacteristic.getIntensity());
@@ -110,12 +110,15 @@
                 if (o1.getConfidence() == null) return -1;
                 return o2.getConfidence().compareTo(o1.getConfidence());
             });
-            peptideCharacteristics.forEach(peptideCharacteristic -> {
-                if (peptideCharacteristic.getConfidence() != null)
+            for (int i = 0; i < peptideCharacteristics.size(); i++)
+            {
+                var peptideCharacteristic = peptideCharacteristics.get(i);
+                if (peptideCharacteristic.getConfidence() != null && peptideCharacteristic.getConfidence() != 0)
                 {
+                    peptideCharacteristic.setConfidenceRank(i+1);
                     iValues.add(peptideCharacteristic.getConfidence());
                 }
-            });
+            }
         }
 
         if (iValues.size() > 1)

--- a/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
+++ b/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
@@ -24,20 +24,24 @@
 <%@ page import="org.labkey.ms2.MS2Controller" %>
 <%@ page import="java.awt.*" %>
 <%@ page import="java.util.ArrayList" %>
+<%@ page import="java.util.Collections" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.Set" %>
+<%@ page import="java.util.TreeMap" %>
 <%@ page import="java.util.TreeSet" %>
 <%@ page import="java.util.stream.Collectors" %>
-<%@ page import="java.util.Collections" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
     MS2Controller.ProteinViewBean bean = ((JspView<MS2Controller.ProteinViewBean>)HttpView.currentView()).getModelBean();
     var currentURL = getActionURL();
     var viewByParam = currentURL.getParameter("viewBy");
     var isIntensityView = viewByParam == null || viewByParam.equalsIgnoreCase("intensity");
     var isConfidenceView = viewByParam != null && viewByParam.equalsIgnoreCase("confidenceScore");
+    Map<Long, String> replicates = new TreeMap<>();
+    bean.replicates.forEach(rep -> replicates.put(rep.getId(), rep.getName()));
 %>
 <%!
     @Override
@@ -58,6 +62,11 @@
     <select name="peptideSettings" id="peptide-setting-select" onchange="LABKEY.ms2.PeptideCharacteristicLegend.changeView()">
         <option value="intensity" <%=isIntensityView ? h("selected") : h("")%> >Intensity</option>
         <option value="confidenceScore" <%=isConfidenceView ? h("selected") : h("")%> >Confidence Score</option>
+    </select>
+
+    <label for="peptide-replicate-select">Replicate:</label>
+    <select name="replicateSettings" id="peptide-replicate-select"  onchange="LABKEY.ms2.PeptideCharacteristicLegend.changeView()">
+        <labkey:options map="<%=replicates%>" value="<%=bean.replicates.get(0)%>"/>
     </select>
 </div>
 <%

--- a/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
+++ b/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
@@ -38,10 +38,15 @@
     MS2Controller.ProteinViewBean bean = ((JspView<MS2Controller.ProteinViewBean>)HttpView.currentView()).getModelBean();
     var currentURL = getActionURL();
     var viewByParam = currentURL.getParameter("viewBy");
+    var replicateIdParam = currentURL.getParameter("replicateId");
     var isIntensityView = viewByParam == null || viewByParam.equalsIgnoreCase("intensity");
     var isConfidenceView = viewByParam != null && viewByParam.equalsIgnoreCase("confidenceScore");
+
     Map<Long, String> replicates = new TreeMap<>();
+    replicates.put(Long.valueOf(0), "All");
     bean.replicates.forEach(rep -> replicates.put(rep.getId(), rep.getName()));
+
+    var selectedReplicate = replicateIdParam != null && !Long.valueOf(replicateIdParam).equals(Long.valueOf(0)) ? Long.valueOf(replicateIdParam) : replicates.get(Long.valueOf(0));
 %>
 <%!
     @Override
@@ -59,14 +64,14 @@
     <h5><b>View Settings </b></h5>
 
     <label for="peptide-setting-select">By:</label>
-    <select name="peptideSettings" id="peptide-setting-select" onchange="LABKEY.ms2.PeptideCharacteristicLegend.changeView()">
+    <select name="peptideSettings" id="peptide-setting-select" onchange="LABKEY.ms2.PeptideCharacteristicLegend.changeView('viewBy', 'peptide-setting-select')">
         <option value="intensity" <%=isIntensityView ? h("selected") : h("")%> >Intensity</option>
         <option value="confidenceScore" <%=isConfidenceView ? h("selected") : h("")%> >Confidence Score</option>
     </select>
 
     <label for="peptide-replicate-select">Replicate:</label>
-    <select name="replicateSettings" id="peptide-replicate-select"  onchange="LABKEY.ms2.PeptideCharacteristicLegend.changeView()">
-        <labkey:options map="<%=replicates%>" value="<%=bean.replicates.get(0)%>"/>
+    <select name="replicateSettings" id="peptide-replicate-select"  onchange="LABKEY.ms2.PeptideCharacteristicLegend.changeView('replicateId', 'peptide-replicate-select')">
+        <labkey:options map="<%=replicates%>" value="<%=selectedReplicate%>"/>
     </select>
 </div>
 <%

--- a/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
+++ b/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
@@ -90,12 +90,17 @@
                 if (o1.getIntensity() == null) return -1;
                 return o2.getIntensity().compareTo(o1.getIntensity());
             });
-            peptideCharacteristics.forEach(peptideCharacteristic -> {
+
+            for (int i = 0; i < peptideCharacteristics.size(); i++)
+            {
+                var peptideCharacteristic = peptideCharacteristics.get(i);
                 if (peptideCharacteristic.getIntensity() != null)
                 {
+                    peptideCharacteristic.setIntensityRank(i+1); // ranks are 1 based
                     iValues.add(peptideCharacteristic.getIntensity());
                 }
-            });
+            }
+
         }
         if (isConfidenceView)
         {

--- a/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
+++ b/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
@@ -181,16 +181,13 @@
                 legendValues.add(start);
                 start = start - 0.01;
             }
-            iValues.sort(Collections.reverseOrder());
-            var count = iValues.size();
-            var sum = (Double) iValues.stream().mapToDouble(Double::doubleValue).sum();
             var max = Collections.max(iValues);
             var min = Collections.min(iValues);
-            var mean = sum/count;
+            var avg = (max+min)/2;
 
-            // only display min, max and mean in the legend
+            // only display min, max and avg in the legend
             legendValues.set(0, max);
-            legendValues.set(5, (max+min)/2);
+            legendValues.set(5, avg);
             legendValues.set(10, min);
 
             int closestToMeanIndex = 0;
@@ -200,7 +197,7 @@
             for (int i = 0; i < peptidesForSequenceMapDisplay.size(); i++)
             {
                 var value = isIntensityView ? peptidesForSequenceMapDisplay.get(i).getIntensity() : peptidesForSequenceMapDisplay.get(i).getConfidence();
-                var diff = Math.abs(value-mean);
+                var diff = Math.abs(value-avg);
                 if (diff < minDiff)
                 {
                     minDiff = diff;

--- a/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
+++ b/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
@@ -46,6 +46,9 @@
     var isConfidenceView = viewByParam != null && viewByParam.equalsIgnoreCase("confidenceScore");
     var isCombinedOrStacked = peptideFormParam == null || peptideFormParam.equalsIgnoreCase("combined") ? "combined" : peptideFormParam.equalsIgnoreCase("stacked") ? "stacked" : "combined";
 
+    // list to store values min, max and mean values displayed on legend
+    List<Double> legendValues =  new ArrayList<>();
+
     Map<Long, String> replicates = new TreeMap<>();
     replicates.put(Long.valueOf(0), "All");
     bean.replicates.forEach(rep -> replicates.put(rep.getId(), rep.getName()));
@@ -92,16 +95,7 @@
 
 </div>
 <%
-    // list to store values min, max and mean values displayed on legend
-    List<Double> legendValues =  new ArrayList<>();
-    // reason to initialize the values list is for the keys in hexColorMap below
-    var start = Double.MIN_VALUE;
-    // fixed size heatmap legend
-    for (int i = 0; i < 11; i++)
-    {
-        legendValues.add(start);
-        start = start - 0.01;
-    }
+
     // helper list of intensity or confidence score values of peptides used for calculations
     List<Double> iValues = new ArrayList<>();
 
@@ -165,7 +159,6 @@
                 if (peptideCharacteristic.getConfidence() != null && peptideCharacteristic.getConfidence() != 0)
                 {
                     peptideCharacteristic.setConfidenceRank(i+1); // ranks are 1 based
-                    iValues.add(peptideCharacteristic.getConfidence());
                 }
             }
 
@@ -180,6 +173,14 @@
 
         if (iValues.size() > 1)
         {
+            // reason to initialize the values list is for the keys in hexColorMap below
+            var start = Double.MIN_VALUE;
+            // fixed size heatmap legend
+            for (int i = 0; i < 11; i++)
+            {
+                legendValues.add(start);
+                start = start - 0.01;
+            }
             iValues.sort(Collections.reverseOrder());
             var count = iValues.size();
             var sum = (Double) iValues.stream().mapToDouble(Double::doubleValue).sum();
@@ -272,15 +273,18 @@
 <%
     var legendLabel = "";
     var legendScale = "";
-    if (isIntensityView)
+    if (!legendValues.isEmpty())
     {
-        legendLabel = "Intensity";
-        legendScale = "(Log 10 base)";
-    }
-    else if (isConfidenceView)
-    {
-        legendLabel = "Confidence Score";
-        legendScale = "-(Log 10 base)";
+        if (isIntensityView)
+        {
+            legendLabel = "Intensity";
+            legendScale = "(Log 10 base)";
+        }
+        else if (isConfidenceView)
+        {
+            legendLabel = "Confidence Score";
+            legendScale = "-(Log 10 base)";
+        }
     }
 
 %>

--- a/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
+++ b/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
@@ -133,13 +133,6 @@
                 if (peptideCharacteristic.getIntensity() != null && peptideCharacteristic.getIntensity() != 0)
                 {
                     peptideCharacteristic.setIntensityRank(i + 1); // ranks are 1 based
-                }
-            }
-
-            for (PeptideCharacteristic peptideCharacteristic : combinedPeptideCharacteristics)
-            {
-                if (peptideCharacteristic.getIntensity() != null && peptideCharacteristic.getIntensity() != 0)
-                {
                     iValues.add(peptideCharacteristic.getIntensity());
                 }
             }
@@ -160,13 +153,6 @@
                 if (peptideCharacteristic.getConfidence() != null && peptideCharacteristic.getConfidence() != 0)
                 {
                     peptideCharacteristic.setConfidenceRank(i+1); // ranks are 1 based
-                }
-            }
-
-            for (PeptideCharacteristic peptideCharacteristic : combinedPeptideCharacteristics)
-            {
-                if (peptideCharacteristic.getConfidence() != null && peptideCharacteristic.getConfidence() != 0)
-                {
                     iValues.add(peptideCharacteristic.getConfidence());
                 }
             }
@@ -207,25 +193,28 @@
             }
 
             // assign blue colors from mean value to last -> lighter to darker
-            Color one = Color.WHITE;
-            Color two = new Color(0, 81, 138);
-            List<Color> blueGradient = ColorGradient.createGradient(one, two, 6);
-            heatMapColorHex.put(legendValues.get(5), "#" + Integer.toHexString(one.getRGB()).substring(2));
+            Color one = new Color(0, 81, 138);
+            Color two = Color.WHITE;
+            List<Color> blueGradient = ColorGradient.createGradient(one, two, 5);
+            heatMapColorHex.put(legendValues.get(5), "#" + Integer.toHexString(two.getRGB()).substring(2));
 
             // to color the heat map legend
+            Collections.reverse(blueGradient);
             for (int i = 6; i < legendValues.size(); i++)
             {
-                var peptideColor = blueGradient.get(i - 5);
+                var peptideColor = blueGradient.get(i - 6);
                 var hexColor = "#" + Integer.toHexString(peptideColor.getRGB()).substring(2);
                 heatMapColorHex.put(legendValues.get(i), hexColor);
             }
 
             // to color the peptide bars in sequence graph
             blueGradient = ColorGradient.createGradient(one, two, (peptidesForSequenceMapDisplay.size() - closestToMeanIndex + 1));
+            Collections.reverse(blueGradient);
+
             // assign blue colors from median to last -> lighter to darker
             for (int i = closestToMeanIndex + 1; i < peptidesForSequenceMapDisplay.size(); i++)
             {
-                var peptideColor = blueGradient.get(i - closestToMeanIndex);
+                var peptideColor = blueGradient.get(i - closestToMeanIndex+1);
                 var peptideCharacteristic = peptidesForSequenceMapDisplay.get(i);
                 var hexColor = "#" + Integer.toHexString(peptideColor.getRGB()).substring(2);
                 peptideCharacteristic.setColor(hexColor);
@@ -234,9 +223,10 @@
                 peptideCharacteristic.setForegroundColor(ColorGradient.getContrastingForegroundColor(peptideColor));
             }
 
+            peptidesForSequenceMapDisplay.get(peptidesForSequenceMapDisplay.size()-1).setColor("#" + Integer.toHexString(one.getRGB()).substring(2));
+
             // assign red colors from median to first -> lighter to darker
             one = new Color(187, 78, 78);
-            two = Color.WHITE;
 
             // to color the heat map legend
             List<Color> redGradient = ColorGradient.createGradient(one, two, 5);
@@ -291,7 +281,7 @@
         <div>
             <strong><%=h(legendLabel)%></strong>
         </div>
-        <div>
+        <div class="heatmap-legendScale">
             <strong><%=h(legendScale)%></strong>
         </div>
     </div>

--- a/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
+++ b/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
@@ -34,6 +34,7 @@
 <%@ page import="java.util.stream.Collectors" %>
 <%@ page import="java.util.Arrays" %>
 <%@ page import="org.labkey.api.protein.PeptideCharacteristic" %>
+<%@ page import="org.labkey.api.ms.Replicate" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%

--- a/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
+++ b/ms2/src/org/labkey/ms2/proteinCoverageMap.jsp
@@ -70,6 +70,10 @@
         dependencies.add("vis/vis");
     }
 %>
+<%
+    if (bean.showViewSettings)
+    {
+%>
 <div class="viewSettings">
     <h5><b>View Settings </b></h5>
 
@@ -98,7 +102,7 @@
 
 </div>
 <%
-
+    }
     // helper list of intensity or confidence score values of peptides used for calculations
     List<Double> iValues = new ArrayList<>();
 

--- a/ms2/webapp/MS2/PeptideCharacteristicLegend.js
+++ b/ms2/webapp/MS2/PeptideCharacteristicLegend.js
@@ -6,7 +6,8 @@ if (!LABKEY.ms2.PeptideCharacteristicLegend) {
     LABKEY.ms2.PeptideCharacteristicLegend = {
 
         addHeatMap: function (peptideCharacteristics, colors) {
-            const rectHeight = document.getElementById('peptideMap').clientHeight/(peptideCharacteristics.length+1); // extra 1 for room
+            const minHeight = document.getElementById('peptideMap').clientHeight < 220 ? 220 : document.getElementById('peptideMap').clientHeight;
+            const rectHeight = minHeight/(peptideCharacteristics.length+1); // extra 1 for room
             const svgHeight = rectHeight * peptideCharacteristics.length;
 
             const svgContainer = d3.select(".heatmap").append("svg")

--- a/ms2/webapp/MS2/PeptideCharacteristicLegend.js
+++ b/ms2/webapp/MS2/PeptideCharacteristicLegend.js
@@ -34,10 +34,10 @@ if (!LABKEY.ms2.PeptideCharacteristicLegend) {
 
         },
 
-        changeView: function () {
-            var viewBy = $("#peptide-setting-select").val();
+        changeView: function (settingName, elementId) {
+            var viewBy = $("#" + elementId).val();
             var currentUrl = new URL(window.location.href);
-            currentUrl.searchParams.set('viewBy', viewBy)
+            currentUrl.searchParams.set(settingName, viewBy)
             window.location = currentUrl.toString();
         }
     }

--- a/ms2/webapp/MS2/PeptideCharacteristicLegend.js
+++ b/ms2/webapp/MS2/PeptideCharacteristicLegend.js
@@ -10,14 +10,14 @@ if (!LABKEY.ms2.PeptideCharacteristicLegend) {
             const len = peptideCharacteristics.length;
             const min = peptideCharacteristics[0];
             const max = peptideCharacteristics[len-1];
-            const y_axis = len * 10;
+            const y_axis = len/2;
             const x_axis = 0;
 
-            var rectWidth = 30;
+            var rectWidth = 25;
             var count = 0;
 
             var svgContainer = d3.select(".heatmap").append("svg")
-                    .attr("height", rectWidth * len + y_axis)
+                    .attr("height", rectWidth * len + 20)
                     .attr("width", 200);
 
             var rect = svgContainer.selectAll(".rect")
@@ -45,7 +45,7 @@ if (!LABKEY.ms2.PeptideCharacteristicLegend) {
                         }
                         return str;
                     })
-                    .attr("y", (d,i) => y_axis + (rectWidth*i) + 25)
+                    .attr("y", (d,i) => y_axis + (rectWidth*i) + 20)
                     .attr("x", x_axis + 35);
 
         },

--- a/ms2/webapp/MS2/PeptideCharacteristicLegend.js
+++ b/ms2/webapp/MS2/PeptideCharacteristicLegend.js
@@ -7,13 +7,17 @@ if (!LABKEY.ms2.PeptideCharacteristicLegend) {
 
         addHeatMap: function (peptideCharacteristics, colors) {
 
-            const y_axis = peptideCharacteristics.length * 10;
+            const len = peptideCharacteristics.length;
+            const min = peptideCharacteristics[0];
+            const max = peptideCharacteristics[len-1];
+            const y_axis = len * 10;
             const x_axis = 0;
 
             var rectWidth = 30;
+            var count = 0;
 
             var svgContainer = d3.select(".heatmap").append("svg")
-                    .attr("height", rectWidth * peptideCharacteristics.length + y_axis)
+                    .attr("height", rectWidth * len + y_axis)
                     .attr("width", 200);
 
             var rect = svgContainer.selectAll(".rect")
@@ -28,7 +32,19 @@ if (!LABKEY.ms2.PeptideCharacteristicLegend) {
             svgContainer.selectAll('.text')
                     .data(peptideCharacteristics)
                     .enter().append('text')
-                    .text((d) => d.toString())
+                    .text((d) => {
+                        var str = "";
+                        if (d.toString() === min.toString() || d.toString() === max.toString() || count === 4) {
+                           str = d.toPrecision(3).toString();
+                        }
+                        if (count === 4) {
+                            count = 0;
+                        }
+                        else {
+                            count++;
+                        }
+                        return str;
+                    })
                     .attr("y", (d,i) => y_axis + (rectWidth*i) + 25)
                     .attr("x", x_axis + 35);
 

--- a/ms2/webapp/MS2/PeptideCharacteristicLegend.js
+++ b/ms2/webapp/MS2/PeptideCharacteristicLegend.js
@@ -33,6 +33,7 @@ if (!LABKEY.ms2.PeptideCharacteristicLegend) {
                     .data(peptideCharacteristics)
                     .enter().append('text')
                     .text((d) => {
+                        // display every 5th value
                         var str = "";
                         if (d.toString() === min.toString() || d.toString() === max.toString() || count === 4) {
                            str = d.toPrecision(3).toString();

--- a/ms2/webapp/MS2/PeptideCharacteristicLegend.js
+++ b/ms2/webapp/MS2/PeptideCharacteristicLegend.js
@@ -6,54 +6,41 @@ if (!LABKEY.ms2.PeptideCharacteristicLegend) {
     LABKEY.ms2.PeptideCharacteristicLegend = {
 
         addHeatMap: function (peptideCharacteristics, colors) {
+            const rectHeight = document.getElementById('peptideMap').clientHeight/(peptideCharacteristics.length+1); // extra 1 for room
+            const svgHeight = rectHeight * peptideCharacteristics.length;
 
-            const len = peptideCharacteristics.length;
-            const min = peptideCharacteristics[0];
-            const max = peptideCharacteristics[len-1];
-            const y_axis = len/2;
-            const x_axis = 0;
-
-            var rectWidth = 25;
-            var count = 0;
-
-            var svgContainer = d3.select(".heatmap").append("svg")
-                    .attr("height", rectWidth * len + 20)
+            const svgContainer = d3.select(".heatmap").append("svg")
+                    .attr("height", svgHeight)
                     .attr("width", 200);
 
-            var rect = svgContainer.selectAll(".rect")
+            const rect = svgContainer.selectAll(".rect")
                     .data(peptideCharacteristics)
                     .enter()
                     .append("rect");
-            rect.attr("y", (d,i) => y_axis + (rectWidth*i))
-                    .attr("x", function (d, i) { return x_axis; })
-                    .attr("height", rectWidth)
+            rect.attr("y", (d,i) => rectHeight*i)
+                    .attr("x", function (d, i) { return 0; })
+                    .attr("height", rectHeight)
                     .attr("width", 20)
                     .style("fill", (d) => colors[d]);
             svgContainer.selectAll('.text')
                     .data(peptideCharacteristics)
                     .enter().append('text')
                     .text((d) => {
-                        // display every 5th value
                         var str = "";
-                        if (d.toString() === min.toString() || d.toString() === max.toString() || count === 4) {
+                        if (d.toString() > 0.0) {
                            str = d.toPrecision(3).toString();
                         }
-                        if (count === 4) {
-                            count = 0;
-                        }
-                        else {
-                            count++;
-                        }
+
                         return str;
                     })
-                    .attr("y", (d,i) => y_axis + (rectWidth*i) + 20)
-                    .attr("x", x_axis + 35);
+                    .attr("y", (d,i) => (rectHeight*i) + rectHeight/2) // place text at the center of rect
+                    .attr("x", 35);
 
         },
 
         changeView: function (settingName, elementId) {
-            var viewBy = $("#" + elementId).val();
-            var currentUrl = new URL(window.location.href);
+            const viewBy = $("#" + elementId).val();
+            const currentUrl = new URL(window.location.href);
             currentUrl.searchParams.set(settingName, viewBy)
             window.location = currentUrl.toString();
         }

--- a/ms2/webapp/MS2/ProteinCoverageMap.css
+++ b/ms2/webapp/MS2/ProteinCoverageMap.css
@@ -86,3 +86,26 @@
      padding-right: 20px;
      display: inline-block;
 }
+
+ .modified-details-table {
+     border:1px solid #000000;
+ }
+ .modified-details-table tr
+ {
+     border-left: 1px solid black;
+     border-right: 1px solid black;
+ }
+
+ .modified-details-table th
+ {
+     padding: 5px;
+     text-align: center;
+     border: 1px solid #000000;
+ }
+
+ .modified-details-table td
+ {
+     padding: 5px;
+     text-align: center;
+     border: 1px solid #000000;
+ }

--- a/ms2/webapp/MS2/ProteinCoverageMap.css
+++ b/ms2/webapp/MS2/ProteinCoverageMap.css
@@ -30,6 +30,11 @@
     text-align: left;
 }
 
+ .protein-coverage-map {
+     caption-side: bottom;
+ }
+
+
  .protein-coverage-map tr
  {
      border-left: 1px solid black;
@@ -65,6 +70,10 @@
 .viewSettings {
     padding-bottom: 10px;
 }
+
+ .peptideForms {
+     display: inline-block;
+ }
 
 .heatmap {
     display: inline-block;

--- a/ms2/webapp/MS2/ProteinCoverageMap.css
+++ b/ms2/webapp/MS2/ProteinCoverageMap.css
@@ -79,6 +79,10 @@
     display: inline-block;
 }
 
+.heatmap-legendScale {
+    padding-bottom: 5px;
+}
+
 .featuresControls {
     display: inline-block;
 }


### PR DESCRIPTION
#### Rationale
This PR adds more settings to sequence graph view of peptides to filter intensity/confidence score on replicates and to toggle between combined and stacked peptide forms.

![Screen Shot 2022-06-27 at 3 06 22 PM](https://user-images.githubusercontent.com/11548616/176044845-8e538a92-e148-4408-8264-87f3f0405266.png)


#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/572
* https://github.com/LabKey/platform/pull/3489
* https://github.com/LabKey/server/pull/266

#### Changes
* add replicate selection in sequence view
* change to intensity/cscore values legend 
* show peptide in stacked forms
