### PR TITLE
Add missing luminex table foreign key constraints and indices

### DIFF
--- a/luminex/resources/schemas/dbscripts/postgresql/luminex-22.000-22.001.sql
+++ b/luminex/resources/schemas/dbscripts/postgresql/luminex-22.000-22.001.sql
@@ -1,0 +1,13 @@
+
+-- add missing FK constraint and indices for luminex.AnalyteTitration
+ALTER TABLE luminex.AnalyteTitration ADD CONSTRAINT FK_AnalyteTitration_AnalyteId FOREIGN KEY (AnalyteId) REFERENCES luminex.Analyte(RowId);
+CREATE INDEX IDX_LuminexAnalyteTitration_AnalyteId ON luminex.AnalyteTitration(AnalyteId);
+ALTER TABLE luminex.AnalyteTitration ADD CONSTRAINT FK_AnalyteTitration_TitrationId FOREIGN KEY (TitrationId) REFERENCES luminex.Titration(RowId);
+CREATE INDEX IDX_LuminexAnalyteTitration_TitrationId ON luminex.AnalyteTitration(TitrationId);
+
+-- add missing indices for FK constraints on existing table columns
+CREATE INDEX IDX_LuminexCurveFit_AnalyteIdTitrationId ON luminex.CurveFit(AnalyteId, TitrationId);
+CREATE INDEX IDX_LuminexRunExclusion_RunId ON luminex.RunExclusion(RunId);
+CREATE INDEX IDX_LuminexRunExclusionAnalyte_AnalyteId ON luminex.RunExclusionAnalyte(AnalyteId);
+CREATE INDEX IDX_LuminexWellExclusion_DataId ON luminex.WellExclusion(DataId);
+CREATE INDEX IDX_LuminexWellExclusionAnalyte_AnalyteId ON luminex.WellExclusionAnalyte(AnalyteId);

--- a/luminex/src/org/labkey/luminex/LuminexModule.java
+++ b/luminex/src/org/labkey/luminex/LuminexModule.java
@@ -46,7 +46,7 @@ public class LuminexModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 22.000;
+        return 22.001;
     }
 
     @Override

--- a/luminex/src/org/labkey/luminex/query/TitrationTable.java
+++ b/luminex/src/org/labkey/luminex/query/TitrationTable.java
@@ -57,7 +57,8 @@ public class TitrationTable extends AbstractLuminexTable
         String bTRUE = getSchema().getSqlDialect().getBooleanTRUE();
         String bFALSE = getSchema().getSqlDialect().getBooleanFALSE();
         SQLFragment qcReportSQL = new SQLFragment();
-        qcReportSQL.append("(CASE WHEN Standard=").append(bTRUE).append(" OR QCControl=").append(bTRUE);
+        qcReportSQL.append("(CASE WHEN ").append(ExprColumn.STR_TABLE_ALIAS).append(".Standard=").append(bTRUE)
+                .append(" OR ").append(ExprColumn.STR_TABLE_ALIAS).append(".QCControl=").append(bTRUE);
         qcReportSQL.append(" THEN ").append(bTRUE).append(" ELSE ").append(bFALSE).append(" END)");
         addColumn(new ExprColumn(this, "IncludeInQcReport", qcReportSQL, JdbcType.BOOLEAN));
 


### PR DESCRIPTION
#### Rationale
Per discussion with client, the Luminex Levey-Jennings reports are loading very slowly when there is a lot of assay runs for the given graph parameters. In review of the luminex schema tables, there were two missing foreign key constraints and a handful of missing indices on existing FKs. This PR adds those missing items via an upgrade script.

#### Changes
* add FK constraints for luminex.AnalyteTitration table AnalyteId and TitrationId columns
* add missing INDEX on new FK constraints and a few existing ones
