### PR TITLE
Luminex Levey-Jennings report data query performance improvements

### DIFF
--- a/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
+++ b/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
@@ -37,6 +37,8 @@ LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore = function(config)
             "    CASE WHEN gs.ValueBased=true THEN gs.AUCStdDev ELSE cf.AUCStdDev END AS GuideSetAUCStdDev,\n" +
             "    CASE WHEN gs.ValueBased=true THEN gs.MaxFIAverage ELSE gs.TitrationMaxFIAverage END AS GuideSetHighMFIAverage,\n" +
             "    CASE WHEN gs.ValueBased=true THEN gs.MaxFIStdDev ELSE gs.TitrationMaxFIStdDev END AS GuideSetHighMFIStdDev,\n" +
+            "    CASE WHEN gs.ValueBased=true THEN gs.MaxFIAverage ELSE gs.SinglePointControlFIAverage END AS GuideSetMFIAverage,\n" +
+            "    CASE WHEN gs.ValueBased=true THEN gs.MaxFIStdDev ELSE gs.SinglePointControlFIStdDev END AS GuideSetMFIStdDev\n" +
             "FROM GuideSet gs\n" +
             "LEFT JOIN (\n" +
             "    SELECT\n" +
@@ -46,7 +48,7 @@ LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore = function(config)
             "        MIN(CASE WHEN CurveType = 'Four Parameter' THEN EC50Average ELSE NULL END) AS EC504PLAverage,\n" +
             "        MIN(CASE WHEN CurveType = 'Four Parameter' THEN EC50StdDev ELSE NULL END) AS EC504PLStdDev,\n" +
             "        MIN(CASE WHEN CurveType = 'Five Parameter' THEN EC50Average ELSE NULL END) AS EC505PLAverage,\n" +
-            "        MIN(CASE WHEN CurveType = 'Five Parameter' THEN EC50StdDev ELSE NULL END) AS EC505PLStdDev,\n" +
+            "        MIN(CASE WHEN CurveType = 'Five Parameter' THEN EC50StdDev ELSE NULL END) AS EC505PLStdDev\n" +
             "    FROM GuideSetCurveFit\n" +
             "    GROUP BY GuideSetId\n" +
             ") cf ON gs.RowId = cf.GuideSetId";
@@ -96,9 +98,10 @@ LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore = function(config)
     {
         sql += ", AverageFiBkgd AS MFI, AverageFiBkgdQCFlagsEnabled AS MFIQCFlagsEnabled"
             //columns needed for guide set ranges (value based or run based)
-        + ", CASE WHEN GuideSet.ValueBased=true THEN GuideSet.MaxFIAverage ELSE GuideSet.SinglePointControlFIAverage END AS GuideSetMFIAverage"
-        + ", CASE WHEN GuideSet.ValueBased=true THEN GuideSet.MaxFIStdDev ELSE GuideSet.SinglePointControlFIStdDev END AS GuideSetMFIStdDev"
+        + ", gs.GuideSetMFIAverage"
+        + ", gs.GuideSetMFIStdDev"
         + " FROM AnalyteSinglePointControl "
+        + " LEFT JOIN (" + guideSetRangeValuesSQL + ") AS gs ON GuideSet = gs.RowId"
         + whereClause;
     }
 

--- a/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
+++ b/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
@@ -27,6 +27,30 @@ LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore = function(config)
         whereClause += config.whereClause;
     }
 
+    // this version of the guide set range values SQL will prevent the need for multiple LEFT OUTER JOINs to the GuideSetCurveFit table
+    var guideSetRangeValuesSQL = "SELECT gs.RowId, gs.Created, gs.ValueBased,\n" +
+            "    CASE WHEN gs.ValueBased=true THEN gs.EC504PLAverage ELSE cf.EC504PLAverage END AS GuideSetEC504PLAverage,\n" +
+            "    CASE WHEN gs.ValueBased=true THEN gs.EC504PLStdDev ELSE cf.EC504PLStdDev END AS GuideSetEC504PLStdDev,\n" +
+            "    CASE WHEN gs.ValueBased=true THEN gs.EC505PLAverage ELSE cf.EC505PLAverage END AS GuideSetEC505PLAverage,\n" +
+            "    CASE WHEN gs.ValueBased=true THEN gs.EC505PLStdDev ELSE cf.EC505PLStdDev END AS GuideSetEC505PLStdDev,\n" +
+            "    CASE WHEN gs.ValueBased=true THEN gs.AUCAverage ELSE cf.AUCAverage END AS GuideSetAUCAverage,\n" +
+            "    CASE WHEN gs.ValueBased=true THEN gs.AUCStdDev ELSE cf.AUCStdDev END AS GuideSetAUCStdDev,\n" +
+            "    CASE WHEN gs.ValueBased=true THEN gs.MaxFIAverage ELSE gs.TitrationMaxFIAverage END AS GuideSetHighMFIAverage,\n" +
+            "    CASE WHEN gs.ValueBased=true THEN gs.MaxFIStdDev ELSE gs.TitrationMaxFIStdDev END AS GuideSetHighMFIStdDev,\n" +
+            "FROM GuideSet gs\n" +
+            "LEFT JOIN (\n" +
+            "    SELECT\n" +
+            "        GuideSetId,\n" +
+            "        MIN(CASE WHEN CurveType = 'Trapezoidal' THEN AUCAverage ELSE NULL END) AS AUCAverage,\n" +
+            "        MIN(CASE WHEN CurveType = 'Trapezoidal' THEN AUCStdDev ELSE NULL END) AS AUCStdDev,\n" +
+            "        MIN(CASE WHEN CurveType = 'Four Parameter' THEN EC50Average ELSE NULL END) AS EC504PLAverage,\n" +
+            "        MIN(CASE WHEN CurveType = 'Four Parameter' THEN EC50StdDev ELSE NULL END) AS EC504PLStdDev,\n" +
+            "        MIN(CASE WHEN CurveType = 'Five Parameter' THEN EC50Average ELSE NULL END) AS EC505PLAverage,\n" +
+            "        MIN(CASE WHEN CurveType = 'Five Parameter' THEN EC50StdDev ELSE NULL END) AS EC505PLStdDev,\n" +
+            "    FROM GuideSetCurveFit\n" +
+            "    GROUP BY GuideSetId\n" +
+            ") cf ON gs.RowId = cf.GuideSetId";
+
     // generate sql for the data store (columns depend on the control type)
     // issue 22267 : add IFDEFINED to "optional" assay design fields
     var sql = "SELECT Analyte"
@@ -45,9 +69,10 @@ LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore = function(config)
             + ", IFDEFINED(" + controlTypeColName + ".Run.NotebookNo)"
             + ", IFDEFINED(" + controlTypeColName + ".Run.AssayType)"
             + ", IFDEFINED(" + controlTypeColName + ".Run.ExpPerformer)"
-            + ", GuideSet.Created AS GuideSetCreated"
+            + ", GuideSet AS GuideSetId"
+            + ", gs.Created AS GuideSetCreated"
             + ", IncludeInGuideSetCalculation"
-            + ", GuideSet.ValueBased AS GuideSetValueBased";
+            + ", gs.ValueBased AS GuideSetValueBased";
     if (config.controlType == "Titration")
     {
         sql += ", \"Four ParameterCurveFit\".EC50 AS EC504PL, \"Four ParameterCurveFit\".EC50QCFlagsEnabled AS EC504PLQCFlagsEnabled"
@@ -55,15 +80,16 @@ LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore = function(config)
         + ", TrapezoidalCurveFit.AUC, TrapezoidalCurveFit.AUCQCFlagsEnabled"
         + ", MaxFI AS HighMFI, MaxFIQCFlagsEnabled AS HighMFIQCFlagsEnabled"
             //columns needed for guide set ranges (value based or run based)
-        + ", CASE WHEN GuideSet.ValueBased=true THEN GuideSet.EC504PLAverage ELSE GuideSet.\"Four ParameterCurveFit\".EC50Average END AS GuideSetEC504PLAverage"
-        + ", CASE WHEN GuideSet.ValueBased=true THEN GuideSet.EC504PLStdDev ELSE GuideSet.\"Four ParameterCurveFit\".EC50StdDev END AS GuideSetEC504PLStdDev"
-        + ", CASE WHEN GuideSet.ValueBased=true THEN GuideSet.EC505PLAverage ELSE GuideSet.\"Five ParameterCurveFit\".EC50Average END AS GuideSetEC505PLAverage"
-        + ", CASE WHEN GuideSet.ValueBased=true THEN GuideSet.EC505PLStdDev ELSE GuideSet.\"Five ParameterCurveFit\".EC50StdDev END AS GuideSetEC505PLStdDev"
-        + ", CASE WHEN GuideSet.ValueBased=true THEN GuideSet.AUCAverage ELSE GuideSet.TrapezoidalCurveFit.AUCAverage END AS GuideSetAUCAverage"
-        + ", CASE WHEN GuideSet.ValueBased=true THEN GuideSet.AUCStdDev ELSE GuideSet.TrapezoidalCurveFit.AUCStdDev END AS GuideSetAUCStdDev"
-        + ", CASE WHEN GuideSet.ValueBased=true THEN GuideSet.MaxFIAverage ELSE GuideSet.TitrationMaxFIAverage END AS GuideSetHighMFIAverage"
-        + ", CASE WHEN GuideSet.ValueBased=true THEN GuideSet.MaxFIStdDev ELSE GuideSet.TitrationMaxFIStdDev END AS GuideSetHighMFIStdDev"
+        + ", gs.GuideSetEC504PLAverage"
+        + ", gs.GuideSetEC504PLStdDev"
+        + ", gs.GuideSetEC505PLAverage"
+        + ", gs.GuideSetEC505PLStdDev"
+        + ", gs.GuideSetAUCAverage"
+        + ", gs.GuideSetAUCStdDev"
+        + ", gs.GuideSetHighMFIAverage"
+        + ", gs.GuideSetHighMFIStdDev"
         + " FROM AnalyteTitration "
+        + " LEFT JOIN (" + guideSetRangeValuesSQL + ") AS gs ON GuideSet = gs.RowId"
         + whereClause;
     }
     else if (config.controlType == "SinglePoint")

--- a/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
+++ b/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
@@ -80,7 +80,7 @@ LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore = function(config)
         autoLoad: false,
         schemaName: 'assay.Luminex.' + LABKEY.QueryKey.encodePart(config.assayName),
         sql: sql,
-        sort: '-Analyte/Data/AcquisitionDate, -' + controlTypeColName + '/Run/Created',
+        sort: config.sort ? config.sort : '-Analyte/Data/AcquisitionDate, -' + controlTypeColName + '/Run/Created',
         maxRows: config.maxRows ? config.maxRows : -1,
         containerFilter: LABKEY.Query.containerFilter.allFolders,
         scope: config.scope
@@ -275,6 +275,7 @@ LABKEY.LeveyJenningsPlotHelper.getLeveyJenningsPlotWindow = function(protocolId,
                     scope: this, // shouldn't matter but might blow up without it.
                     plotType: plotType,
                     runId: row[controlType+'/Run'],
+                    sort: 'Analyte/Data/AcquisitionDate, ' + controlType + '/Run/Created',
                 };
 
                 _createWindow(config);

--- a/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
@@ -265,7 +265,7 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.grid.GridPanel, {
         this.store.on('exception', function(store, type, action, options, response){
             var errorJson = Ext.util.JSON.decode(response.responseText);
             if (errorJson.exception) {
-                Ext.get('EC504PLTrendPlotDiv').update("<span class='labkey-error'>" + errorJson.exception + "</span>");
+                Ext.get(document.querySelector('.ljTrendPlot').id).update("<span class='labkey-error'>" + errorJson.exception + "</span>");
             }
         });
 

--- a/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
@@ -243,10 +243,6 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.grid.GridPanel, {
         }
 
         // create a new store now that the graph params are selected and bind it to the grid
-        var controlTypeColName = this.controlType == "SinglePoint" ? "SinglePointControl" : this.controlType;
-        var orderByClause = " ORDER BY Analyte.Data.AcquisitionDate DESC, " + controlTypeColName + ".Run.Created DESC"
-                            + " LIMIT " + (hasReportFilter ? "10000" : this.defaultRowSize);
-
         var storeConfig = {
             assayName: this.assayName,
             controlName: this.controlName,
@@ -254,9 +250,9 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.grid.GridPanel, {
             analyte: this.analyte,
             isotype: this.isotype,
             conjugate: this.conjugate,
+            maxRows: !hasReportFilter ? this.defaultRowSize : undefined,
             scope: this,
             loadListener: this.storeLoaded,
-            orderBy: orderByClause
         };
 
         if (whereClause != "")


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Move ORDER BY and LIMIT from the executeSQL sql to the sort and maxRows parameters on the API call
* Fix for sort order of data query in Levey-Jennings plot window
* Levey-Jennings data query change how guide set range values are joined into the results (use a single join instead of joining to the GuideSetCurveFit table multiple times for each curve type)
* Fix for Levey-Jennings error display so that it doesn't hardcode to expect an EC50 plot panel tab
