### PR TITLE
Fix luminex tests and clean-up

### DIFF
--- a/flow/src/org/labkey/flow/data/FlowAssayProvider.java
+++ b/flow/src/org/labkey/flow/data/FlowAssayProvider.java
@@ -443,7 +443,7 @@ public class FlowAssayProvider extends AbstractAssayProvider
     }
 
     @Override
-    public void deleteProtocol(ExpProtocol protocol, User user)
+    public void deleteProtocol(ExpProtocol protocol, User user, @Nullable final String auditUserComment)
     {
         // Do nothing. Flow protocol can't be deleted.
     }

--- a/luminex/src/org/labkey/luminex/LuminexAssayProvider.java
+++ b/luminex/src/org/labkey/luminex/LuminexAssayProvider.java
@@ -441,9 +441,8 @@ public class LuminexAssayProvider extends AbstractAssayProvider
         return url;
     }
 
-
     @Override
-    public void deleteProtocol(ExpProtocol protocol, User user) throws ExperimentException
+    public void deleteProtocol(ExpProtocol protocol, User user, @Nullable final String auditUserComment) throws ExperimentException
     {
         // Clear out the guide sets that are FK'd to the protocol
         SQLFragment deleteGuideSetSQL = new SQLFragment("DELETE FROM ");
@@ -452,7 +451,7 @@ public class LuminexAssayProvider extends AbstractAssayProvider
         deleteGuideSetSQL.add(protocol.getRowId());
         new SqlExecutor(LuminexProtocolSchema.getSchema()).execute(deleteGuideSetSQL);
 
-        super.deleteProtocol(protocol, user);
+        super.deleteProtocol(protocol, user, auditUserComment);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Test failures due to custom assay protocol clean up https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySuites_DailyDPostgres/2250071?buildTab=tests&name=luminex&expandedTest=build%3A%28id%3A2250071%29%2Cid%3A719

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4063

#### Changes
* Updated the override of `deleteProtocol` for custom AssayProviders