### PR TITLE
Issue 45918: LuminexDataHandler update: if samples/unknowns are not run in replicate, persist the row that has the bead count to the DB

### DIFF
--- a/luminex/src/org/labkey/luminex/LuminexDataHandler.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataHandler.java
@@ -487,7 +487,15 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
 
                 // now add the dataRows to the rows list to be persisted
                 for (LuminexDataRow dataRow : dataRows)
-                    rows.put(new DataRowKey(dataRow), dataRow.toMap(analyte));
+                {
+                    DataRowKey rowKey = new DataRowKey(dataRow);
+
+                    // Issue 45918: If samples/unknowns are not run in replicate, persist the row that has the bead count to the DB
+                    if (rows.containsKey(rowKey) && dataRow.getBeadCount() == null)
+                        continue;
+
+                    rows.put(rowKey, dataRow.toMap(analyte));
+                }
             }
 
             List<Integer> dataIds = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45918

When a Luminex data file is imported that has both "summary" and "raw" data sections but the samples are not run in replicate, the two sections are mostly copies of one another. The exception is that the "raw" section has the bead count values, so we want to make sure that is the one that is persisted to the DB.

#### Changes
* LuminexDataHandler change to check for DataRowKey existence in map before replacing
