### PR TITLE
Use shared Lombok library version property

### DIFF
--- a/ms2/build.gradle
+++ b/ms2/build.gradle
@@ -43,8 +43,8 @@ dependencies {
            )
    )
    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
-   compileOnly 'org.projectlombok:lombok:1.18.24'
-   annotationProcessor 'org.projectlombok:lombok:1.18.24'
+   compileOnly "org.projectlombok:lombok:${lombokVersion}"
+   annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
 
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "published", depExtension: "module")


### PR DESCRIPTION
#### Rationale
We prefer to keep modules in sync for their shared library versions

#### Changes
* Use property to stay current with Lombok updates