### PR TITLE
Issue 46855: Schema mismatch for elisa.CureveFit

### DIFF
--- a/elisa/resources/schemas/dbscripts/postgresql/elisa-22.000-22.001.sql
+++ b/elisa/resources/schemas/dbscripts/postgresql/elisa-22.000-22.001.sql
@@ -1,0 +1,29 @@
+CREATE SCHEMA IF NOT EXISTS elisa;
+
+CREATE TABLE IF NOT EXISTS elisa.CurveFit
+(
+    RowId SERIAL NOT NULL,
+    Container ENTITYID NOT NULL,
+    Created TIMESTAMP NOT NULL,
+    CreatedBy USERID NOT NULL,
+    Modified TIMESTAMP NOT NULL,
+    ModifiedBy USERID NOT NULL,
+
+    RunId INTEGER NOT NULL,
+    ProtocolId INTEGER NOT NULL,
+    PlateName VARCHAR(250),
+    Spot INTEGER,
+    RSquared DOUBLE PRECISION,
+    FitParameters VARCHAR(500),
+
+    CONSTRAINT PK_CurveFit PRIMARY KEY (RowId),
+    CONSTRAINT FK_CurveFit_ProtocolId FOREIGN KEY (ProtocolId) REFERENCES exp.Protocol (RowId),
+    CONSTRAINT FK_CurveFit_RunId FOREIGN KEY (RunId)
+        REFERENCES exp.ExperimentRun (RowId) MATCH SIMPLE
+        ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+
+CREATE INDEX IF NOT EXISTS IX_CurveFit_ProtocolId ON elisa.CurveFit(ProtocolId);
+CREATE INDEX IF NOT EXISTS IX_CurveFit_RunId ON elisa.CurveFit(RunId);
+
+SELECT core.executeJavaUpgradeCode('moveCurveFitData');

--- a/elisa/resources/schemas/dbscripts/postgresql/elisa-22.000-22.001.sql
+++ b/elisa/resources/schemas/dbscripts/postgresql/elisa-22.000-22.001.sql
@@ -1,3 +1,4 @@
+-- elisa-0.000-20.000.sql somehow failed to run on multiple server, so try adding it again if it doesn't exist. Issue 46855
 CREATE SCHEMA IF NOT EXISTS elisa;
 
 CREATE TABLE IF NOT EXISTS elisa.CurveFit

--- a/elisa/resources/schemas/dbscripts/sqlserver/elisa-22.000-22.001.sql
+++ b/elisa/resources/schemas/dbscripts/sqlserver/elisa-22.000-22.001.sql
@@ -1,0 +1,43 @@
+IF NOT EXISTS(SELECT * FROM sys.Schemas WHERE name = 'elisa')
+    BEGIN
+        EXEC ('CREATE SCHEMA elisa');
+    END
+GO
+
+IF OBJECT_ID(N'elisa.CurveFit', N'U') IS NULL BEGIN
+    CREATE TABLE elisa.CurveFit
+    (
+        RowId INT IDENTITY (1, 1) NOT NULL,
+        Container ENTITYID NOT NULL,
+        Created DATETIME NOT NULL,
+        CreatedBy USERID NOT NULL,
+        Modified DATETIME NOT NULL,
+        ModifiedBy USERID NOT NULL,
+
+        RunId INT NOT NULL,
+        ProtocolId INT NOT NULL,
+        PlateName NVARCHAR(250),
+        Spot INT,
+        RSquared DOUBLE PRECISION,
+        FitParameters NVARCHAR(500),
+
+        CONSTRAINT PK_CurveFit PRIMARY KEY (RowId),
+        CONSTRAINT FK_CurveFit_ProtocolId FOREIGN KEY (ProtocolId) REFERENCES exp.Protocol (RowId),
+        CONSTRAINT FK_CurveFit_ExperimentRun FOREIGN KEY (RunId)
+            REFERENCES exp.ExperimentRun (RowId)
+            ON UPDATE NO ACTION ON DELETE NO ACTION
+    );
+END;
+
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'IX_CurveFit_ProtocolId')
+    BEGIN
+        EXEC ('CREATE INDEX IX_CurveFit_ProtocolId ON elisa.CurveFit(ProtocolId)');
+    END
+GO
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'IX_CurveFit_RunId')
+    BEGIN
+        EXEC ('CREATE INDEX IX_CurveFit_RunId ON elisa.CurveFit(RunId)');
+    END
+GO
+
+EXEC core.executeJavaUpgradeCode 'moveCurveFitData';

--- a/elisa/resources/schemas/dbscripts/sqlserver/elisa-22.000-22.001.sql
+++ b/elisa/resources/schemas/dbscripts/sqlserver/elisa-22.000-22.001.sql
@@ -1,3 +1,4 @@
+-- elisa-0.000-20.000.sql somehow failed to run on multiple server, so try adding it again if it doesn't exist. Issue 46855
 IF NOT EXISTS(SELECT * FROM sys.Schemas WHERE name = 'elisa')
     BEGIN
         EXEC ('CREATE SCHEMA elisa');

--- a/elisa/src/org/labkey/elisa/ElisaModule.java
+++ b/elisa/src/org/labkey/elisa/ElisaModule.java
@@ -47,7 +47,7 @@ public class ElisaModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 22.000;
+        return 22.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
The updated DB schema / XML checker indicated a few servers that, for some reason, didn't have the expected elisa schema in their DB. This PR adds a new upgrade script to conditionally create the schema/table/index objects.

See further details here: https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=46855

#### Changes
* Conditionally rerun the script to get to the expected schema
