### PR TITLE
Update artifactory URL for 21.11

### DIFF
--- a/elisa/.npmrc
+++ b/elisa/.npmrc
@@ -1,2 +1,2 @@
 # Set registry for @labkey scopes
-@labkey:registry=https://artifactory.labkey.com/artifactory/api/npm/libs-client/
+@labkey:registry=https://labkey.jfrog.io/artifactory/api/npm/libs-client/

--- a/elisa/package-lock.json
+++ b/elisa/package-lock.json
@@ -2333,12 +2333,12 @@
     },
     "@labkey/api": {
       "version": "1.6.3",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.3.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.3.tgz",
       "integrity": "sha1-TDvflKWLM9jUb427JB0bLIuVQEs="
     },
     "@labkey/build": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-4.0.0.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-4.0.0.tgz",
       "integrity": "sha1-CpieGah7bZRmOFmQMTCvyX+lxv4=",
       "dev": true,
       "requires": {
@@ -2483,7 +2483,7 @@
     },
     "@labkey/components": {
       "version": "2.60.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.60.0.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.60.0.tgz",
       "integrity": "sha1-VmIABgAk8J+nPnu5lyoAJeosBr8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
@@ -2526,7 +2526,7 @@
     },
     "@labkey/eslint-config-base": {
       "version": "0.0.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/eslint-config-base/-/@labkey/eslint-config-base-0.0.8.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/eslint-config-base/-/@labkey/eslint-config-base-0.0.8.tgz",
       "integrity": "sha1-zGBA9a8jgwSAh3TpyWRFaqfFN0s=",
       "dev": true,
       "requires": {
@@ -2543,7 +2543,7 @@
     },
     "@labkey/eslint-config-react": {
       "version": "0.0.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/eslint-config-react/-/@labkey/eslint-config-react-0.0.8.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/eslint-config-react/-/@labkey/eslint-config-react-0.0.8.tgz",
       "integrity": "sha1-5326T0G33/fxDhByI4d3BxwBIrE=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
#### Rationale
Artifactory migration

#### Related Pull Requests
* [Server](https://github.com/LabKey/server/pull/281)

#### Changes
* Update artifactory url in package.json and package-lock.json