### PR TITLE
Use PatriciaTrie from Commons Collections 4

### DIFF
--- a/flow/enginesrc/org/labkey/flow/analysis/model/CompensationMatrix.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/CompensationMatrix.java
@@ -801,7 +801,7 @@ public class CompensationMatrix implements Serializable
 
             Date d = fcs.getDateTime();
             // verify the date is correct
-            assertEquals("2016-07-06 09:50:22", DateUtil.formatDateTime(d, "YYYY-MM-dd HH:mm:ss"));
+            assertEquals("2016-07-06 09:50:22", DateUtil.formatDateTime(d, "yyyy-MM-dd HH:mm:ss"));
             CompensationMatrix compensationMatrix = fromSpillKeyword(fcs.getKeywords());
             Assert.assertEquals(compensationMatrix,compensationMatrix);
             String[] expectedNames = {"FITC-A","PE-A","Alexa Fluor 700-A","PerCP-Cy5-5-A","APC-Cy7-A","BV 421-A","BV 510-A"};

--- a/flow/enginesrc/org/labkey/flow/analysis/model/FCSCache.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/model/FCSCache.java
@@ -16,11 +16,11 @@
 
 package org.labkey.flow.analysis.model;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.BlockingCache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
-import org.labkey.api.cache.Wrapper;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,7 +41,7 @@ public class FCSCache
         {
             super(CacheManager.getCache(CACHE_SIZE, CacheManager.DAY, "FCS header cache"), new CacheLoader<URI, FCSHeader>(){
                 @Override
-                public FCSHeader load(URI uri, Object argument)
+                public FCSHeader load(@NotNull URI uri, Object argument)
                 {
                     // should CacheLoader.load() declare throw Exception?
                     try
@@ -58,7 +58,7 @@ public class FCSCache
 
 
         @Override
-        public FCSHeader load(URI uri, Object argument)
+        public FCSHeader load(@NotNull URI uri, Object argument)
         {
             // should CacheLoader.load() declare throw Exception?
             try
@@ -81,7 +81,7 @@ public class FCSCache
         {
             super(CacheManager.getCache(CACHE_SIZE, CacheManager.DAY, "FCS cache"), new CacheLoader<URI, FCS>(){
                 @Override
-                public FCS load(URI uri, Object argument)
+                public FCS load(@NotNull URI uri, Object argument)
                 {
                     // should CacheLoader.load() declare throw Exception?
                     try

--- a/flow/src/org/labkey/flow/persist/AttributeCache.java
+++ b/flow/src/org/labkey/flow/persist/AttributeCache.java
@@ -18,8 +18,8 @@ package org.labkey.flow.persist;
 
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.BlockingCache;
@@ -55,7 +55,7 @@ abstract public class AttributeCache<A extends Comparable<A>, E extends Attribut
     private CacheLoader<String, Attributes<A, E>> BY_CONTAINER_LOADER = new CacheLoader<String, Attributes<A, E>>()
     {
         @Override
-        public Attributes<A, E> load(String containerId, @Nullable Object argument)
+        public Attributes<A, E> load(@NotNull String containerId, @Nullable Object argument)
         {
             LOG.debug("Loading " + _type + " by containerId: " + containerId);
             Collection<FlowEntry> entries = FlowManager.get().getAttributeEntries(containerId, _type);

--- a/ms2/build.gradle
+++ b/ms2/build.gradle
@@ -7,28 +7,16 @@ plugins {
 
 dependencies {
    BuildUtils.addExternalDependency(
-           project,
-           new ExternalDependency(
-                   "org.ardverk:patricia-trie:${patriciaTrieVersion}",
-                   "PATRICIA Trie",
-                   "PATRICIA Trie",
-                   "http://code.google.com/p/patricia-trie/",
-                   ExternalDependency.APACHE_2_LICENSE_NAME,
-                   ExternalDependency.APACHE_2_LICENSE_URL,
-                   "PATRICIA Trie data structure implementation"
-           )
-   )
-   BuildUtils.addExternalDependency(
-           project,
-           new ExternalDependency(
-                   "org.xerial:sqlite-jdbc:${sqliteJdbcVersion}",
-                   "SQLite JDBC Driver",
-                   "bitbucket.org",
-                   "https://bitbucket.org/xerial/sqlite-jdbc/wiki/Home",
-                   ExternalDependency.APACHE_2_LICENSE_NAME,
-                   ExternalDependency.APACHE_2_LICENSE_URL,
-                   "SQLite JDBC Driver"
-           )
+      project,
+      new ExternalDependency(
+         "org.xerial:sqlite-jdbc:${sqliteJdbcVersion}",
+         "SQLite JDBC Driver",
+         "bitbucket.org",
+         "https://bitbucket.org/xerial/sqlite-jdbc/wiki/Home",
+         ExternalDependency.APACHE_2_LICENSE_NAME,
+         ExternalDependency.APACHE_2_LICENSE_URL,
+         "SQLite JDBC Driver"
+      )
    )
    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
    compileOnly "org.projectlombok:lombok:${lombokVersion}"

--- a/ms2/src/org/labkey/ms2/protein/fasta/FastaValidator.java
+++ b/ms2/src/org/labkey/ms2/protein/fasta/FastaValidator.java
@@ -32,7 +32,7 @@ public class FastaValidator
     {
     }
 
-    //** Determine if any
+    /** Determine if FASTA file has any duplicate protein names **/
     public List<String> validate(File fastaFile)
     {
         List<String> errors = new ArrayList<>();

--- a/ms2/src/org/labkey/ms2/protein/fasta/FastaValidator.java
+++ b/ms2/src/org/labkey/ms2/protein/fasta/FastaValidator.java
@@ -15,9 +15,7 @@
  */
 package org.labkey.ms2.protein.fasta;
 
-import org.ardverk.collection.ByteArrayKeyAnalyzer;
-import org.ardverk.collection.PatriciaTrie;
-import org.labkey.api.util.StringUtilsLabKey;
+import org.apache.commons.collections4.trie.PatriciaTrie;
 
 import java.io.File;
 import java.text.DecimalFormat;
@@ -25,36 +23,28 @@ import java.text.Format;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * User: adam
- * Date: Jan 12, 2008
- * Time: 7:43:36 PM
- */
 public class FastaValidator
 {
     /** Use a trie to get space-efficient storage */
-    private final PatriciaTrie _proteinNames = new PatriciaTrie<>(ByteArrayKeyAnalyzer.VARIABLE);
+    private final PatriciaTrie<String> _proteinNames = new PatriciaTrie<>();
 
     public FastaValidator()
     {
     }
 
+    //** Determine if any
     public List<String> validate(File fastaFile)
     {
         List<String> errors = new ArrayList<>();
         Format lineFormat = DecimalFormat.getIntegerInstance();
         ProteinFastaLoader curLoader = new ProteinFastaLoader(fastaFile);
 
-        //noinspection ForLoopReplaceableByForEach
         for (ProteinFastaLoader.ProteinIterator proteinIterator = curLoader.iterator(); proteinIterator.hasNext();)
         {
             Protein protein = proteinIterator.next();
-
-            // Use UTF-8 encoding so that we only use a single byte for ASCII characters
             String lookupString = protein.getLookup().toLowerCase();
-            byte[] lookup = lookupString.getBytes(StringUtilsLabKey.DEFAULT_CHARSET);
 
-            if (_proteinNames.containsKey(lookup))
+            if (_proteinNames.containsKey(lookupString))
             {
                 errors.add("Line " + lineFormat.format(proteinIterator.getLastHeaderLineNum()) + ": " + lookupString + " is a duplicate protein name");
 
@@ -66,7 +56,7 @@ public class FastaValidator
             }
             else
             {
-                _proteinNames.put(lookup, null);
+                _proteinNames.put(lookupString, null);
             }
         }
 

--- a/ms2/src/org/labkey/ms2/protein/fasta/ProteinFastaLoader.java
+++ b/ms2/src/org/labkey/ms2/protein/fasta/ProteinFastaLoader.java
@@ -29,13 +29,7 @@ public class ProteinFastaLoader extends FastaLoader<Protein> implements Iterable
 {
     public ProteinFastaLoader(File fastaFile)
     {
-        super(fastaFile, new FastaIteratorElementFactory<Protein>() {
-            @Override
-            public Protein createNext(String header, byte[] body)
-            {
-                return new Protein(header, body);
-            }
-        });
+        super(fastaFile, Protein::new);
     }
 
     @Override

--- a/nab/src/org/labkey/nab/query/NabProtocolSchema.java
+++ b/nab/src/org/labkey/nab/query/NabProtocolSchema.java
@@ -141,7 +141,7 @@ public class NabProtocolSchema extends AssayProtocolSchema
         return CUTOFF_CACHE.get(Integer.toString(protocol.getRowId()), null, new CacheLoader<String, Set<Double>>()
         {
             @Override
-            public Set<Double> load(String key, @Nullable Object argument)
+            public Set<Double> load(@NotNull String key, @Nullable Object argument)
             {
                 return Collections.unmodifiableSet(DilutionManager.getCutoffValues(protocol));
             }

--- a/viability/src/org/labkey/viability/GuavaDataHandler.java
+++ b/viability/src/org/labkey/viability/GuavaDataHandler.java
@@ -18,8 +18,11 @@ package org.labkey.viability;
 
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.beanutils.Converter;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
+import org.labkey.api.assay.AssayDataType;
+import org.labkey.api.assay.AssayRunUploadContext;
+import org.labkey.api.assay.AssayUploadXarContext;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
@@ -33,12 +36,8 @@ import org.labkey.api.qc.DataLoaderSettings;
 import org.labkey.api.qc.TransformDataHandler;
 import org.labkey.api.reader.ColumnDescriptor;
 import org.labkey.api.reader.TabLoader;
-import org.labkey.api.assay.AssayDataType;
-import org.labkey.api.assay.AssayRunUploadContext;
-import org.labkey.api.assay.AssayUploadXarContext;
 import org.labkey.api.util.FileType;
 import org.labkey.api.view.ViewBackgroundInfo;
-import org.springframework.util.StringUtils;
 
 import java.io.BufferedReader;
 import java.io.File;


### PR DESCRIPTION
#### Rationale
We've been using a one-off, 12-year-old implementation of Patricia-Trie (a space-efficient data structure) to validate that FASTA files contain no duplicate protein names. Commons Collections has its own implementation of Patricia-Trie, so switch over to that and drop the old library.

Also a bit of clean up with `@NotNull` annotations, bad `StringUtils` imports, and bad date formats.