### PR TITLE
Add additional logging for FCS folder file watchers

### DIFF
--- a/flow/src/org/labkey/flow/script/FCSDirectoryFileFilter.java
+++ b/flow/src/org/labkey/flow/script/FCSDirectoryFileFilter.java
@@ -15,6 +15,9 @@
  */
 package org.labkey.flow.script;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.file.FileAnalysisTaskPipeline;
 import org.labkey.flow.analysis.model.FCS;
 
@@ -24,6 +27,8 @@ import java.nio.file.Path;
 
 public class FCSDirectoryFileFilter implements FileAnalysisTaskPipeline.FilePathFilter
 {
+    private static final Logger LOG = LogManager.getLogger(PipelineService.class);
+
     @Override
     public boolean accept(Path path)
     {
@@ -34,9 +39,13 @@ public class FCSDirectoryFileFilter implements FileAnalysisTaskPipeline.FilePath
     public boolean accept(File dir)
     {
         if (!dir.isDirectory())
+        {
+            LOG.debug("FCSDirectoryFileFilter : rejecting file because it is not a directory: " + dir.getPath());
             return false;
+        }
 
         File[] fcsFiles = dir.listFiles((FileFilter) FCS.FCSFILTER);
+        LOG.debug("FCSDirectoryFileFilter : found " + (fcsFiles != null ? fcsFiles.length : 0) + " fcs files in : " + dir.getPath());
         return null != fcsFiles && 0 != fcsFiles.length;
     }
 }


### PR DESCRIPTION
#### Rationale
Recently, we have noticed that processing folders of FCS files using the flow filewatcher works either one time or only when the file watcher is re-enabled. We haven't been able to get a local repro on a dev machine but we can see it on client and internal deployments.

This adds some additional logging to help the team narrow down the problem.
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46341)

#### Related PRs

https://github.com/LabKey/premium/pull/349