### PR TITLE
47210: NAb assays require specific template control well group names

### DIFF
--- a/nab/src/org/labkey/nab/NabPlateTypeHandler.java
+++ b/nab/src/org/labkey/nab/NabPlateTypeHandler.java
@@ -79,6 +79,12 @@ public class NabPlateTypeHandler extends AbstractPlateTypeHandler
     }
 
     @Override
+    public boolean canCreateNewGroups(WellGroup.Type type)
+    {
+        return type != WellGroup.Type.CONTROL;
+    }
+
+    @Override
     public PlateTemplate createPlate(String templateTypeName, Container container, int rowCount, int colCount)
     {
         PlateTemplate template = PlateService.get().createPlateTemplate(container, getAssayType(), rowCount, colCount);


### PR DESCRIPTION
#### Rationale
The NAb assays rely on specific control well group names in order to identify the cell and virus control wells. A few clients have run into problems when they created their own control wells with different names and received errors in the run. 

The work to support arbitrary control well group names would have been more significant, so the recommended approach is:
- New control well groups cannot be created
- Cell and virus control well groups cannot be renamed or deleted

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47210)

#### Related Pull Requests
https://github.com/LabKey/platform/pull/4223