### PR TITLE
Migrate to new JSONObject/JSONArray library

### DIFF
--- a/nab/src/org/labkey/nab/NabAssayController.java
+++ b/nab/src/org/labkey/nab/NabAssayController.java
@@ -1222,7 +1222,7 @@ public class NabAssayController extends SpringActionController
 
     public static class QCControlInfo implements CustomApiForm
     {
-        private List<WellExclusion> _exclusions = new ArrayList<>();
+        private final List<WellExclusion> _exclusions = new ArrayList<>();
         private int _runId;
 
         public int getRunId()


### PR DESCRIPTION
#### Rationale
We want to use the new `org.json.JSON*` library