### PR TITLE
Luminex Levey-Jennings report data query performance improvements

### DIFF
--- a/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
@@ -243,10 +243,6 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.grid.GridPanel, {
         }
 
         // create a new store now that the graph params are selected and bind it to the grid
-        var controlTypeColName = this.controlType == "SinglePoint" ? "SinglePointControl" : this.controlType;
-        var orderByClause = " ORDER BY Analyte.Data.AcquisitionDate DESC, " + controlTypeColName + ".Run.Created DESC"
-                            + " LIMIT " + (hasReportFilter ? "10000" : this.defaultRowSize);
-
         var storeConfig = {
             assayName: this.assayName,
             controlName: this.controlName,
@@ -254,9 +250,9 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.grid.GridPanel, {
             analyte: this.analyte,
             isotype: this.isotype,
             conjugate: this.conjugate,
+            maxRows: !hasReportFilter ? this.defaultRowSize : undefined,
             scope: this,
             loadListener: this.storeLoaded,
-            orderBy: orderByClause
         };
 
         if (whereClause != "")
@@ -269,7 +265,7 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.grid.GridPanel, {
         this.store.on('exception', function(store, type, action, options, response){
             var errorJson = Ext.util.JSON.decode(response.responseText);
             if (errorJson.exception) {
-                Ext.get('EC504PLTrendPlotDiv').update("<span class='labkey-error'>" + errorJson.exception + "</span>");
+                Ext.get(document.querySelector('.ljTrendPlot').id).update("<span class='labkey-error'>" + errorJson.exception + "</span>");
             }
         });
 


### PR DESCRIPTION
#### Rationale
Luminex clients with a large amount of runs/results are running into performance issues loading the Levey-Jennings report data. After investigation and reviewing execution plans from the client's server, two main drivers for the performance issues were 1) the ORDER BY and LIMIT being applied within the SQL of the executeSql call instead of as API params and 2) the number of joins we are doing to the luminex.GuideSet table to get data point ranges.

#### Changes
- Move ORDER BY and LIMIT from the executeSQL sql to the sort and maxRows parameters on the API call
- Fix for sort order of data query in Levey-Jennings plot window
- Levey-Jennings data query change how guide set range values are joined into the results (use a single join instead of joining to the GuideSetCurveFit table multiple times for each curve type)
- Fix for Levey-Jennings error display so that it doesn't hardcode to expect an EC50 plot panel tab
