### PR TITLE
46093: Fix ClassCastException

### DIFF
--- a/flow/src/org/labkey/flow/query/FlowSchema.java
+++ b/flow/src/org/labkey/flow/query/FlowSchema.java
@@ -1375,13 +1375,16 @@ public class FlowSchema extends UserSchema implements UserSchema.HasContextualRo
                 {
                     for (Map.Entry<FieldKey, ColumnInfo> entry : lookupTable.getExtendedColumns(includeHidden).entrySet())
                     {
-                        FieldKey fieldKey = entry.getKey();
-                        BaseColumnInfo col = (BaseColumnInfo)entry.getValue();
+                        MutableColumnInfo mutableColumnInfo;
+                        if (entry.getValue() instanceof BaseColumnInfo col)
+                            mutableColumnInfo = WrappedColumnInfo.wrap(col);
+                        else
+                            mutableColumnInfo = (MutableColumnInfo)entry.getValue();
                         // Add the lookup column FieldKey as a parent to the column's FieldKey
-                        var wrapped = WrappedColumnInfo.wrap(col);
+                        FieldKey fieldKey = entry.getKey();
                         FieldKey newFieldKey = FieldKey.remap(fieldKey, lookupColumn.getFieldKey(), null);
-                        wrapped.setFieldKey(newFieldKey);
-                        ret.put(newFieldKey, wrapped);
+                        mutableColumnInfo.setFieldKey(newFieldKey);
+                        ret.put(newFieldKey, mutableColumnInfo);
                     }
                 }
             }


### PR DESCRIPTION
#### Rationale
Looks like this was related to Matt's previous [fix](https://www.labkey.org/CIML/Support%20Tickets/issues-details.view?issueId=45174) to work around a locked `ColumnInfo`.

Repro is to link flow data into a study and try to create a chart from the dataset.

[Related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46093)