### PR TITLE
Fix broken decoy summary SQL on PostgreSQL 15.x

### DIFF
--- a/ms2/src/org/labkey/ms2/MS2Manager.java
+++ b/ms2/src/org/labkey/ms2/MS2Manager.java
@@ -103,7 +103,6 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -1548,13 +1547,13 @@ public class MS2Manager
                 .append("(SELECT count(rowId) targets, score1 \n")
                 .append("FROM ms2.fractions f join ms2.peptidesdata p on f.fraction = p.fraction\n")
                 .append("WHERE  f.run = ? and p.decoy = ").append(schema.getSqlDialect().getBooleanFALSE()).append("\n")
-                .append(" and p.hitrank = 1")
+                .append(" and p.hitrank = 1\n")
                 .append("GROUP BY p.score1) t\n")
                 .append("FULL OUTER JOIN\n")
                 .append("(SELECT count(rowId) decoys, score1 \n")
                 .append("FROM ms2.fractions f join ms2.peptidesdata p on f.fraction = p.fraction\n")
                 .append("WHERE f.run = ? and p.decoy = ").append(schema.getSqlDialect().getBooleanTRUE()).append("\n")
-                .append(" and p.hitrank = 1")
+                .append(" and p.hitrank = 1\n")
                 .append("GROUP BY p.score1) d ON t.score1 = d.score1\n")
                 .append("ORDER BY coalesce(t.score1, d.score1) DESC");
         sql.add(run);


### PR DESCRIPTION
#### Rationale
Mascot tests are failing on PostgreSQL 15.0 due to decoy summary SQL syntax errors that have been tolerated on PostgreSQL 14.x & before as well as SQL Server.

From the [PostgreSQL 15 change log](https://www.postgresql.org/docs/current/release-15.html):

```
Prevent [numeric literals](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS-NUMERIC) from having non-numeric trailing characters (Peter Eisentraut)

Previously, query text like 123abc would be interpreted as 123 followed by a separate token abc.
```

New exception:
```
ERROR Table                    2022-11-16T20:42:33,462    http-nio-8111-exec-10 : SQL Exception with SQLState: 42601
org.postgresql.util.PSQLException: ERROR: trailing junk after numeric literal at or near "1G"
  Position: 294
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2676) ~[postgresql-42.5.0.jar:42.5.0]
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2366) ~[postgresql-42.5.0.jar:42.5.0]
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:356) ~[postgresql-42.5.0.jar:42.5.0]
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:496) ~[postgresql-42.5.0.jar:42.5.0]
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:413) ~[postgresql-42.5.0.jar:42.5.0]
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:190) ~[postgresql-42.5.0.jar:42.5.0]
	at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:134) ~[postgresql-42.5.0.jar:42.5.0]
	at org.apache.tomcat.dbcp.dbcp2.DelegatingPreparedStatement.executeQuery(DelegatingPreparedStatement.java:122) ~[tomcat-dbcp.jar:9.0.27]
	at org.apache.tomcat.dbcp.dbcp2.DelegatingPreparedStatement.executeQuery(DelegatingPreparedStatement.java:122) ~[tomcat-dbcp.jar:9.0.27]
	at org.labkey.api.data.dialect.StatementWrapper.executeQuery(StatementWrapper.java:1247) ~[api-22.12-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutingSelector$ExecutingResultSetFactory.executeQuery(SqlExecutingSelector.java:504) ~[api-22.12-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutingSelector$ExecutingResultSetFactory.handleResultSet(SqlExecutingSelector.java:406) ~[api-22.12-SNAPSHOT.jar:?]
	at org.labkey.api.data.BaseSelector.getArrayList(BaseSelector.java:108) ~[api-22.12-SNAPSHOT.jar:?]
	at org.labkey.api.data.BaseSelector.getArrayList(BaseSelector.java:103) ~[api-22.12-SNAPSHOT.jar:?]
	at org.labkey.ms2.MS2Manager.getDecoySummaryForRun(MS2Manager.java:1595) ~[ms2-22.12-SNAPSHOT.jar:?]
	at org.labkey.ms2.pipeline.mascot.MascotRun.getAdditionalRunSummaryView(MascotRun.java:125) ~[ms2-22.12-SNAPSHOT.jar:?]
	at org.labkey.ms2.MS2Controller$ShowRunAction.getView(MS2Controller.java:448) ~[ms2-22.12-SNAPSHOT.jar:?]
	at org.labkey.ms2.MS2Controller$ShowRunAction.getView(MS2Controller.java:389) ~[ms2-22.12-SNAPSHOT.jar:?]
ERROR Table                    2022-11-16T20:42:33,463    http-nio-8111-exec-10 : SQL  [49739]
    SELECT coalesce(t.targets, 0) targetCount, coalesce(d.decoys,0) decoyCount, coalesce(t.score1, d.score1, 0) scoreThreshold FROM
    (SELECT count(rowId) targets, score1 
    FROM ms2.fractions f join ms2.peptidesdata p on f.fraction = p.fraction
    WHERE  f.run = ? and p.decoy = false
     and p.hitrank = 1GROUP BY p.score1) t
    FULL OUTER JOIN
    (SELECT count(rowId) decoys, score1 
    FROM ms2.fractions f join ms2.peptidesdata p on f.fraction = p.fraction
    WHERE f.run = ? and p.decoy = true
     and p.hitrank = 1GROUP BY p.score1) d ON t.score1 = d.score1
    ORDER BY coalesce(t.score1, d.score1) DESC
    ?[1] 8
    ?[2] 8
```
