### PR TITLE
Remove reference to internal module as a dependency

### DIFF
--- a/flow/build.gradle
+++ b/flow/build.gradle
@@ -14,7 +14,6 @@ sourceSets {
 
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "engineImplementation", depProjectPath: BuildUtils.getApiProjectPath(project.gradle))
-    BuildUtils.addLabKeyDependency(project: project, config: "engineImplementation", depProjectPath: BuildUtils.getInternalProjectPath(project.gradle))
     engineImplementation "org.labkey.api:labkey-client-api:${labkeyClientApiVersion}"
     engineImplementation "org.apache.tomcat:tomcat-jasper:${apacheTomcatVersion}"
     engineImplementation "org.apache.tomcat:tomcat-jsp-api:${apacheTomcatVersion}"


### PR DESCRIPTION
#### Rationale
The guts of the internal module were moved elsewhere with [platform PR #4015](https://github.com/LabKey/platform/pull/4015).  Now we remove it entirely.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/166
* https://github.com/LabKey/server/pull/398

#### Changes
* Remove references to `BuildUtils.getInternalProjectPath`
