### PR TITLE
Issue 550 - Show modified peptide forms in sequence view

### DIFF
--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -50,6 +50,7 @@ import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.gwt.server.BaseRemoteService;
 import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.ms.Replicate;
 import org.labkey.api.ms2.MS2Service;
 import org.labkey.api.ms2.MS2Urls;
 import org.labkey.api.pipeline.PipeRoot;
@@ -4214,9 +4215,12 @@ public class MS2Controller extends SpringActionController
         public MS2Run run;
         public String showRunUrl;
         public boolean enableAllPeptidesFeature;
+        public boolean showViewSettings;
+        public boolean showLegendAndLabel = true;
         public static final String ALL_PEPTIDES_URL_PARAM = "allPeps";
         public int aaRowWidth;
         public List<ProteinFeature> features = Collections.emptyList();
+        public List<Replicate> replicates = Collections.emptyList();
     }
 
 
@@ -4271,7 +4275,7 @@ public class MS2Controller extends SpringActionController
                         pep.setSequence(peptide);
                         peptideCharacteristics.add(pep);
                     }
-                    protein.setPeptideCharacteristics(peptideCharacteristics);
+                    protein.setCombinedPeptideCharacteristics(peptideCharacteristics);
                 }
                 protein.setShowEntireFragmentInCoverage(stringSearch);
                 bean.protein = protein;
@@ -4555,7 +4559,7 @@ public class MS2Controller extends SpringActionController
                         pepCharacteristic.setSequence(pep);
                         peptideCharacteristics.add(pepCharacteristic);
                     }
-                    protein.setPeptideCharacteristics(peptideCharacteristics);
+                    protein.setCombinedPeptideCharacteristics(peptideCharacteristics);
                     pcm.setAllPeptideCounts();
 
                     // add filter to get the total and distinct counts of peptides for the target protein to the ProteinCoverageMapBuilder

--- a/ms2/src/org/labkey/ms2/ProteinCoverageMapBuilder.java
+++ b/ms2/src/org/labkey/ms2/ProteinCoverageMapBuilder.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.ms2;
 
-import lombok.Builder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -181,7 +180,7 @@ public class ProteinCoverageMapBuilder
             _protein.setShowEntireFragmentInCoverage(true);
             _protein.setForCoverageMapExport(true);
             _protein.setPeptides(peptides);
-            _protein.setPeptideCharacteristics(createPeptideCharacteristics(peptides));
+            _protein.setCombinedPeptideCharacteristics(createPeptideCharacteristics(peptides));
 
             String coverage = _protein.getCoverageMap(null, null).toString();
             String expectedHtml = "<div><table id=\"peptideMap\" border=\"1\"  >" +
@@ -203,7 +202,7 @@ public class ProteinCoverageMapBuilder
             String[] peptides2 = {"K.LC'TPTMPSNGTLK.T", "K.LC'TPTMPSNGTLK.T", "K.LIAYNEGSFFIR.G", "R.IINTASPAGLFGNFGQANYSAAK.M",
                     "R.VIGQLFEVGGGWC'GQTR.W", "R.VIGQLFEVGGGWC'GQTR.W", "R.VIGQLFEVGGGWC'GQTR.W"};
 
-            _protein.setPeptideCharacteristics(createPeptideCharacteristics(peptides1));
+            _protein.setCombinedPeptideCharacteristics(createPeptideCharacteristics(peptides1));
             ProteinCoverageMapBuilder pcm1 = new ProteinCoverageMapBuilder(null, _protein, _run, f, false);
 
             Set<String> distinct = new HashSet<>(Arrays.asList(peptides1));
@@ -237,7 +236,7 @@ public class ProteinCoverageMapBuilder
             // add some peptide filter conditions and check the header info line
             f.addCondition(FieldKey.fromParts("Scan"), 100, CompareType.NEQ_OR_NULL);
             f.addCondition(FieldKey.fromParts("PeptideProhet"), 0.9, CompareType.GTE);
-            _protein.setPeptideCharacteristics(createPeptideCharacteristics(peptides2));
+            _protein.setCombinedPeptideCharacteristics(createPeptideCharacteristics(peptides2));
             ProteinCoverageMapBuilder pcm2 = new ProteinCoverageMapBuilder(null, _protein, _run, f, false);
             distinct = new HashSet<>(Arrays.asList(peptides2));
             counts = new Pair<>(peptides2.length, distinct.size());

--- a/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
+++ b/ms2/src/org/labkey/ms2/protein/ProteinServiceImpl.java
@@ -24,6 +24,7 @@ import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.ms.Replicate;
 import org.labkey.api.protein.PeptideCharacteristic;
 import org.labkey.api.protein.ProteinFeature;
 import org.labkey.api.protein.ProteinService;
@@ -180,9 +181,25 @@ public class ProteinServiceImpl implements ProteinService
         MS2Controller.ProteinViewBean bean = new MS2Controller.ProteinViewBean();
         bean.protein = ProteinManager.getProtein(seqId);
         bean.protein.setShowEntireFragmentInCoverage(showEntireFragmentInCoverage);
-        bean.protein.setPeptideCharacteristics(peptideCharacteristics);
+        bean.protein.setCombinedPeptideCharacteristics(peptideCharacteristics);
         bean.features = getProteinFeatures(accessionForFeatures);
         bean.aaRowWidth = aaRowWidth;
+        return new JspView<>("/org/labkey/ms2/proteinCoverageMap.jsp", bean);
+    }
+
+    @Override
+    public WebPartView<?> getProteinCoverageViewWithSettings(int seqId, List<PeptideCharacteristic> peptideCharacteristics, int aaRowWidth, boolean showEntireFragmentInCoverage, @Nullable String accessionForFeatures , List<Replicate> replicates, List<PeptideCharacteristic> modifiedPeptideCharacteristics, boolean showStackedPeptides)
+    {
+        MS2Controller.ProteinViewBean bean = new MS2Controller.ProteinViewBean();
+        bean.protein = ProteinManager.getProtein(seqId);
+        bean.protein.setShowEntireFragmentInCoverage(showEntireFragmentInCoverage);
+        bean.protein.setCombinedPeptideCharacteristics(peptideCharacteristics);
+        bean.features = getProteinFeatures(accessionForFeatures);
+        bean.aaRowWidth = aaRowWidth;
+        bean.replicates = replicates;
+        bean.showViewSettings = true;
+        bean.protein.setModifiedPeptideCharacteristics(modifiedPeptideCharacteristics);
+        bean.protein.setShowStakedPeptides(showStackedPeptides);
         return new JspView<>("/org/labkey/ms2/proteinCoverageMap.jsp", bean);
     }
 

--- a/ms2/webapp/MS2/PeptideCharacteristicLegend.js
+++ b/ms2/webapp/MS2/PeptideCharacteristicLegend.js
@@ -6,38 +6,43 @@ if (!LABKEY.ms2.PeptideCharacteristicLegend) {
     LABKEY.ms2.PeptideCharacteristicLegend = {
 
         addHeatMap: function (peptideCharacteristics, colors) {
+            const minHeight = document.getElementById('peptideMap').clientHeight < 220 ? 220 : document.getElementById('peptideMap').clientHeight;
+            const rectHeight = minHeight/(peptideCharacteristics.length+1); // extra 1 for room
+            const svgHeight = rectHeight * peptideCharacteristics.length;
 
-            const y_axis = peptideCharacteristics.length * 10;
-            const x_axis = 0;
-
-            var rectWidth = 30;
-
-            var svgContainer = d3.select(".heatmap").append("svg")
-                    .attr("height", rectWidth * peptideCharacteristics.length + y_axis)
+            const svgContainer = d3.select(".heatmap").append("svg")
+                    .attr("height", svgHeight)
                     .attr("width", 200);
 
-            var rect = svgContainer.selectAll(".rect")
+            const rect = svgContainer.selectAll(".rect")
                     .data(peptideCharacteristics)
                     .enter()
                     .append("rect");
-            rect.attr("y", (d,i) => y_axis + (rectWidth*i))
-                    .attr("x", function (d, i) { return x_axis; })
-                    .attr("height", rectWidth)
+            rect.attr("y", (d,i) => rectHeight*i)
+                    .attr("x", function (d, i) { return 0; })
+                    .attr("height", rectHeight)
                     .attr("width", 20)
                     .style("fill", (d) => colors[d]);
             svgContainer.selectAll('.text')
                     .data(peptideCharacteristics)
                     .enter().append('text')
-                    .text((d) => d.toString())
-                    .attr("y", (d,i) => y_axis + (rectWidth*i) + 25)
-                    .attr("x", x_axis + 35);
+                    .text((d) => {
+                        var str = "";
+                        if (d.toString() > 0.0) {
+                           str = d.toPrecision(3).toString();
+                        }
+
+                        return str;
+                    })
+                    .attr("y", (d,i) => (rectHeight*i) + rectHeight/2) // place text at the center of rect
+                    .attr("x", 35);
 
         },
 
-        changeView: function () {
-            var viewBy = $("#peptide-setting-select").val();
-            var currentUrl = new URL(window.location.href);
-            currentUrl.searchParams.set('viewBy', viewBy)
+        changeView: function (settingName, elementId) {
+            const viewBy = $("#" + elementId).val();
+            const currentUrl = new URL(window.location.href);
+            currentUrl.searchParams.set(settingName, viewBy)
             window.location = currentUrl.toString();
         }
     }

--- a/ms2/webapp/MS2/ProteinCoverageMap.css
+++ b/ms2/webapp/MS2/ProteinCoverageMap.css
@@ -30,6 +30,11 @@
     text-align: left;
 }
 
+ .protein-coverage-map {
+     caption-side: bottom;
+ }
+
+
  .protein-coverage-map tr
  {
      border-left: 1px solid black;
@@ -66,8 +71,16 @@
     padding-bottom: 10px;
 }
 
+ .peptideForms {
+     display: inline-block;
+ }
+
 .heatmap {
     display: inline-block;
+}
+
+.heatmap-legendScale {
+    padding-bottom: 5px;
 }
 
 .featuresControls {
@@ -77,3 +90,26 @@
      padding-right: 20px;
      display: inline-block;
 }
+
+ .modified-details-table {
+     border:1px solid #000000;
+ }
+ .modified-details-table tr
+ {
+     border-left: 1px solid black;
+     border-right: 1px solid black;
+ }
+
+ .modified-details-table th
+ {
+     padding: 5px;
+     text-align: center;
+     border: 1px solid #000000;
+ }
+
+ .modified-details-table td
+ {
+     padding: 5px;
+     text-align: center;
+     border: 1px solid #000000;
+ }


### PR DESCRIPTION
#### Rationale
This PR adds more settings to sequence graph view of peptides to filter intensity/confidence score on replicates and to toggle between combined and stacked peptide forms.

![Screen Shot 2022-06-27 at 3 06 22 PM](https://user-images.githubusercontent.com/11548616/176044845-8e538a92-e148-4408-8264-87f3f0405266.png)


#### Related Pull Requests
* https://github.com/LabKey/server/pull/275
* https://github.com/LabKey/targetedms/pull/579
* https://github.com/LabKey/platform/pull/3528

#### Changes
* add replicate selection in sequence view
* change to intensity/cscore values legend 
* show peptide in stacked forms
