### PR TITLE
Additional logging to help track down MS2Test failure

### DIFF
--- a/ms2/test/src/org/labkey/test/tests/ms2/MS2Test.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/MS2Test.java
@@ -867,6 +867,7 @@ public class MS2Test extends AbstractMS2ImportTest
         assertTextPresent(RUN_GROUP1_NAME2,
                 RUN_GROUP2_NAME,
                 DEFAULT_EXPERIMENT);
+        log(getCurrentRelativeURL()); // Track down MS2Test failure -- are there any parameters that are causing "X!TandemSearches" to be selected?
         new DataRegionTable("XTandemSearchRuns", getDriver()).checkCheckbox(1);
         clickButton("Remove");
 


### PR DESCRIPTION
#### Rationale
MS2Test is failing with no-question-mark-urls experimental feature on. Why?

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->
