### PR TITLE
Move non-code resources from internal to core and ms2

### DIFF
--- a/ms2/src/META-INF/XMLProteinLoader.uniprot.properties
+++ b/ms2/src/META-INF/XMLProteinLoader.uniprot.properties
@@ -1,0 +1,4 @@
+XMLProteinLoader.uniprot.skipTag.reference =  reference
+XMLProteinLoader.uniprot.skipTag.comment = comment
+XMLProteinLoader.uniprot.skipTag.lineage = lineage
+XMLProteinLoader.uniprot.skipTag.copyright = copyright

--- a/ms2/src/org/labkey/ms2/protein/XMLProteinHandler.java
+++ b/ms2/src/org/labkey/ms2/protein/XMLProteinHandler.java
@@ -16,20 +16,18 @@
 
 package org.labkey.ms2.protein;
 
+import org.labkey.ms2.protein.tools.REProperties;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xml.sax.helpers.XMLReaderFactory;
-import org.xml.sax.SAXException;
-import org.xml.sax.Attributes;
-import org.xml.sax.XMLReader;
-import org.labkey.ms2.protein.tools.REProperties;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
 import java.io.IOException;
 import java.sql.Connection;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * User: brittp
@@ -94,10 +92,10 @@ public class XMLProteinHandler extends DefaultHandler
     protected static final boolean DEFAULT_DYNAMIC_VALIDATION = false;
 
     /* when there is a tag and all its children that we don't want to process, we put it */
-    /* in this list.  The name must be unique within the entire parse tree.  Currently   */
+    /* in this list. The name must be unique within the entire parse tree. Currently,    */
     /* the VALUE part of hashtable is ignored.                                           */
     private String skipMe = null;
-    private XMLProteinLoader _loader;
+    private final XMLProteinLoader _loader;
     public static final String PROGRAM_PREFIX = "XMLProteinLoader";
 
     public XMLProteinHandler(Connection conn, XMLProteinLoader loader) throws SAXException, IOException

--- a/ms2/src/org/labkey/ms2/protein/XMLProteinLoader.java
+++ b/ms2/src/org/labkey/ms2/protein/XMLProteinLoader.java
@@ -26,7 +26,6 @@ import org.xml.sax.SAXException;
 import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
-import java.util.Date;
 
 /**
  * Based loosely on XERCES'


### PR DESCRIPTION
#### Rationale
First step in eliminating the `internal` module

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4006
