### PR TITLE
Add npm `--legacy-peer-deps` flag

### DIFF
--- a/elisa/package.json
+++ b/elisa/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "setup": "npm ci",
+    "setup": "npm ci --legacy-peer-deps",
     "build": "npm run build-dev",
     "start-link": "cross-env LINK=true npm run start",
     "start": "cross-env NODE_ENV=development webpack serve --config node_modules/@labkey/build/webpack/watch.config.js",


### PR DESCRIPTION
#### Rationale
Failed javascript builds: https://teamcity.labkey.org/buildConfiguration/LabKey_227Release_Community_ModuleSuites_JavaScript_ElisaModuleJavaScript/1926558?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&expandBuildChangesSection=true

#### Changes
* Add npm legacy dependencies flag
