### PR TITLE
Luminex Levey-Jennings report grid improvements

### DIFF
--- a/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
@@ -180,7 +180,7 @@ public class AnalyteSinglePointControlTable extends AbstractLuminexTable
         defaultCols.add(FieldKey.fromParts("Analyte", "Properties", "LotNumber"));
         defaultCols.add(FieldKey.fromParts("GuideSet", "Created"));
         defaultCols.add(FieldKey.fromParts("AverageFiBkgd"));
-        defaultCols.add(FieldKey.fromParts("AverageFiBkgdQCFlagsEnabled"));
+        defaultCols.add(FieldKey.fromParts("SinglePointControl", "Run", "QCFlags"));
         setDefaultVisibleColumns(defaultCols);
     }
 

--- a/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
@@ -165,7 +165,7 @@ public class AnalyteSinglePointControlTable extends AbstractLuminexTable
         // set the default columns for this table to be those used for the QC Report
         List<FieldKey> defaultCols = new ArrayList<>();
         defaultCols.add(FieldKey.fromParts("SinglePointControl", "Run", "Name"));
-        defaultCols.add(FieldKey.fromParts("LJPlots"));
+        defaultCols.add(FieldKey.fromParts("L-J Plots"));
         defaultCols.add(FieldKey.fromParts("SinglePointControl", "Name"));
         defaultCols.add(FieldKey.fromParts("SinglePointControl", "Run", "Batch", "Network"));
         defaultCols.add(FieldKey.fromParts("SinglePointControl", "Run", "Batch", "CustomProtocol"));

--- a/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
@@ -140,7 +140,7 @@ public class AnalyteSinglePointControlTable extends AbstractLuminexTable
                         int analyte = (int)ctx.get("analyte");
                         int singlePointControl = (int)ctx.get("singlePointControl");
 
-                        String linkTag = "<a href=\"javascript:LABKEY.LeveyJenningsPlotHelper.getLeveyJenningsPlotWindow(%d,%d,%d,'%s','SinglePointControl')\">";
+                        String linkTag = "<a href=\"javascript:LABKEY.LeveyJenningsPlotHelper.getLeveyJenningsPlotWindow(%d,%d,%d,'%s','SinglePoint')\">";
 
                         out.write( String.format(linkTag, protocolId, analyte, singlePointControl, "MFI") );
                         out.write( String.format("<img src='%s' width='27' height='20'>", AppProps.getInstance().getContextPath() + "/luminex/ljPlotIcon.png") );

--- a/luminex/src/org/labkey/luminex/query/AnalyteTitrationTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteTitrationTable.java
@@ -196,6 +196,7 @@ public class AnalyteTitrationTable extends AbstractCurveFitPivotTable
             defaultCols.add(FieldKey.fromParts(StatsService.CurveFitType.FIVE_PARAMETER.getLabel() + "CurveFit", "EC50"));
         defaultCols.add(FieldKey.fromParts("MaxFI"));
         defaultCols.add(FieldKey.fromParts("TrapezoidalCurveFit", "AUC"));
+        defaultCols.add(FieldKey.fromParts("Titration", "Run", "QCFlags"));
         setDefaultVisibleColumns(defaultCols);
     }
 

--- a/luminex/src/org/labkey/luminex/query/AnalyteTitrationTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteTitrationTable.java
@@ -141,7 +141,7 @@ public class AnalyteTitrationTable extends AbstractCurveFitPivotTable
                         int analyte = (int)ctx.get("analyte");
                         int titration = (int)ctx.get("titration");
 
-                        String jsFuncCall = "javascript:LABKEY.LeveyJenningsPlotHelper.getLeveyJenningsPlotWindow(%d,%d,%d,'%s')";
+                        String jsFuncCall = "javascript:LABKEY.LeveyJenningsPlotHelper.getLeveyJenningsPlotWindow(%d,%d,%d,'%s','Titration')";
 
                         NavTree ljPlotsNav = new NavTree("Levey-Jennings Plot Menu");
                         ljPlotsNav.setImage(AppProps.getInstance().getContextPath() + "/luminex/ljPlotIcon.png", 27, 20);

--- a/luminex/src/org/labkey/luminex/query/AnalyteTitrationTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteTitrationTable.java
@@ -174,7 +174,7 @@ public class AnalyteTitrationTable extends AbstractCurveFitPivotTable
         // set the default columns for this table to be those used for the QC Report
         List<FieldKey> defaultCols = new ArrayList<>();
         defaultCols.add(FieldKey.fromParts("Titration", "Run", "Name"));
-        defaultCols.add(FieldKey.fromParts("LJPlots"));
+        defaultCols.add(FieldKey.fromParts("L-J Plots"));
         defaultCols.add(FieldKey.fromParts("Titration"));
         defaultCols.add(FieldKey.fromParts("Titration", "Standard"));
         defaultCols.add(FieldKey.fromParts("Titration", "QCControl"));

--- a/luminex/src/org/labkey/luminex/view/leveyJenningsReport.jsp
+++ b/luminex/src/org/labkey/luminex/view/leveyJenningsReport.jsp
@@ -195,15 +195,7 @@
                 controlType: _controlType,
                 assayName: _protocolName,
                 listeners: {
-                    'applyGraphBtnClicked': function(analyte, isotype, conjugate){
-                        _analyte = analyte;
-                        _isotype = isotype;
-                        _conjugate = conjugate;
-
-                        guideSetPanel.graphParamsSelected(analyte, isotype, conjugate);
-                        trendPlotPanel.graphParamsSelected(analyte, isotype, conjugate);
-                        trackingDataPanel.graphParamsSelected(analyte, isotype, conjugate);
-                    },
+                    'applyGraphBtnClicked': graphParamsSelected,
                     'graphParamsChanged': function(){
                         guideSetPanel.disable();
                         trendPlotPanel.disable();
@@ -292,6 +284,21 @@
                     },
                 }
             });
+
+            function graphParamsSelected(analyte, isotype, conjugate){
+                _analyte = analyte;
+                _isotype = isotype;
+                _conjugate = conjugate;
+
+                guideSetPanel.graphParamsSelected(analyte, isotype, conjugate);
+                trendPlotPanel.graphParamsSelected(analyte, isotype, conjugate);
+                trackingDataPanel.graphParamsSelected(analyte, isotype, conjugate);
+            }
+
+            var urlParams = LABKEY.ActionURL.getParameters();
+            if (urlParams.hasOwnProperty("analyte") && urlParams.hasOwnProperty("isotype") && urlParams.hasOwnProperty("conjugate")) {
+                graphParamsSelected(urlParams.analyte, urlParams.isotype, urlParams.conjugate);
+            }
         }
 
         Ext.onReady(init);

--- a/luminex/src/org/labkey/luminex/view/leveyJenningsReport.jsp
+++ b/luminex/src/org/labkey/luminex/view/leveyJenningsReport.jsp
@@ -21,7 +21,6 @@
 */
 
 %>
-<%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
@@ -41,6 +40,13 @@
     LeveyJenningsForm bean = me.getModelBean();
 %>
 
+<style>
+    .lj-report-title {
+        font-size: 110%;
+        font-weight: bold;
+    }
+</style>
+
 <div class="leveljenningsreport">
 <table>
     <tr>
@@ -58,7 +64,7 @@
 
         var $h = Ext.util.Format.htmlEncode;
 
-        // the default number of records to return for the report when no start and end date are provided
+        // the default number of records to return for the report when no filters have been applied
         var defaultRowSize = 30;
 
         // local variables for storing the selected graph parameters
@@ -231,7 +237,7 @@
                     'currentGuideSetUpdated': function() {
                         guideSetPanel.toggleExportBtn(false);
                         trendPlotPanel.setTrendPlotLoading();
-                        trackingDataPanel.graphParamsSelected(_analyte, _isotype, _conjugate, trendPlotPanel.getStartDate(), trendPlotPanel.getEndDate());
+                        trackingDataPanel.graphParamsSelected(_analyte, _isotype, _conjugate);
                     },
                     'exportPdfBtnClicked': function() {
                         trendPlotPanel.exportToPdf();
@@ -255,10 +261,6 @@
                 has4PLCurveFit: _has4PLCurveFit,
                 has5PLCurveFit: _has5PLCurveFit,
                 listeners: {
-                    'reportFilterApplied': function(startDate, endDate, network, networkAny, protocol, protocolAny) {
-                        trendPlotPanel.setTrendPlotLoading();
-                        trackingDataPanel.graphParamsSelected(_analyte, _isotype, _conjugate, startDate, endDate, network, networkAny, protocol, protocolAny);
-                    },
                     'togglePdfBtn': function(toEnable) {
                         guideSetPanel.toggleExportBtn(toEnable);
                     }
@@ -281,12 +283,14 @@
                     'appliedGuideSetUpdated': function() {
                         guideSetPanel.toggleExportBtn(false);
                         trendPlotPanel.setTrendPlotLoading();
-                        trackingDataPanel.graphParamsSelected(_analyte, _isotype, _conjugate, trendPlotPanel.getStartDate(), trendPlotPanel.getEndDate(),
-                                trendPlotPanel.network, trendPlotPanel.networkAny, trendPlotPanel.protocol, trendPlotPanel.protocolAny);
+                        trackingDataPanel.graphParamsSelected(_analyte, _isotype, _conjugate);
                     },
-                    'trackingDataLoaded': function(store) {
-                        trendPlotPanel.trackingDataLoaded(store);
-                    }
+                    'plotDataLoading': function(store) {
+                        trendPlotPanel.plotDataLoading(store);
+                    },
+                    'plotDataLoaded': function(store, hasReportFilter) {
+                        trendPlotPanel.plotDataLoaded(store, hasReportFilter);
+                    },
                 }
             });
         }

--- a/luminex/src/org/labkey/luminex/view/leveyJenningsReport.jsp
+++ b/luminex/src/org/labkey/luminex/view/leveyJenningsReport.jsp
@@ -202,7 +202,7 @@
 
                         guideSetPanel.graphParamsSelected(analyte, isotype, conjugate);
                         trendPlotPanel.graphParamsSelected(analyte, isotype, conjugate);
-                        trackingDataPanel.graphParamsSelected(analyte, isotype, conjugate, null, null);
+                        trackingDataPanel.graphParamsSelected(analyte, isotype, conjugate);
                     },
                     'graphParamsChanged': function(){
                         guideSetPanel.disable();
@@ -237,7 +237,7 @@
                     'currentGuideSetUpdated': function() {
                         guideSetPanel.toggleExportBtn(false);
                         trendPlotPanel.setTrendPlotLoading();
-                        trackingDataPanel.graphParamsSelected(_analyte, _isotype, _conjugate);
+                        trackingDataPanel.graphParamsSelected(_analyte, _isotype, _conjugate, true);
                     },
                     'exportPdfBtnClicked': function() {
                         trendPlotPanel.exportToPdf();
@@ -283,10 +283,10 @@
                     'appliedGuideSetUpdated': function() {
                         guideSetPanel.toggleExportBtn(false);
                         trendPlotPanel.setTrendPlotLoading();
-                        trackingDataPanel.graphParamsSelected(_analyte, _isotype, _conjugate);
+                        trackingDataPanel.graphParamsSelected(_analyte, _isotype, _conjugate, true);
                     },
-                    'plotDataLoading': function(store) {
-                        trendPlotPanel.plotDataLoading(store);
+                    'plotDataLoading': function(store, hasGuideSetUpdates) {
+                        trendPlotPanel.plotDataLoading(store, hasGuideSetUpdates);
                     },
                     'plotDataLoaded': function(store, hasReportFilter) {
                         trendPlotPanel.plotDataLoaded(store, hasReportFilter);

--- a/luminex/src/org/labkey/luminex/view/leveyJenningsReport.jsp
+++ b/luminex/src/org/labkey/luminex/view/leveyJenningsReport.jsp
@@ -270,7 +270,6 @@
             // initialize the grid panel to display the tracking data
             var trackingDataPanel = new LABKEY.LeveyJenningsTrackingDataPanel({
                 renderTo: 'trackingDataPanel',
-                cls: 'extContainer',
                 controlName: _controlName,
                 controlType: _controlType,
                 assayName: _protocolName,

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetDisablingTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetDisablingTest.java
@@ -208,10 +208,10 @@ public final class LuminexGuideSetDisablingTest extends LuminexTest
     {
         // note: this uses the run based guide set
 
-        // simular to verifyHighlightUpdatesAfterQCFlagChange (but not quite the same... not sure how this other place works)
+        // similar to verifyHighlightUpdatesAfterQCFlagChange (but not quite the same... not sure how this other place works)
         _guideSetHelper.goToLeveyJenningsGraphPage(TEST_ASSAY_LUM, CONTROL_NAME);
         _guideSetHelper.setUpLeveyJenningsGraphParams(RUN_BASED_ANALYTE);
-        final String plate1_AUC = "64608.73";
+        final String plate1_AUC = "64608.734";
         final String plate2_AUC = "61889.88";
 
         validateFlaggedForQC(plate1_AUC, plate2_AUC);
@@ -244,23 +244,17 @@ public final class LuminexGuideSetDisablingTest extends LuminexTest
 
     private void saveGuideSetParameters()
     {
-        // Wait for grid to refresh before checking QC flags
-        doAndWaitForElementToRefresh(() -> click(Ext4Helper.Locators.windowButton(GUIDE_SET_WINDOW_NAME, "Save")),
-                Locator.tagWithId("div", "trackingDataPanel").append(Locator.byClass("x-grid3-row-table")), shortWait());
+        click(Ext4Helper.Locators.windowButton(GUIDE_SET_WINDOW_NAME, "Save"));
         _guideSetHelper.waitForGuideSetExtMaskToDisappear();
     }
 
     private void validateFlaggedForQC(String... texts)
     {
-        // NOTE: We sometimes get a bad value here which we are investigating. For now the test will ignore such a value.
-        List<String> badVals = Arrays.asList("8.08", "7.90");
-
-        Locator redCellLoc = Locator.tagWithId("div", "trackingDataPanel").append(Locator.tagWithClass("div", "x-grid3-cell-inner").withPredicate("contains(@style,'red')"));
-        List<WebElement> qcFlaggedCells = redCellLoc.findElements(getDriver());
+        Locator redCellLoc = Locator.tagWithClass("table", "labkey-data-region").append(Locator.xpath("//span[contains(@style,'red')]"));
+        List<WebElement> qcFlaggedCells = isElementPresent(redCellLoc) ? redCellLoc.findElements(getDriver()) : Collections.emptyList();
 
         List<String> expectedQcFlaggedValues = new ArrayList<>(Arrays.asList(texts));
         List<String> qcFlaggedValues = getTexts(qcFlaggedCells);
-        qcFlaggedValues.removeAll(badVals);
 
         Collections.sort(expectedQcFlaggedValues);
         Collections.sort(qcFlaggedValues);

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
@@ -337,7 +337,6 @@ public final class LuminexGuideSetTest extends LuminexTest
         DataRegionTable table = _guideSetHelper.getTrackingDataRegion();
         table.checkCheckbox(table.getRowIndex("Titration/Run/Batch/Network", network));
         clickButton("Apply Guide Set", 0);
-        waitForElement(ExtHelper.locateGridRowCheckbox(network));
         waitForElement(ExtHelper.locateGridRowCheckbox(comment));
         sleep(1000);
         // deselect the current guide set to test error message

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
@@ -490,28 +490,33 @@ public final class LuminexGuideSetTest extends LuminexTest
         _guideSetHelper.setUpLeveyJenningsGraphParams("GS Analyte B");
         _guideSetHelper.applyGuideSetToRun("NETWORK5", GUIDE_SET_5_COMMENT, true);
         assertTextNotPresent(newQcFlags);
+        assertElementPresent(Locator.xpath("//td/span[contains(@style,'red')]"),2);
 
         //6. Create new Guide Set for GS Analyte B that includes plate 5 (but not plate 5a)
-        //	- the AUC QC Flag for plate 5 is removed
+        //	- the AUC QC Flag for plate 5 is removed for GS Analyte B but still exists for GS Analyte A
         Locator.XPathLocator aucLink =  Locator.xpath("//a[contains(text(),'AUC')]");
         waitForElement(aucLink);
         int aucCount = getElementCount(aucLink);
         _guideSetHelper.createGuideSet(false);
         _guideSetHelper.editRunBasedGuideSet(new String[]{"allRunsRow_1"}, "Guide set includes plate 5", true);
-        assertEquals("Wrong count for AUC flag links", aucCount-1, (getElementCount(aucLink)));
+        assertEquals("Wrong count for AUC flag links", aucCount, (getElementCount(aucLink)));
+        assertElementPresent(Locator.xpath("//td/span[contains(@style,'red')]"),1);
 
         //7. Switch to GS Analyte A, and edit the current guide set to include plate 3
         //	- the QC Flag for plate 3 (the run included) and the other plates (4, 5, and 5a) are all removed as all values are within the guide set ranges
         _guideSetHelper.setUpLeveyJenningsGraphParams("GS Analyte A");
-        assertExpectedAnalyte1QCFlagsPresent();
+        assertExpectedAnalyte1QCFlagsInitial();
+        assertElementPresent(Locator.xpath("//td/span[contains(@style,'red')]"),7);
         clickButtonContainingText("Edit", 0);
         _guideSetHelper.editRunBasedGuideSet(new String[]{"allRunsRow_3"}, "edited analyte 1", false);
-        assertQCFlagsNotPresent();
+        assertExpectedAnalyte1QCFlagsUpdated();
+        assertElementPresent(Locator.xpath("//td/span[contains(@style,'red')]"),0);
 
         //8. Edit the GS Analyte A guide set and remove plate 3
         //	- the QC Flags for plates 3, 4, 5, and 5a return (HMFI for all 4 and AUC for plates 4, 5, and 5a)
         removePlate3FromGuideSet();
-        assertExpectedAnalyte1QCFlagsPresent();
+        assertExpectedAnalyte1QCFlagsInitial();
+        assertElementPresent(Locator.xpath("//td/span[contains(@style,'red')]"),7);
     }
 
     @LogMethod
@@ -524,18 +529,17 @@ public final class LuminexGuideSetTest extends LuminexTest
         _guideSetHelper.waitForGuideSetExtMaskToDisappear();
     }
 
-    private void assertExpectedAnalyte1QCFlagsPresent()
+    private void assertExpectedAnalyte1QCFlagsInitial()
     {
         waitForElements(Locator.xpath("//a[contains(text(),'HMFI')]"), 4);
         waitForElements(Locator.xpath("//a[contains(text(),'AUC')]"), 3);
     }
 
-    private void assertQCFlagsNotPresent()
+    private void assertExpectedAnalyte1QCFlagsUpdated()
     {
-        for (String flag : new String[] {"AUC", "HMFI", "EC50-4", "EC50-5", "PCV"})
-        {
+        for (String flag : new String[] {"HMFI", "EC50-4", "EC50-5"})
             assertElementNotPresent(Locator.xpath("//a[contains(text(),'" + flag + "')]"));
-        }
+        waitForElements(Locator.xpath("//a[contains(text(),'AUC')]"), 1); // for GS Analyte B
     }
 
     private void importPlateFiveAgain()

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
@@ -140,7 +140,7 @@ public final class LuminexGuideSetTest extends LuminexTest
         excludeReplicateGroupFromRun("Guide Set plate 5", "A6,B6", 2, 1);
         _guideSetHelper.goToLeveyJenningsGraphPage(TEST_ASSAY_LUM, "Standard1");
         _guideSetHelper.setUpLeveyJenningsGraphParams("GS Analyte B");
-        assertTextPresent("28040.51");
+        assertTextPresent("28040.512");
     }
 
     private void excludeReplicateGroupFromRun(String run, String wells, int jobCount, int jobInfoCount)
@@ -475,9 +475,9 @@ public final class LuminexGuideSetTest extends LuminexTest
         _guideSetHelper.applyGuideSetToRun("NETWORK5", GUIDE_SET_5_COMMENT, false);
         //assert ec50 and HMFI red text present
         waitForText(newQcFlags);
-        assertElementPresent(Locator.xpath("//span[text()='28040.51' and contains(@style,'red')]")); // EC50
-        assertElementPresent(Locator.xpath("//span[text()='79121.45' and contains(@style,'red')]")); // AUC
-        assertElementPresent(Locator.xpath("//span[text()='32145.80' and contains(@style,'red')]")); // High MFI
+        assertElementPresent(Locator.xpath("//span[text()='28040.512' and contains(@style,'red')]")); // EC50
+        assertElementPresent(Locator.xpath("//span[text()='79121.445' and contains(@style,'red')]")); // AUC
+        assertElementPresent(Locator.xpath("//span[text()='32145.8' and contains(@style,'red')]")); // High MFI
         //verify new flags present in run list
         goToTestAssayHome();
         drt = new DataRegionTable("Runs", getDriver());

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
@@ -539,7 +539,7 @@ public final class LuminexGuideSetTest extends LuminexTest
     {
         for (String flag : new String[] {"HMFI", "EC50-4", "EC50-5"})
             assertElementNotPresent(Locator.xpath("//a[contains(text(),'" + flag + "')]"));
-        waitForElements(Locator.xpath("//a[contains(text(),'AUC')]"), 1); // for GS Analyte B
+        waitForElements(Locator.xpath("//a[contains(text(),'AUC')]"), 7);
     }
 
     private void importPlateFiveAgain()

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
@@ -334,7 +334,8 @@ public final class LuminexGuideSetTest extends LuminexTest
     @LogMethod
     private void verifyGuideSetToRun(String network, String comment)
     {
-        click(ExtHelper.locateGridRowCheckbox(network));
+        DataRegionTable table = _guideSetHelper.getTrackingDataRegion();
+        table.checkCheckbox(table.getRowIndex("Titration/Run/Batch/Network", network));
         clickButton("Apply Guide Set", 0);
         waitForElement(ExtHelper.locateGridRowCheckbox(network));
         waitForElement(ExtHelper.locateGridRowCheckbox(comment));

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
@@ -532,7 +532,7 @@ public final class LuminexGuideSetTest extends LuminexTest
     private void assertExpectedAnalyte1QCFlagsInitial()
     {
         waitForElements(Locator.xpath("//a[contains(text(),'HMFI')]"), 4);
-        waitForElements(Locator.xpath("//a[contains(text(),'AUC')]"), 3);
+        waitForElements(Locator.xpath("//a[contains(text(),'AUC')]"), 9);
     }
 
     private void assertExpectedAnalyte1QCFlagsUpdated()

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
@@ -20,6 +20,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.ReactAssayDesignerPage;
@@ -275,7 +276,7 @@ public final class LuminexGuideSetTest extends LuminexTest
         // verify that the PDF of curves file was generated along with the xls file and the Rout file
         DataRegionTable table = new DataRegionTable("Runs", getDriver());
         table.setFilter("Name", "Equals", "Guide Set plate " + index);
-        clickAndWait(Locator.tagWithAttribute("img", "src", "/labkey/experiment/images/graphIcon.gif"));
+        clickAndWait(Locator.tagWithAttribute("img", "src", WebTestHelper.getContextPath() + "/experiment/images/graphIcon.gif"));
         clickAndWait(Locator.linkWithText("Text View"));
         waitForElement(Locator.css(".labkey-protocol-applications")); // bottom section of the "Text View" tab for the run details page
         waitForElements(Locator.linkWithText("Guide Set plate " + index + ".Standard1_Control_Curves_4PL.pdf"), 3);

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexRTransformTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexRTransformTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.ReactAssayDesignerPage;
@@ -105,7 +106,7 @@ public final class LuminexRTransformTest extends LuminexTest
     private void verifyPDFsGenerated()
     {
         DataRegionTable.DataRegion(getDriver()).find(); // Make sure page is loaded
-        WebElement curvePng = Locator.tagWithAttribute("img", "src", "/labkey/_images/sigmoidal_curve.png").findElement(getDriver());
+        WebElement curvePng = Locator.tagWithAttribute("img", "src", WebTestHelper.getContextPath() + "/_images/sigmoidal_curve.png").findElement(getDriver());
         shortWait().until(LabKeyExpectedConditions.animationIsDone(curvePng));
         File curvePdf = clickAndWaitForDownload(curvePng);
         assertEquals("Curve PDF has wrong name: " + curvePdf.getName(), "WithAltNegativeBead.Standard1_Control_Curves_4PL.pdf", curvePdf.getName());

--- a/luminex/test/src/org/labkey/test/util/luminex/LuminexGuideSetHelper.java
+++ b/luminex/test/src/org/labkey/test/util/luminex/LuminexGuideSetHelper.java
@@ -89,6 +89,13 @@ public class LuminexGuideSetHelper
         table.clearFilter("GuideSet/Created");
     }
 
+    public DataRegionTable getTrackingDataRegion()
+    {
+        DataRegionTable table = new DataRegionTable.DataRegionFinder(_test.getDriver()).find();
+        table.setAsync(true);
+        return table;
+    }
+
     public void waitForManageGuideSetWindow(boolean creating)
     {
         WebElement window = _test.shortWait().until(ExpectedConditions.visibilityOfElementLocated(GS_WINDOW_LOC));
@@ -180,8 +187,6 @@ public class LuminexGuideSetHelper
         _test._extHelper.waitForExt3MaskToDisappear(WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
         _test.waitForElementToDisappear(GS_WINDOW_LOC);
         waitForLeveyJenningsTrendPlot();
-        // Wait for the grid to populate as well.
-        _test.waitForElements(Locator.xpath("//div[contains(@class, 'x-grid3-row-checker')]"));
     }
 
     public void goToLeveyJenningsGraphPage(String assayName, String titrationName)
@@ -207,10 +212,11 @@ public class LuminexGuideSetHelper
     @LogMethod
     public void applyGuideSetToRun(@LoggedParam String[] networks, @LoggedParam String comment, boolean useCurrent)
     {
+        DataRegionTable table = getTrackingDataRegion();
         for (String network : networks)
-            _test.click(ExtHelper.locateGridRowCheckbox(network));
+            table.checkCheckbox(table.getRowIndex("Network", network));
 
-        WebElement applyGuideSetButton = _test.scrollIntoView(Locator.button("Apply Guide Set"));
+        WebElement applyGuideSetButton = _test.scrollIntoView(Locator.lkButton("Apply Guide Set"));
         _test.doAndWaitForPageSignal(applyGuideSetButton::click, "guideSetSelectionChange");
 
         WebElement applyGuideSetWindow = ExtHelper.Locators.window("Apply Guide Set...").waitForElement(_test.getDriver(), WAIT_FOR_JAVASCRIPT);

--- a/luminex/webapp/luminex/ApplyGuideSetPanel.js
+++ b/luminex/webapp/luminex/ApplyGuideSetPanel.js
@@ -110,8 +110,8 @@ LABKEY.ApplyGuideSetPanel = Ext.extend(Ext.FormPanel, {
         selectedHeaderCols.push({header:'Acquisition Date', dataIndex:'Analyte/Data/AcquisitionDate', renderer: this.dateRenderer, width:100});
         if (this.controlType == 'Titration')
         {
-            selectedHeaderCols.push({header:'EC50 4PL', dataIndex:'Four ParameterCurveFit/EC50', width:75, renderer: this.numberRenderer, align: 'right'});
-            selectedHeaderCols.push({header:'EC50 5PL', dataIndex:'Five ParameterCurveFit/EC50', width:75, renderer: this.numberRenderer, align: 'right'});
+            selectedHeaderCols.push({header:'EC50 4PL', dataIndex:'Four ParameterCurveFit/EC50', width:75, renderer: this.numberRenderer, align: 'right', hidden: !this.has4PLCurveFit});
+            selectedHeaderCols.push({header:'EC50 5PL', dataIndex:'Five ParameterCurveFit/EC50', width:75, renderer: this.numberRenderer, align: 'right', hidden: !this.has5PLCurveFit});
             selectedHeaderCols.push({header:'AUC', dataIndex:'TrapezoidalCurveFit/AUC', width:75, renderer: this.numberRenderer, align: 'right'});
             selectedHeaderCols.push({header:'High MFI', dataIndex:'MaxFI', width:75, renderer: this.numberRenderer, align: 'right'});
         }
@@ -216,8 +216,8 @@ LABKEY.ApplyGuideSetPanel = Ext.extend(Ext.FormPanel, {
         ];
         if (this.controlType == 'Titration')
         {
-            guideSetColumnModelColumns.push({header: 'Avg EC50 4PL', dataIndex: 'AverageEC504PL', renderer: this.numberRenderer, align: 'right', sortable: false});
-            guideSetColumnModelColumns.push({header: 'Avg EC50 5PL', dataIndex: 'AverageEC505PL', renderer: this.numberRenderer, align: 'right', sortable: false});
+            guideSetColumnModelColumns.push({header: 'Avg EC50 4PL', dataIndex: 'AverageEC504PL', renderer: this.numberRenderer, align: 'right', sortable: false, hidden: !this.has4PLCurveFit});
+            guideSetColumnModelColumns.push({header: 'Avg EC50 5PL', dataIndex: 'AverageEC505PL', renderer: this.numberRenderer, align: 'right', sortable: false, hidden: !this.has5PLCurveFit});
             guideSetColumnModelColumns.push({header: 'Avg AUC', dataIndex: 'AverageAUC', renderer: this.numberRenderer, align: 'right', sortable: false});
             guideSetColumnModelColumns.push({header: 'Avg High MFI', dataIndex: 'AverageMFI', renderer: this.numberRenderer, align: 'right', sortable: false});
         }

--- a/luminex/webapp/luminex/LeveyJenningsGuideSetPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsGuideSetPanel.js
@@ -16,7 +16,7 @@ var $h = Ext.util.Format.htmlEncode;
  * Class to create a small panel for displaying the current guide set info for the selected graph parameters
  *   and to give the user access to the edit guide set and create new guide set buttons
  *
- * @params titration
+ * @params titration on single point control
  * @params assayName
  */
 LABKEY.LeveyJenningsGuideSetPanel = Ext.extend(Ext.FormPanel, {
@@ -59,7 +59,7 @@ LABKEY.LeveyJenningsGuideSetPanel = Ext.extend(Ext.FormPanel, {
         this.paramsDisplayField = new Ext.form.DisplayField({
             hideLabel: true,
             value: "",
-            style: "font-size:110%; font-weight:bold",
+            cls: "lj-report-title",
             width: 738,
             border: true
         });

--- a/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
+++ b/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
@@ -6,12 +6,69 @@
 Ext.namespace('LABKEY', 'Luminex.panel');
 LABKEY.LeveyJenningsPlotHelper = {};
 
+LABKEY.LeveyJenningsPlotHelper.PlotTypeMap = {
+    EC504PL: 'EC50 - 4PL',
+    EC505PL: 'EC50 - 5PL Rumi',
+    AUC: 'AUC',
+    HighMFI: 'High MFI',
+    MFI: 'MFI' // not sure why we cannot get these named right.
+};
+
+LABKEY.LeveyJenningsPlotHelper.TitrationColumnsMap = {
+    "GuideSetId": "GuideSet",
+    "AcquisitionDate": "Analyte/Data/AcquisitionDate",
+    "LotNumber": "Analyte/Properties/LotNumber",
+    "RunRowId": "Titration/Run/RowId",
+    "Network": "Titration/Run/Batch/Network",
+    "NotebookNo": "Analyte/Data/Run/NotebookNo",
+    "AssayType": "Analyte/Data/Run/AssayType",
+    "ExpPerformer": "Analyte/Data/Run/ExpPerformer",
+    "EC504PL": "Four ParameterCurveFit/EC50",
+    "EC505PL": "Five ParameterCurveFit/EC50",
+    "AUC": "TrapezoidalCurveFit/AUC",
+    "HighMFI": "MaxFI",
+};
+
+LABKEY.LeveyJenningsPlotHelper.SinglePointControlColumnsMap = {
+    "GuideSetId": "GuideSet",
+    "AcquisitionDate": "Analyte/Data/AcquisitionDate",
+    "LotNumber": "Analyte/Properties/LotNumber",
+    "RunRowId": "SinglePointControl/Run/RowId",
+    "Network": "SinglePointControl/Run/Batch/Network",
+    "NotebookNo": "SinglePointControl/Run/NotebookNo",
+    "AssayType": "SinglePointControl/Run/AssayType",
+    "ExpPerformer": "SinglePointControl/Run/ExpPerformer",
+    "MFI": "AverageFiBkgd",
+};
+
 LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore = function(config)
 {
-    var controlTypeColName = config.controlType === "SinglePoint" ? "SinglePointControl" : config.controlType;
+    var isSinglePointControl = config.controlType === 'SinglePoint';
+    var controlTypeColName = isSinglePointControl ? 'SinglePointControl' : config.controlType;
+    var columnsMap = isSinglePointControl ? LABKEY.LeveyJenningsPlotHelper.SinglePointControlColumnsMap : LABKEY.LeveyJenningsPlotHelper.TitrationColumnsMap;
 
-    // this version of the guide set range values SQL will prevent the need for multiple LEFT OUTER JOINs to the GuideSetCurveFit table
-    var guideSetRangeValuesSQL = "SELECT gs.RowId, gs.Created, gs.ValueBased,\n" +
+    var store = new LABKEY.ext.Store({
+        autoLoad: true,
+        schemaName: 'assay.Luminex.' + LABKEY.QueryKey.encodePart(config.assayName),
+        queryName: isSinglePointControl ? 'AnalyteSinglePointControl' : 'AnalyteTitration',
+        columns: Object.values(columnsMap).join(','),
+        filterArray: config.filters,
+        sort: config.sort ? config.sort : '-Analyte/Data/AcquisitionDate, -' + controlTypeColName + '/Run/Created',
+        maxRows: config.maxRows ? config.maxRows : -1,
+        containerFilter: LABKEY.Query.containerFilter.allFolders,
+        scope: config.scope
+    });
+
+    if (config.loadListener) {
+        store.addListener('load', config.loadListener, config.scope);
+    }
+
+    return store;
+};
+
+LABKEY.LeveyJenningsPlotHelper.getGuideSetRangesStore = function(config)
+{
+    var sql = "SELECT gs.RowId, gs.Created, gs.ValueBased,\n" +
             "    CASE WHEN gs.ValueBased=true THEN gs.EC504PLAverage ELSE cf.EC504PLAverage END AS GuideSetEC504PLAverage,\n" +
             "    CASE WHEN gs.ValueBased=true THEN gs.EC504PLStdDev ELSE cf.EC504PLStdDev END AS GuideSetEC504PLStdDev,\n" +
             "    CASE WHEN gs.ValueBased=true THEN gs.EC505PLAverage ELSE cf.EC505PLAverage END AS GuideSetEC505PLAverage,\n" +
@@ -36,102 +93,47 @@ LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore = function(config)
             "    GROUP BY GuideSetId\n" +
             ") cf ON gs.RowId = cf.GuideSetId";
 
-    // generate sql for the data store (columns depend on the control type)
-    // issue 22267 : add IFDEFINED to "optional" assay design fields
-    var sql = "SELECT Analyte"
-            + ", " + controlTypeColName + ".Run.Created" // NOTE: necessary for union case
-            + ", Analyte.Data.AcquisitionDate"
-            + ", IFDEFINED(Analyte.Properties.LotNumber)"
-            + ", " + controlTypeColName
-            + ", IFDEFINED(" + controlTypeColName + ".Run.Isotype)"
-            + ", IFDEFINED(" + controlTypeColName + ".Run.Conjugate)"
-            + ", " + controlTypeColName + ".Run.RowId AS RunRowId"
-            + ", " + controlTypeColName + ".Run.Name AS RunName"
-            + ", " + controlTypeColName + ".Run.Folder.Name AS FolderName"
-            + ", " + controlTypeColName + ".Run.Folder.EntityId"
-            + ", IFDEFINED(" + controlTypeColName + ".Run.Batch.Network)"
-            + ", IFDEFINED(" + controlTypeColName + ".Run.Batch.CustomProtocol)"
-            + ", IFDEFINED(" + controlTypeColName + ".Run.NotebookNo)"
-            + ", IFDEFINED(" + controlTypeColName + ".Run.AssayType)"
-            + ", IFDEFINED(" + controlTypeColName + ".Run.ExpPerformer)"
-            + ", GuideSet AS GuideSetId"
-            + ", gs.Created AS GuideSetCreated"
-            + ", IncludeInGuideSetCalculation"
-            + ", gs.ValueBased AS GuideSetValueBased";
-    if (config.controlType === "Titration")
-    {
-        sql += ", \"Four ParameterCurveFit\".EC50 AS EC504PL, \"Four ParameterCurveFit\".EC50QCFlagsEnabled AS EC504PLQCFlagsEnabled"
-        + ", \"Five ParameterCurveFit\".EC50 AS EC505PL, \"Five ParameterCurveFit\".EC50QCFlagsEnabled AS EC505PLQCFlagsEnabled"
-        + ", TrapezoidalCurveFit.AUC, TrapezoidalCurveFit.AUCQCFlagsEnabled"
-        + ", MaxFI AS HighMFI, MaxFIQCFlagsEnabled AS HighMFIQCFlagsEnabled"
-        //columns needed for guide set ranges (value based or run based)
-        + ", gs.GuideSetEC504PLAverage"
-        + ", gs.GuideSetEC504PLStdDev"
-        + ", gs.GuideSetEC505PLAverage"
-        + ", gs.GuideSetEC505PLStdDev"
-        + ", gs.GuideSetAUCAverage"
-        + ", gs.GuideSetAUCStdDev"
-        + ", gs.GuideSetHighMFIAverage"
-        + ", gs.GuideSetHighMFIStdDev"
-        + " FROM AnalyteTitration "
-        + " LEFT JOIN (" + guideSetRangeValuesSQL + ") AS gs ON GuideSet = gs.RowId";
-    }
-    else if (config.controlType === "SinglePoint")
-    {
-        sql += ", AverageFiBkgd AS MFI, AverageFiBkgdQCFlagsEnabled AS MFIQCFlagsEnabled"
-        //columns needed for guide set ranges (value based or run based)
-        + ", gs.GuideSetMFIAverage"
-        + ", gs.GuideSetMFIStdDev"
-        + " FROM AnalyteSinglePointControl "
-        + " LEFT JOIN (" + guideSetRangeValuesSQL + ") AS gs ON GuideSet = gs.RowId";
-    }
-
     var store = new LABKEY.ext.Store({
-        autoLoad: false,
+        autoLoad: true,
         schemaName: 'assay.Luminex.' + LABKEY.QueryKey.encodePart(config.assayName),
         sql: sql,
-        filterArray: config.filters,
-        sort: config.sort ? config.sort : '-Analyte/Data/AcquisitionDate, -' + controlTypeColName + '/Run/Created',
-        maxRows: config.maxRows ? config.maxRows : -1,
+        maxRows: -1,
         containerFilter: LABKEY.Query.containerFilter.allFolders,
         scope: config.scope
     });
 
-    // not assuming scope for now...
     if (config.loadListener)
         store.addListener('load', config.loadListener, config.scope);
 
     return store;
 };
 
-// consider reducing scope of this object...?
-LABKEY.LeveyJenningsPlotHelper.PlotTypeMap = {
-    EC504PL: 'EC50 - 4PL',
-    EC505PL: 'EC50 - 5PL Rumi',
-    AUC: 'AUC',
-    HighMFI: 'High MFI',
-    MFI: 'MFI' // not sure why we cannot get these named right.
-};
-
 LABKEY.LeveyJenningsPlotHelper.renderPlot = function(config)
 {
     var plotData = [];
-    var records = config.store.getRange();
+    var records = config.dataStore.getRange();
     var otherHoverProps = ['Network', 'AssayType', 'ExpPerformer', 'AcquisitionDate'];
+    var columnsMap = config.controlType === 'SinglePoint' ? LABKEY.LeveyJenningsPlotHelper.SinglePointControlColumnsMap : LABKEY.LeveyJenningsPlotHelper.TitrationColumnsMap;
 
     var _pushData = function(record)
     {
         var data = {
-            xLabel: record.get('NotebookNo'),
-            pointColor: record.get('LotNumber'),
-            value: record.get(config.plotType),
-            gsMean: record.get('GuideSet' + config.plotType + 'Average'),
-            gsStdDev: record.get('GuideSet' + config.plotType + 'StdDev')
+            xLabel: record.get(columnsMap['NotebookNo']),
+            pointColor: record.get(columnsMap['LotNumber']),
+            value: record.get(columnsMap[config.plotType]),
         };
+
+        // merge in the guide set range mean and stdDev values
+        var gsRecordIndex = config.guideSetRangeStore ? config.guideSetRangeStore.findExact('RowId', record.get(columnsMap['GuideSetId'])) : -1;
+        if (gsRecordIndex > -1) {
+            var gsRecord = config.guideSetRangeStore.getAt(gsRecordIndex);
+            data['gsMean'] = gsRecord.get('GuideSet' + config.plotType + 'Average');
+            data['gsStdDev'] = gsRecord.get('GuideSet' + config.plotType + 'StdDev');
+        }
 
         // add some other values to the data object for the hover display
         Ext.each(otherHoverProps, function(prop) {
-            var val = record.get(prop);
+            var val = record.get(columnsMap[prop]);
 
             // convert values that are date objects to a display string format
             if (val != null && LABKEY.Utils.isDate(val)) {
@@ -152,7 +154,7 @@ LABKEY.LeveyJenningsPlotHelper.renderPlot = function(config)
 
         for (var i = 0; i < records.length; i++)
         {
-            if (records[i].get('RunRowId') == config.runId)
+            if (records[i].get(columnsMap['RunRowId']) == config.runId)
             {
                 index = i;
                 break;
@@ -215,7 +217,7 @@ LABKEY.LeveyJenningsPlotHelper.renderPlot = function(config)
         colorRange: ['black', 'red', 'green', 'blue', 'purple', 'orange', 'grey', 'brown'],
         hoverTextFn: function(row){
             var display = 'Notebook: ' + row.xLabel
-                    + '\nLot Number: ' + row.pointColor
+                    + '\nLot Number: ' + (row.pointColor ? row.pointColor : '')
                     + '\n' + config.plotType + ': ' + row.value;
 
             // add any of the non-null extra display values to the hover
@@ -251,8 +253,7 @@ LABKEY.LeveyJenningsPlotHelper.renderPlot = function(config)
 // plotType: EC504PL, EC505PL, AUC, HighMFI
 LABKEY.LeveyJenningsPlotHelper.getLeveyJenningsPlotWindow = function(protocolId, analyteId, typeId, plotType, controlType)
 {
-    if (controlType == null)
-        controlType = 'Titration';
+    var controlTypeColName = controlType === 'SinglePoint' ? 'SinglePointControl' : controlType;
 
     LABKEY.Assay.getById({
         id: protocolId,
@@ -267,20 +268,20 @@ LABKEY.LeveyJenningsPlotHelper.getLeveyJenningsPlotWindow = function(protocolId,
         // note make sure to mix assayName into config...
         LABKEY.Query.selectRows({
             schemaName: 'assay.Luminex.' + LABKEY.QueryKey.encodePart(assayName),
-            queryName: 'Analyte'+controlType,
-            columns: [controlType+'/Name', 'Analyte/Name', controlType+'/Run/Isotype', controlType+'/Run/Conjugate', controlType+'/Run', 'Analyte/Data/AcquisitionDate'],
+            queryName: 'Analyte'+controlTypeColName,
+            columns: [controlTypeColName+'/Name', 'Analyte/Name', controlTypeColName+'/Run/Isotype', controlTypeColName+'/Run/Conjugate', controlTypeColName+'/Run', 'Analyte/Data/AcquisitionDate'],
             filterArray: [
                 LABKEY.Filter.create('Analyte', analyteId),
-                LABKEY.Filter.create(controlType, typeId)
+                LABKEY.Filter.create(controlTypeColName, typeId)
             ],
             success: function(data) {
                 var row = data.rows[0];
 
                 const filters = [
                     LABKEY.Filter.create('Analyte/Name', row['Analyte/Name']),
-                    LABKEY.Filter.create(controlType + '/Name', row[controlType+'/Name']),
-                    LABKEY.Filter.create(controlType + '/Run/Isotype', row[controlType+'/Run/Isotype']),
-                    LABKEY.Filter.create(controlType + '/Run/Conjugate', row[controlType+'/Run/Conjugate']),
+                    LABKEY.Filter.create(controlTypeColName + '/Name', row[controlTypeColName+'/Name']),
+                    LABKEY.Filter.create(controlTypeColName + '/Run/Isotype', row[controlTypeColName+'/Run/Isotype']),
+                    LABKEY.Filter.create(controlTypeColName + '/Run/Conjugate', row[controlTypeColName+'/Run/Conjugate']),
                 ];
                 if (controlType === 'Titration') {
                     filters.push(LABKEY.Filter.create('Titration/IncludeInQcReport', true));
@@ -288,16 +289,16 @@ LABKEY.LeveyJenningsPlotHelper.getLeveyJenningsPlotWindow = function(protocolId,
 
                 var config = {
                     assayName: assayName,
-                    controlName: row[controlType+'/Name'],
-                    controlType: controlType === "SinglePointControl" ? "SinglePoint" : "Titration",
+                    controlName: row[controlTypeColName+'/Name'],
+                    controlType: controlType,
                     analyte: row['Analyte/Name'],
-                    isotype: row[controlType+'/Run/Isotype'],
-                    conjugate: row[controlType+'/Run/Conjugate'],
+                    isotype: row[controlTypeColName+'/Run/Isotype'],
+                    conjugate: row[controlTypeColName+'/Run/Conjugate'],
                     yAxisScale: 'linear',
                     plotType: plotType,
-                    runId: row[controlType+'/Run'],
+                    runId: row[controlTypeColName+'/Run'],
                     filters: filters,
-                    sort: 'Analyte/Data/AcquisitionDate, ' + controlType + '/Run/Created',
+                    sort: 'Analyte/Data/AcquisitionDate, ' + controlTypeColName + '/Run/Created',
                     scope: this, // shouldn't matter but might blow up without it.
                 };
 
@@ -327,17 +328,31 @@ LABKEY.LeveyJenningsPlotHelper.getLeveyJenningsPlotWindow = function(protocolId,
                 },
                 listeners : {
                     afterrender: function() {
-
                         window.getEl().mask("Loading...", "x-mask-loading");
+                        var dataStoreLoaded = false;
+                        var guideSetStoreLoaded = false;
 
                         config.loadListener = function(store) {
-                            config.store = store;
-                            LABKEY.LeveyJenningsPlotHelper.renderPlot(config);
-                            window.getEl().unmask();
+                            dataStoreLoaded = true;
+                            config.dataStore = store;
+                            if (guideSetStoreLoaded) {
+                                LABKEY.LeveyJenningsPlotHelper.renderPlot(config);
+                                window.getEl().unmask();
+                            }
                         };
+                        LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore(config);
 
-                        var store = LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore(config);
-                        store.load()
+                        LABKEY.LeveyJenningsPlotHelper.getGuideSetRangesStore({
+                            assayName: config.assayName,
+                            loadListener: function(store) {
+                                guideSetStoreLoaded = true;
+                                config.guideSetRangeStore = store;
+                                if (dataStoreLoaded) {
+                                    LABKEY.LeveyJenningsPlotHelper.renderPlot(config);
+                                    window.getEl().unmask();
+                                }
+                            },
+                        });
                     }
                 }
             }]

--- a/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
+++ b/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
@@ -19,6 +19,7 @@ LABKEY.LeveyJenningsPlotHelper.TitrationColumnsMap = {
     "AcquisitionDate": "Analyte/Data/AcquisitionDate",
     "LotNumber": "Analyte/Properties/LotNumber",
     "RunRowId": "Titration/Run/RowId",
+    "AssayId": "Titration/Run/Name",
     "Network": "Titration/Run/Batch/Network",
     "NotebookNo": "Analyte/Data/Run/NotebookNo",
     "AssayType": "Analyte/Data/Run/AssayType",
@@ -34,6 +35,7 @@ LABKEY.LeveyJenningsPlotHelper.SinglePointControlColumnsMap = {
     "AcquisitionDate": "Analyte/Data/AcquisitionDate",
     "LotNumber": "Analyte/Properties/LotNumber",
     "RunRowId": "SinglePointControl/Run/RowId",
+    "AssayId": "SinglePointControl/Run/Name",
     "Network": "SinglePointControl/Run/Batch/Network",
     "NotebookNo": "SinglePointControl/Run/NotebookNo",
     "AssayType": "SinglePointControl/Run/AssayType",
@@ -122,6 +124,11 @@ LABKEY.LeveyJenningsPlotHelper.renderPlot = function(config)
             pointColor: record.get(columnsMap['LotNumber']),
             value: record.get(columnsMap[config.plotType]),
         };
+
+        // fall back to using the AssayId if the NotebookNo prop doesn't exist
+        if (!record.get(columnsMap['NotebookNo'])) {
+            data.xLabel = record.get(columnsMap['AssayId']);
+        }
 
         // merge in the guide set range mean and stdDev values
         var gsRecordIndex = config.guideSetRangeStore ? config.guideSetRangeStore.findExact('RowId', record.get(columnsMap['GuideSetId'])) : -1;

--- a/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
+++ b/luminex/webapp/luminex/LeveyJenningsPlotHelpers.js
@@ -272,8 +272,8 @@ LABKEY.LeveyJenningsPlotHelper.getLeveyJenningsPlotWindow = function(protocolId,
 
     var _getConfig = function(assayName)
     {
-        // note make sure to mix assayName into config...
         LABKEY.Query.selectRows({
+            containerFilter: LABKEY.Query.containerFilter.allFolders,
             schemaName: 'assay.Luminex.' + LABKEY.QueryKey.encodePart(assayName),
             queryName: 'Analyte'+controlTypeColName,
             columns: [controlTypeColName+'/Name', 'Analyte/Name', controlTypeColName+'/Run/Isotype', controlTypeColName+'/Run/Conjugate', controlTypeColName+'/Run', 'Analyte/Data/AcquisitionDate'],

--- a/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
@@ -127,7 +127,10 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.Component, {
     },
 
     storeLoading: function() {
-        this.fireEvent('plotDataLoading', this.store);
+        this.fireEvent('plotDataLoading', this.store, this.hasGuideSetUpdate);
+
+        // reset hasGuideSetUpdate so that other grid filter changes won't trigger this as well
+        this.hasGuideSetUpdate = false;
     },
 
     storeLoaded: function() {
@@ -135,8 +138,10 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.Component, {
     },
 
     // function called by the JSP when the graph params are selected and the "Apply" button is clicked
-    graphParamsSelected: function (analyte, isotype, conjugate)
+    graphParamsSelected: function (analyte, isotype, conjugate, hasGuideSetUpdate)
     {
+        this.hasGuideSetUpdate = hasGuideSetUpdate;
+
         // store the params locally
         this.analyte = analyte;
         this.isotype = isotype;

--- a/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
@@ -186,6 +186,10 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.Component, {
         dataRegion.getSelected({
             success: function(response) {
                 var selectedRecords = scope.parseGridSelectionKeys(response.selected, false);
+                if (selectedRecords.length === 0) {
+                    LABKEY.Utils.alert('Error', 'Please select rows in the tracking data grid before clicking the "Apply Guide Set" button.');
+                    return;
+                }
 
                 // create a pop-up window to display the apply guide set UI
                 var win = new Ext.Window({
@@ -241,6 +245,10 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.Component, {
         dataRegion.getSelected({
             success: function(response) {
                 var analyteIds = scope.parseGridSelectionKeys(response.selected, true);
+                if (analyteIds.length === 0) {
+                    LABKEY.Utils.alert('Error', 'Please select rows in the tracking data grid before clicking the "View 4PL Curves" button.');
+                    return;
+                }
 
                 LABKEY.Query.selectRows({
                     schemaName: "assay.Luminex." + LABKEY.QueryKey.encodePart(_protocolName),

--- a/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
@@ -14,12 +14,12 @@ Ext.namespace('LABKEY');
 Ext.QuickTips.init();
 
 /**
- * Class to create a labkey editorGridPanel to display the tracking data for the selected graph parameters
+ * Class to create a QueryWebPart to display the tracking data for the selected graph parameters
  *
  * @params controlName
  * @params assayName
  */
-LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.grid.GridPanel, {
+LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.Component, {
     constructor: function (config)
     {
         // check that the config properties needed are present
@@ -28,26 +28,10 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.grid.GridPanel, {
         if (!config.assayName || config.assayName == "null")
             throw "You must specify a assayName!";
 
-        // apply some Ext panel specific properties to the config
-        Ext.apply(config, {
-            width: 1375,
-            autoHeight: true,
-            title: $h(config.controlName) + ' Tracking Data',
-            loadMask: {msg: "Loading data..."},
-            columnLines: true,
-            stripeRows: true,
-            viewConfig: {
-                forceFit: true,
-                scrollOffset: 0
-            },
-            disabled: true,
-            analyte: null,
-            isotype: null,
-            conjugate: null,
-            userCanUpdate: LABKEY.user.canUpdate
-        });
+        config.html = '<div id="trackingDataPanel_title" class="lj-report-title"></div>'
+                + '<div id="trackingDataPanel_QWP"></div>';
 
-        this.addEvents('appliedGuideSetUpdated', 'trackingDataLoaded');
+        this.addEvents('appliedGuideSetUpdated', 'plotDataLoading', 'plotDataLoaded');
 
         LABKEY.LeveyJenningsTrackingDataPanel.superclass.constructor.call(this, config);
     },
@@ -55,194 +39,73 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.grid.GridPanel, {
     initComponent: function ()
     {
         this.store = new Ext.data.ArrayStore();
-        this.selModel = this.getTrackingDataSelModel();
-        this.colModel = this.getTrackingDataColModel();
 
         // initialize an export button for the toolbar
-        this.exportMenuButton = new Ext.Button({
-            text: 'Export',
-            menu: [
-                {
-                    text: 'Excel',
-                    handler: function ()
-                    {
-                        this.exportData('excel');
-                    },
-                    scope: this
-                },
-                {
-                    text: 'TSV',
-                    handler: function ()
-                    {
-                        this.exportData('tsv');
-                    },
-                    scope: this
-                }
-            ]
-        });
+        // this.exportMenuButton = new Ext.Button({
+        //     text: 'Export',
+        //     menu: [
+        //         {
+        //             text: 'Excel',
+        //             handler: function ()
+        //             {
+        //                 this.exportData('excel');
+        //             },
+        //             scope: this
+        //         },
+        //         {
+        //             text: 'TSV',
+        //             handler: function ()
+        //             {
+        //                 this.exportData('tsv');
+        //             },
+        //             scope: this
+        //         }
+        //     ]
+        // });
 
         // initialize the apply guide set button to the toolbar
-        this.applyGuideSetButton = new Ext.Button({
-            disabled: true,
-            text: 'Apply Guide Set',
-            handler: this.applyGuideSetClicked,
-            scope: this
-        });
+        // this.applyGuideSetButton = new Ext.Button({
+        //     disabled: true,
+        //     text: 'Apply Guide Set',
+        //     handler: this.applyGuideSetClicked,
+        //     scope: this
+        // });
 
         // initialize the view curves button to the toolbar
-        this.viewCurvesButton = new Ext.Button({
-            disabled: true,
-            text: 'View 4PL Curves',
-            tooltip: 'Click to view overlapping curves for the selected runs.',
-            handler: this.viewCurvesClicked,
-            scope: this
-        });
+        // this.viewCurvesButton = new Ext.Button({
+        //     disabled: true,
+        //     text: 'View 4PL Curves',
+        //     tooltip: 'Click to view overlapping curves for the selected runs.',
+        //     handler: this.viewCurvesClicked,
+        //     scope: this
+        // });
 
         // if the controlType is Titration, show the viewCurves 'View 4PL Curves' button, for Single Point Controls do not
-        if (this.controlType == "Titration")
-        {
-            // if the user has permissions to update in this container, show them the Apply Guide Set button
-            this.tbar = this.userCanUpdate ? [this.exportMenuButton, this.applyGuideSetButton, this.viewCurvesButton] : [this.exportMenuButton, this.viewCurvesButton];
-        }
-        else
-        {
-            // if the user has permissions to update in this container, show them the Apply Guide Set button
-            this.tbar = this.userCanUpdate ? [this.exportMenuButton, this.applyGuideSetButton ] : [this.exportMenuButton];
-        }
-
-        this.fbar = [
-            {xtype: 'label', text: 'Bold values in the "Guide Set Date" column indicate runs that are members of a guide set.'}
-        ];
+        // if (this.controlType == "Titration")
+        // {
+        //     // if the user has permissions to update in this container, show them the Apply Guide Set button
+        //     this.tbar = LABKEY.user.canUpdate ? [this.exportMenuButton, this.applyGuideSetButton, this.viewCurvesButton] : [this.exportMenuButton, this.viewCurvesButton];
+        // }
+        // else
+        // {
+        //     // if the user has permissions to update in this container, show them the Apply Guide Set button
+        //     this.tbar = LABKEY.user.canUpdate ? [this.exportMenuButton, this.applyGuideSetButton ] : [this.exportMenuButton];
+        // }
+        //
+        // this.fbar = [
+        //     {xtype: 'label', text: 'Bold values in the "Guide Set Date" column indicate runs that are members of a guide set.'}
+        // ];
 
         LABKEY.LeveyJenningsTrackingDataPanel.superclass.initComponent.call(this);
     },
 
-    getNeworkProtocolFilter: function(name, value) {
-        var fieldName = (this.controlType == "Titration" ? "Titration" : "SinglePointControl") + '.Run.Batch.' + name;
-        if (value != null) {
-            return " AND " + fieldName + " = '" + value.replace(/'/g, "''") + "'";
-        }
-        else {
-            return " AND " + fieldName + " IS NULL";
-        }
+    hasReportFilter: function() {
+        var userFilters = this.qwp.getUserFilterArray();
+        return userFilters.length > 0;
     },
 
-    storeLoaded: function(store, records, options) {
-        this.fireEvent('trackingDataLoaded', store);
-        this.loadQCFlags(store, records, options);
-    },
-
-    getTrackingDataSelModel: function ()
-    {
-        return new Ext.grid.CheckboxSelectionModel({
-            listeners: {
-                scope: this,
-                'selectionchange': function (selectionModel)
-                {
-                    if (selectionModel.hasSelection())
-                    {
-                        this.applyGuideSetButton.enable();
-                        this.viewCurvesButton.enable();
-                    }
-                    else
-                    {
-                        this.applyGuideSetButton.disable();
-                        this.viewCurvesButton.disable();
-                    }
-                }
-            }
-        });
-    },
-
-    getTrackingDataColModel: function ()
-    {
-        return new Ext.grid.ColumnModel({
-            defaults: {sortable: true},
-            columns: this.getTrackingDataColumns(),
-            scope: this
-        });
-    },
-
-    getTrackingDataColumns: function ()
-    {
-        var cols = [
-            this.selModel,
-            {header: 'Analyte', dataIndex: 'Analyte', hidden: true, renderer: this.encodingRenderer},
-            {header: 'Isotype', dataIndex: 'Isotype', hidden: true, renderer: this.encodingRenderer},
-            {header: 'Conjugate', dataIndex: 'Conjugate', hidden: true, renderer: this.encodingRenderer},
-            {header: 'QC Flags', dataIndex: 'QCFlags', width: 75},
-            {header: 'Assay Id', dataIndex: 'RunName', renderer: this.assayIdHrefRenderer, width: 200},
-            {header: 'Network', dataIndex: 'Network', width: 75, renderer: this.encodingRenderer, hidden: !this.networkExists},
-            {header: 'Protocol', dataIndex: 'CustomProtocol', width: 75, renderer: this.encodingRenderer, hidden: !this.protocolExists},
-            {header: 'Folder', dataIndex: 'FolderName', width: 75, renderer: this.encodingRenderer},
-            {header: 'Notebook No.', dataIndex: 'NotebookNo', width: 100, renderer: this.encodingRenderer},
-            {header: 'Assay Type', dataIndex: 'AssayType', width: 100, renderer: this.encodingRenderer},
-            {header: 'Experiment Performer', dataIndex: 'ExpPerformer', width: 100, renderer: this.encodingRenderer},
-            {header: 'Acquisition Date', dataIndex: 'AcquisitionDate', renderer: this.dateRenderer, width: 100},
-            {header: 'Analyte Lot No.', dataIndex: 'LotNumber', width: 100, renderer: this.encodingRenderer},
-            {header: 'Guide Set Start Date', dataIndex: 'GuideSetCreated', renderer: this.formatGuideSetMembers, scope: this, width: 100},
-            {header: 'GS Member', dataIndex: 'IncludeInGuideSetCalculation', hidden: true}
-        ];
-
-        if (this.controlType == "Titration")
-        {
-            cols.splice(2, 0, {header: 'Titration', dataIndex: 'Titration', hidden: true, renderer: this.encodingRenderer});
-            cols.push({header: 'EC50 4PL', dataIndex: 'EC504PL', width: 75, renderer: this.outOfRangeRenderer("EC504PLQCFlagsEnabled"), scope: this, align: 'right', hidden: !this.has4PLCurveFit});
-            cols.push({header: 'EC50 4PL QC Flags Enabled', dataIndex: 'EC504PLQCFlagsEnabled', hidden: true});
-            cols.push({header: 'EC50 5PL', dataIndex: 'EC505PL', width: 75, renderer: this.outOfRangeRenderer("EC505PLQCFlagsEnabled"), scope: this, align: 'right', hidden: !this.has5PLCurveFit});
-            cols.push({header: 'EC50 5PL QC Flags Enabled', dataIndex: 'EC505PLQCFlagsEnabled', hidden: true});
-            cols.push({header: 'AUC', dataIndex: 'AUC', width: 75, renderer: this.outOfRangeRenderer("AUCQCFlagsEnabled"), scope: this, align: 'right'});
-            cols.push({header: 'AUC  QC Flags Enabled', dataIndex: 'AUCQCFlagsEnabled', hidden: true});
-            cols.push({header: 'High MFI', dataIndex: 'HighMFI', width: 75, renderer: this.outOfRangeRenderer("HighMFIQCFlagsEnabled"), scope: this, align: 'right'});
-            cols.push({header: 'High  QC Flags Enabled', dataIndex: 'HighMFIQCFlagsEnabled', hidden: true});
-        }
-        else if (this.controlType == "SinglePoint")
-        {
-            cols.splice(2, 0, {header: 'SinglePointControl', dataIndex: 'SinglePointControl', hidden: true, renderer: this.encodingRenderer});
-            cols.push({header: 'MFI', dataIndex: 'MFI', width: 75, renderer: this.outOfRangeRenderer("MFIQCFlagsEnabled"), scope: this, align: 'right'});
-            cols.push({header: 'MFI QC Flags Enabled', dataIndex: 'MFIQCFlagsEnabled', hidden: true});
-        }
-
-        return cols;
-    },
-
-    // function called by the JSP when the graph params are selected and the "Apply" button is clicked
-    graphParamsSelected: function (analyte, isotype, conjugate, startDate, endDate, network, networkAny, protocol, protocolAny)
-    {
-        // store the params locally
-        this.analyte = analyte;
-        this.isotype = isotype;
-        this.conjugate = conjugate;
-
-        // set the grid title based on the selected graph params
-        this.setTitle($h(this.controlName) + ' Tracking Data for ' + $h(this.analyte)
-                + ' - ' + $h(this.isotype == '' ? '[None]' : this.isotype)
-                + ' ' + $h(this.conjugate == '' ? '[None]' : this.conjugate));
-
-        var whereClause = "";
-        var hasReportFilter = false;
-        if (startDate)
-        {
-            hasReportFilter = true;
-            whereClause += " AND CAST(Analyte.Data.AcquisitionDate AS DATE) >= '" + startDate + "'";
-        }
-        if (endDate)
-        {
-            hasReportFilter = true;
-            whereClause += " AND CAST(Analyte.Data.AcquisitionDate AS DATE) <= '" + endDate + "'";
-        }
-        if (Ext.isDefined(network) && !networkAny)
-        {
-            hasReportFilter = true;
-            whereClause += this.getNeworkProtocolFilter("Network", network);
-        }
-        if (Ext.isDefined(protocol) && !protocolAny)
-        {
-            hasReportFilter = true;
-            whereClause += this.getNeworkProtocolFilter("CustomProtocol", protocol);
-        }
-
-        // create a new store now that the graph params are selected and bind it to the grid
+    configurePlotDataStore: function(baseFilters) {
+        // create a new store now that the graph params are selected
         var storeConfig = {
             assayName: this.assayName,
             controlName: this.controlName,
@@ -250,15 +113,11 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.grid.GridPanel, {
             analyte: this.analyte,
             isotype: this.isotype,
             conjugate: this.conjugate,
-            maxRows: !hasReportFilter ? this.defaultRowSize : undefined,
+            filters: baseFilters.concat(this.qwp.getUserFilterArray()),
+            maxRows: !this.hasReportFilter() ? this.defaultRowSize : undefined,
             scope: this,
             loadListener: this.storeLoaded,
         };
-
-        if (whereClause != "")
-        {
-            storeConfig['whereClause'] = whereClause;
-        }
 
         this.store = LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore(storeConfig);
 
@@ -269,585 +128,488 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.grid.GridPanel, {
             }
         });
 
-        var newColModel = this.getTrackingDataColModel();
-        this.reconfigure(this.store, newColModel);
+        this.storeLoading();
         this.store.load();
+    },
+
+    storeLoading: function() {
+        this.fireEvent('plotDataLoading', this.store);
+    },
+
+    storeLoaded: function() {
+        this.fireEvent('plotDataLoaded', this.store, this.hasReportFilter());
+    },
+
+    // function called by the JSP when the graph params are selected and the "Apply" button is clicked
+    graphParamsSelected: function (analyte, isotype, conjugate)
+    {
+        // store the params locally
+        this.analyte = analyte;
+        this.isotype = isotype;
+        this.conjugate = conjugate;
+
+        // set the grid title based on the selected graph params
+        document.getElementById('trackingDataPanel_title').innerHTML =
+            $h(this.controlName) + ' Tracking Data for ' + $h(this.analyte)
+            + ' - ' + $h(this.isotype === '' ? '[None]' : this.isotype)
+            + ' ' + $h(this.conjugate === '' ? '[None]' : this.conjugate);
+
+        var controlTypeColName = this.controlType === 'SinglePoint' ? 'SinglePointControl' : this.controlType;
+        const filters = [
+            LABKEY.Filter.create('Analyte/Name', this.analyte),
+            LABKEY.Filter.create(controlTypeColName + '/Name', this.controlName),
+            LABKEY.Filter.create(controlTypeColName + '/Run/Isotype', this.isotype),
+            LABKEY.Filter.create(controlTypeColName + '/Run/Conjugate', this.conjugate),
+        ];
+        if (this.controlType === 'Titration') {
+            filters.push(LABKEY.Filter.create('Titration/IncludeInQcReport', true));
+        }
+
+        this.qwp = new LABKEY.QueryWebPart({
+            renderTo: 'trackingDataPanel_QWP',
+            schemaName: "assay.Luminex." + LABKEY.QueryKey.encodePart(_protocolName),
+            queryName: this.controlType === 'SinglePoint' ? 'AnalyteSinglePointControl' : 'AnalyteTitration',
+            containerFilter: LABKEY.Query.containerFilter.allFolders,
+            maxRows: this.defaultRowSize,
+            showUpdateColumn : false,
+            showImportDataButton : false,
+            showInsertNewButton : false,
+            showDeleteButton : false,
+            showReports : false,
+            frame: 'none',
+            filters: filters,
+            sort: '-Analyte/Data/AcquisitionDate, -' + controlTypeColName + '/Run/Created',
+            listeners: {
+                scope: this,
+                success: function(qwp) {
+                    this.configurePlotDataStore(filters);
+                }
+            }
+        });
+
+        this.configurePlotDataStore(filters);
 
         // enable the trending data grid
         this.enable();
     },
 
-    applyGuideSetClicked: function ()
-    {
-        // get the selected record list from the grid
-        var selection = this.selModel.getSelections();
-        var selectedRecords = [];
-        // Copy so that it's available in the scope for the callback function
-        var controlType = this.controlType;
-        Ext.each(selection, function (record)
-        {
-            var newItem = {Analyte: record.get("Analyte")};
-            if (controlType == 'Titration')
-            {
-                newItem.ControlId = record.get("Titration");
-            }
-            else
-            {
-                newItem.ControlId = record.get("SinglePointControl");
-            }
-            selectedRecords.push(newItem);
-        });
+    // applyGuideSetClicked: function ()
+    // {
+    //     // get the selected record list from the grid
+    //     var selection = this.selModel.getSelections();
+    //     var selectedRecords = [];
+    //     // Copy so that it's available in the scope for the callback function
+    //     var controlType = this.controlType;
+    //     Ext.each(selection, function (record)
+    //     {
+    //         var newItem = {Analyte: record.get("Analyte")};
+    //         if (controlType == 'Titration')
+    //         {
+    //             newItem.ControlId = record.get("Titration");
+    //         }
+    //         else
+    //         {
+    //             newItem.ControlId = record.get("SinglePointControl");
+    //         }
+    //         selectedRecords.push(newItem);
+    //     });
+    //
+    //     // create a pop-up window to display the apply guide set UI
+    //     var win = new Ext.Window({
+    //         layout: 'fit',
+    //         width: 1115,
+    //         height: 500,
+    //         closeAction: 'close',
+    //         modal: true,
+    //         padding: 15,
+    //         cls: 'extContainer leveljenningsreport',
+    //         bodyStyle: 'background-color: white;',
+    //         title: 'Apply Guide Set...',
+    //         items: [new LABKEY.ApplyGuideSetPanel({
+    //             assayName: this.assayName,
+    //             controlName: this.controlName,
+    //             controlType: this.controlType,
+    //             analyte: this.analyte,
+    //             isotype: this.isotype,
+    //             conjugate: this.conjugate,
+    //             selectedRecords: selectedRecords,
+    //             networkExists: this.networkExists,
+    //             protocolExists: this.protocolExists,
+    //             listeners: {
+    //                 scope: this,
+    //                 'closeApplyGuideSetPanel': function (hasUpdated)
+    //                 {
+    //                     if (hasUpdated)
+    //                         this.fireEvent('appliedGuideSetUpdated');
+    //                     win.close();
+    //                 }
+    //             }
+    //         })]
+    //     });
+    //
+    //     // for testing, narrow window puts left aligned buttons off of the page
+    //     win.on('show', function(cmp) {
+    //         var posArr = cmp.getPosition();
+    //         if (posArr[0] < 0)
+    //             cmp.setPosition(0, posArr[1]);
+    //     });
+    //
+    //     win.show(this);
+    // },
+    //
+    // viewCurvesClicked: function ()
+    // {
+    //     // create a pop-up window to display the plot
+    //     var plotDiv = new Ext.Container({
+    //         height: 600,
+    //         width: 900,
+    //         autoEl: {tag: 'div'}
+    //     });
+    //     var pdfDiv = new Ext.Container({
+    //         hidden: true,
+    //         autoEl: {tag: 'div'}
+    //     });
+    //
+    //     var yAxisScaleDefault = 'Linear';
+    //     var yAxisScaleStore = new Ext.data.ArrayStore({
+    //         fields: ['value'],
+    //         data: [['Linear'], ['Log']]
+    //     });
+    //
+    //     var yAxisColDefault = 'FIBackground', yAxisColDisplayDefault = 'FI-Bkgd';
+    //     var yAxisColStore = new Ext.data.ArrayStore({
+    //         fields: ['name', 'value'],
+    //         data: [['FI', 'FI'], ['FI-Bkgd', 'FIBackground'], ['FI-Bkgd-Neg', 'FIBackgroundNegative']]
+    //     });
+    //
+    //     var legendColDefault = 'Name';
+    //     var legendColStore = new Ext.data.ArrayStore({
+    //         fields: ['name', 'value'],
+    //         data: [['Assay Type', 'AssayType'], ['Experiment Performer', 'ExpPerformer'], ['Assay Id', 'Name'], ['Notebook No.', 'NotebookNo']]
+    //     });
+    //
+    //     var win = new Ext.Window({
+    //         layout: 'fit',
+    //         width: 900,
+    //         minWidth: 600,
+    //         height: 660,
+    //         minHeight: 500,
+    //         closeAction: 'hide',
+    //         modal: true,
+    //         cls: 'extContainer',
+    //         title: 'Curve Comparison',
+    //         items: [plotDiv, pdfDiv],
+    //         // stash the default values for the plot options on the win component
+    //         yAxisScale: yAxisScaleDefault,
+    //         yAxisCol: yAxisColDefault,
+    //         yAxisDisplay: yAxisColDisplayDefault,
+    //         legendCol: legendColDefault,
+    //         buttonAlign: 'left',
+    //         buttons: [{
+    //             xtype: 'label',
+    //             text: 'Y-Axis:'
+    //         },{
+    //             xtype: 'combo',
+    //             width: 80,
+    //             id: 'curvecomparison-yaxis-combo',
+    //             store: yAxisColStore ,
+    //             displayField: 'name',
+    //             valueField: 'value',
+    //             mode: 'local',
+    //             editable: false,
+    //             forceSelection: true,
+    //             triggerAction: 'all',
+    //             value: yAxisColDefault,
+    //             listeners: {
+    //                 scope: this,
+    //                 select: function(cmp, record) {
+    //                     win.yAxisCol = record.data.value;
+    //                     win.yAxisDisplay = record.data.name;
+    //                     this.updateCurvesPlot(win, plotDiv.getId(), false);
+    //                 }
+    //             }
+    //         },{
+    //             xtype: 'label',
+    //             text: 'Scale:'
+    //         },{
+    //             xtype: 'combo',
+    //             width: 75,
+    //             id: 'curvecomparison-scale-combo',
+    //             store: yAxisScaleStore ,
+    //             displayField: 'value',
+    //             valueField: 'value',
+    //             mode: 'local',
+    //             editable: false,
+    //             forceSelection: true,
+    //             triggerAction: 'all',
+    //             value: yAxisScaleDefault,
+    //             listeners: {
+    //                 scope: this,
+    //                 select: function(cmp, record) {
+    //                     win.yAxisScale = record.data.value;
+    //                     this.updateCurvesPlot(win, plotDiv.getId(), false);
+    //                 }
+    //             }
+    //         },{
+    //             xtype: 'label',
+    //             text: 'Legend:'
+    //         },{
+    //             xtype: 'combo',
+    //             width: 140,
+    //             id: 'curvecomparison-legend-combo',
+    //             store: legendColStore ,
+    //             displayField: 'name',
+    //             valueField: 'value',
+    //             mode: 'local',
+    //             editable: false,
+    //             forceSelection: true,
+    //             triggerAction: 'all',
+    //             value: legendColDefault,
+    //             listeners: {
+    //                 scope: this,
+    //                 select: function(cmp, record) {
+    //                     win.legendCol = record.data.value;
+    //                     this.updateCurvesPlot(win, plotDiv.getId(), false);
+    //                 }
+    //             }
+    //         },
+    //         '->',
+    //         {
+    //             xtype: 'button',
+    //             text: 'Export to PDF',
+    //             handler: function (btn)
+    //             {
+    //                 this.updateCurvesPlot(win, pdfDiv.getId(), true);
+    //             },
+    //             scope: this
+    //         },
+    //         {
+    //             xtype: 'button',
+    //             text: 'Close',
+    //             handler: function ()
+    //             {
+    //                 win.hide();
+    //             }
+    //         }],
+    //         listeners: {
+    //             scope: this,
+    //             'resize': function (w, width, height)
+    //             {
+    //                 // update the curve plot to the new size of the window
+    //                 this.updateCurvesPlot(win, plotDiv.getId(), false);
+    //             }
+    //         }
+    //     });
+    //
+    //     // for testing, narrow window puts left aligned buttons off of the page
+    //     win.on('show', function(cmp) {
+    //         var posArr = cmp.getPosition();
+    //         if (posArr[0] < 0)
+    //             cmp.setPosition(0, posArr[1]);
+    //     });
+    //
+    //     win.show(this);
+    //
+    //     this.updateCurvesPlot(win, plotDiv.getId(), false);
+    // },
+    //
+    // updateCurvesPlot: function (win, divId, outputPdf)
+    // {
+    //     win.getEl().mask("loading curves...", "x-mask-loading");
+    //
+    //     // get the selected record list from the grid
+    //     var selection = this.selModel.getSelections();
+    //     var runIds = [];
+    //     Ext.each(selection, function (record)
+    //     {
+    //         runIds.push(record.get("RunRowId"));
+    //     });
+    //
+    //     // build the config object of the properties that will be needed by the R report
+    //     var config = {reportId: 'module:luminex/CurveComparisonPlot.r', showSection: 'Curve Comparison Plot'};
+    //     config['RunIds'] = runIds.join(";");
+    //     config['Protocol'] = this.assayName;
+    //     config['Titration'] = this.controlName;
+    //     config['Analyte'] = this.analyte;
+    //     config['YAxisScale'] = !outputPdf ? win.yAxisScale  : 'Linear';
+    //     config['YAxisCol'] = win.yAxisCol,
+    //     config['YAxisDisplay'] = win.yAxisDisplay,
+    //     config['LegendCol'] = win.legendCol,
+    //     config['MainTitle'] = $h(this.controlName) + ' 4PL for ' + $h(this.analyte)
+    //             + ' - ' + $h(this.isotype === '' ? '[None]' : this.isotype)
+    //             + ' ' + $h(this.conjugate === '' ? '[None]' : this.conjugate);
+    //     config['PlotHeight'] = win.getHeight();
+    //     config['PlotWidth'] = win.getWidth();
+    //     if (outputPdf)
+    //         config['PdfOut'] = true;
+    //
+    //     // call and display the Report webpart
+    //     new LABKEY.WebPart({
+    //         partName: 'Report',
+    //         renderTo: divId,
+    //         frame: 'none',
+    //         partConfig: config,
+    //         success: function ()
+    //         {
+    //             this.getEl().unmask();
+    //
+    //             if (outputPdf)
+    //             {
+    //                 // ugly way of getting the href for the pdf file and open it
+    //                 if (Ext.getDom(divId))
+    //                 {
+    //                     var html = Ext.getDom(divId).innerHTML;
+    //                     html = html.replace(/&amp;/g, "&");
+    //                     var pdfHref = html.substring(html.indexOf('href="') + 6, html.indexOf('&attachment=true'));
+    //                     if (pdfHref.indexOf("deleteFile") == -1) {
+    //                         pdfHref = pdfHref + "&deleteFile=false";
+    //                     }
+    //                     window.location = pdfHref + "&attachment=true";
+    //                 }
+    //
+    //             }
+    //         },
+    //         failure: function (response)
+    //         {
+    //             Ext.get(plotDiv.getId()).update("Error: " + response.statusText);
+    //             this.getEl().unmask();
+    //         },
+    //         scope: win
+    //     }).render();
+    // },
 
-        // create a pop-up window to display the apply guide set UI
-        var win = new Ext.Window({
-            layout: 'fit',
-            width: 1115,
-            height: 500,
-            closeAction: 'close',
-            modal: true,
-            padding: 15,
-            cls: 'extContainer leveljenningsreport',
-            bodyStyle: 'background-color: white;',
-            title: 'Apply Guide Set...',
-            items: [new LABKEY.ApplyGuideSetPanel({
-                assayName: this.assayName,
-                controlName: this.controlName,
-                controlType: this.controlType,
-                analyte: this.analyte,
-                isotype: this.isotype,
-                conjugate: this.conjugate,
-                selectedRecords: selectedRecords,
-                networkExists: this.networkExists,
-                protocolExists: this.protocolExists,
-                listeners: {
-                    scope: this,
-                    'closeApplyGuideSetPanel': function (hasUpdated)
-                    {
-                        if (hasUpdated)
-                            this.fireEvent('appliedGuideSetUpdated');
-                        win.close();
-                    }
-                }
-            })]
-        });
-
-        // for testing, narrow window puts left aligned buttons off of the page
-        win.on('show', function(cmp) {
-            var posArr = cmp.getPosition();
-            if (posArr[0] < 0)
-                cmp.setPosition(0, posArr[1]);
-        });
-
-        win.show(this);
-    },
-
-    viewCurvesClicked: function ()
-    {
-        // create a pop-up window to display the plot
-        var plotDiv = new Ext.Container({
-            height: 600,
-            width: 900,
-            autoEl: {tag: 'div'}
-        });
-        var pdfDiv = new Ext.Container({
-            hidden: true,
-            autoEl: {tag: 'div'}
-        });
-
-        var yAxisScaleDefault = 'Linear';
-        var yAxisScaleStore = new Ext.data.ArrayStore({
-            fields: ['value'],
-            data: [['Linear'], ['Log']]
-        });
-
-        var yAxisColDefault = 'FIBackground', yAxisColDisplayDefault = 'FI-Bkgd';
-        var yAxisColStore = new Ext.data.ArrayStore({
-            fields: ['name', 'value'],
-            data: [['FI', 'FI'], ['FI-Bkgd', 'FIBackground'], ['FI-Bkgd-Neg', 'FIBackgroundNegative']]
-        });
-
-        var legendColDefault = 'Name';
-        var legendColStore = new Ext.data.ArrayStore({
-            fields: ['name', 'value'],
-            data: [['Assay Type', 'AssayType'], ['Experiment Performer', 'ExpPerformer'], ['Assay Id', 'Name'], ['Notebook No.', 'NotebookNo']]
-        });
-
-        var win = new Ext.Window({
-            layout: 'fit',
-            width: 900,
-            minWidth: 600,
-            height: 660,
-            minHeight: 500,
-            closeAction: 'hide',
-            modal: true,
-            cls: 'extContainer',
-            title: 'Curve Comparison',
-            items: [plotDiv, pdfDiv],
-            // stash the default values for the plot options on the win component
-            yAxisScale: yAxisScaleDefault,
-            yAxisCol: yAxisColDefault,
-            yAxisDisplay: yAxisColDisplayDefault,
-            legendCol: legendColDefault,
-            buttonAlign: 'left',
-            buttons: [{
-                xtype: 'label',
-                text: 'Y-Axis:'
-            },{
-                xtype: 'combo',
-                width: 80,
-                id: 'curvecomparison-yaxis-combo',
-                store: yAxisColStore ,
-                displayField: 'name',
-                valueField: 'value',
-                mode: 'local',
-                editable: false,
-                forceSelection: true,
-                triggerAction: 'all',
-                value: yAxisColDefault,
-                listeners: {
-                    scope: this,
-                    select: function(cmp, record) {
-                        win.yAxisCol = record.data.value;
-                        win.yAxisDisplay = record.data.name;
-                        this.updateCurvesPlot(win, plotDiv.getId(), false);
-                    }
-                }
-            },{
-                xtype: 'label',
-                text: 'Scale:'
-            },{
-                xtype: 'combo',
-                width: 75,
-                id: 'curvecomparison-scale-combo',
-                store: yAxisScaleStore ,
-                displayField: 'value',
-                valueField: 'value',
-                mode: 'local',
-                editable: false,
-                forceSelection: true,
-                triggerAction: 'all',
-                value: yAxisScaleDefault,
-                listeners: {
-                    scope: this,
-                    select: function(cmp, record) {
-                        win.yAxisScale = record.data.value;
-                        this.updateCurvesPlot(win, plotDiv.getId(), false);
-                    }
-                }
-            },{
-                xtype: 'label',
-                text: 'Legend:'
-            },{
-                xtype: 'combo',
-                width: 140,
-                id: 'curvecomparison-legend-combo',
-                store: legendColStore ,
-                displayField: 'name',
-                valueField: 'value',
-                mode: 'local',
-                editable: false,
-                forceSelection: true,
-                triggerAction: 'all',
-                value: legendColDefault,
-                listeners: {
-                    scope: this,
-                    select: function(cmp, record) {
-                        win.legendCol = record.data.value;
-                        this.updateCurvesPlot(win, plotDiv.getId(), false);
-                    }
-                }
-            },
-            '->',
-            {
-                xtype: 'button',
-                text: 'Export to PDF',
-                handler: function (btn)
-                {
-                    this.updateCurvesPlot(win, pdfDiv.getId(), true);
-                },
-                scope: this
-            },
-            {
-                xtype: 'button',
-                text: 'Close',
-                handler: function ()
-                {
-                    win.hide();
-                }
-            }],
-            listeners: {
-                scope: this,
-                'resize': function (w, width, height)
-                {
-                    // update the curve plot to the new size of the window
-                    this.updateCurvesPlot(win, plotDiv.getId(), false);
-                }
-            }
-        });
-
-        // for testing, narrow window puts left aligned buttons off of the page
-        win.on('show', function(cmp) {
-            var posArr = cmp.getPosition();
-            if (posArr[0] < 0)
-                cmp.setPosition(0, posArr[1]);
-        });
-
-        win.show(this);
-
-        this.updateCurvesPlot(win, plotDiv.getId(), false);
-    },
-
-    updateCurvesPlot: function (win, divId, outputPdf)
-    {
-        win.getEl().mask("loading curves...", "x-mask-loading");
-
-        // get the selected record list from the grid
-        var selection = this.selModel.getSelections();
-        var runIds = [];
-        Ext.each(selection, function (record)
-        {
-            runIds.push(record.get("RunRowId"));
-        });
-
-        // build the config object of the properties that will be needed by the R report
-        var config = {reportId: 'module:luminex/CurveComparisonPlot.r', showSection: 'Curve Comparison Plot'};
-        config['RunIds'] = runIds.join(";");
-        config['Protocol'] = this.assayName;
-        config['Titration'] = this.controlName;
-        config['Analyte'] = this.analyte;
-        config['YAxisScale'] = !outputPdf ? win.yAxisScale  : 'Linear';
-        config['YAxisCol'] = win.yAxisCol,
-        config['YAxisDisplay'] = win.yAxisDisplay,
-        config['LegendCol'] = win.legendCol,
-        config['MainTitle'] = $h(this.controlName) + ' 4PL for ' + $h(this.analyte)
-                + ' - ' + $h(this.isotype === '' ? '[None]' : this.isotype)
-                + ' ' + $h(this.conjugate === '' ? '[None]' : this.conjugate);
-        config['PlotHeight'] = win.getHeight();
-        config['PlotWidth'] = win.getWidth();
-        if (outputPdf)
-            config['PdfOut'] = true;
-
-        // call and display the Report webpart
-        new LABKEY.WebPart({
-            partName: 'Report',
-            renderTo: divId,
-            frame: 'none',
-            partConfig: config,
-            success: function ()
-            {
-                this.getEl().unmask();
-
-                if (outputPdf)
-                {
-                    // ugly way of getting the href for the pdf file and open it
-                    if (Ext.getDom(divId))
-                    {
-                        var html = Ext.getDom(divId).innerHTML;
-                        html = html.replace(/&amp;/g, "&");
-                        var pdfHref = html.substring(html.indexOf('href="') + 6, html.indexOf('&attachment=true'));
-                        if (pdfHref.indexOf("deleteFile") == -1) {
-                            pdfHref = pdfHref + "&deleteFile=false";
-                        }
-                        window.location = pdfHref + "&attachment=true";
-                    }
-
-                }
-            },
-            failure: function (response)
-            {
-                Ext.get(plotDiv.getId()).update("Error: " + response.statusText);
-                this.getEl().unmask();
-            },
-            scope: win
-        }).render();
-    },
-
-    exportData: function (type)
-    {
-        // build up the JSON to pass to the export util
-        var exportJson = {
-            fileName: this.title + ".xls",
-            sheets: [
-                {
-                    name: 'data',
-                    // add a header section to the export with the graph parameter information
-                    data: [
-                        [this.controlType == 'Titration' ? 'Titration' : 'SinglePointControl', this.controlName],
-                        ['Analyte:', this.analyte],
-                        ['Isotype:', this.isotype],
-                        ['Conjugate:', this.conjugate],
-                        ['Export Date:', this.dateRenderer(new Date())],
-                        []
-                    ]
-                }
-            ]
-        };
-
-        // get all of the columns that are currently being shown in the grid (except for the checkbox column)
-        var columns = this.getColumnModel().getColumnsBy(function (c)
-        {
-            return !c.hidden && c.dataIndex != "";
-        });
-
-        // add the column header row to the export JSON object
-        var rowIndex = exportJson.sheets[0].data.length;
-        exportJson.sheets[0].data.push([]);
-        Ext.each(columns, function (col)
-        {
-            exportJson.sheets[0].data[rowIndex].push(col.header);
-        });
-
-        // loop through the grid store to put the data into the export JSON object
-        Ext.each(this.getStore().getRange(), function (row)
-        {
-            var rowIndex = exportJson.sheets[0].data.length;
-            exportJson.sheets[0].data[rowIndex] = [];
-
-            // loop through the column list to get the data for each column
-            var colIndex = 0;
-            Ext.each(columns, function (col)
-            {
-                // some of the columns may not be defined in the assay design, so set to null
-                var value = null;
-                if (null != row.get(col.dataIndex))
-                {
-                    value = row.get(col.dataIndex);
-                }
-
-                // render dates with the proper renderer
-                if (value instanceof Date)
-                {
-                    value = this.dateRenderer(value);
-                }
-                // render numbers with the proper rounding and format
-                if (typeof(value) == 'number')
-                {
-                    value = this.numberRenderer(value);
-                }
-                // render out of range values with an asterisk
-                var enabledStates = row.get(col.dataIndex + "QCFlagsEnabled");
-                if (enabledStates != null && (enabledStates.indexOf('t') > -1 || enabledStates.indexOf('1') > -1))
-                {
-                    value = "*" + value;
-                }
-
-                // render the flags in an excel friendly format
-                if (col.dataIndex == "QCFlags")
-                {
-                    value = this.flagsExcelRenderer(value);
-                }
-
-                // Issue 19019: specify that this value should be displayed as a string and not converted to a date
-                if (col.dataIndex == "RunName")
-                {
-                    value = {value: value, forceString: true};
-                }
-
-                exportJson.sheets[0].data[rowIndex][colIndex] = value;
-                colIndex++;
-            }, this);
-        }, this);
-
-        if (type == 'excel')
-        {
-            LABKEY.Utils.convertToExcel(exportJson);
-        }
-        else
-        {
-            LABKEY.Utils.convertToTable({
-                fileNamePrefix: this.title,
-                delim: 'TAB',
-                rows: exportJson.sheets[0].data
-            });
-        }
-    },
-
-    outOfRangeRenderer: function (enabledDataIndex)
-    {
-        return function (val, metaData, record)
-        {
-            if (null == val)
-            {
-                return null;
-            }
-
-            // if the record has an enabled QC flag, highlight it in red
-            var enabledStates = record.get(enabledDataIndex);
-            if (enabledStates != null && (enabledStates.indexOf('t') > -1 || enabledStates.indexOf('1') > -1))
-            {
-                metaData.attr = "style='color:red'";
-            }
-
-            // if this is a very small number, display more decimal places
-            var precision = this.getPrecision(val);
-            return Ext.util.Format.number(Ext.util.Format.round(val, precision), (precision == 6 ? '0.000000' : '0.00'));
-        }
-    },
-
-    getPrecision: function (val)
-    {
-        return (null != val && val > 0 && val < 1) ? 6 : 2;
-    },
-
-    formatGuideSetMembers: function (val, metaData, record)
-    {
-        if (record.get("IncludeInGuideSetCalculation"))
-        {
-            metaData.attr = "style='font-weight:bold'";
-        }
-        return this.dateRenderer(val);
-    },
-
-    loadQCFlags: function (store, records, options)
-    {
-        // query the server for the QC Flags that match the selected Titration and Analyte and update the grid store accordingly
-        this.getEl().mask("loading QC Flags...", "x-mask-loading");
-        var prefix = this.controlType == 'Titration' ? 'Titration' : 'SinglePointControl';
-        LABKEY.Query.executeSql({
-            schemaName: "assay.Luminex." + LABKEY.QueryKey.encodePart(this.assayName),
-            sql: 'SELECT DISTINCT x.Run, x.FlagType, x.Enabled, FROM Analyte' + prefix + 'QCFlags AS x '
-                    + 'WHERE x.Analyte.Name=\'' + this.analyte.replace(/'/g, "''") + '\' AND x.' + prefix + '.Name=\'' + this.controlName.replace(/'/g, "''") + '\' '
-                    + (this.isotype == '' ? '  AND x.' + prefix + '.Run.Isotype IS NULL ' : '  AND x.' + prefix + '.Run.Isotype=\'' + this.isotype.replace(/'/g, "''") + '\' ')
-                    + (this.conjugate == '' ? '  AND x.' + prefix + '.Run.Conjugate IS NULL ' : '  AND x.' + prefix + '.Run.Conjugate=\'' + this.conjugate.replace(/'/g, "''") + '\' ')
-                    + 'ORDER BY x.Run, x.FlagType, x.Enabled LIMIT 10000 ',
-            sort: "Run,FlagType,Enabled",
-            containerFilter: LABKEY.Query.containerFilter.allFolders,
-            success: function (data)
-            {
-                // put together the flag display for each runId
-                var runFlagList = {};
-                for (var i = 0; i < data.rows.length; i++)
-                {
-                    var row = data.rows[i];
-                    if (runFlagList[row.Run] == undefined)
-                    {
-                        runFlagList[row.Run] = {id: row.Run, count: 0, value: ""};
-                    }
-
-                    // add a comma separator
-                    if (runFlagList[row.Run].count > 0)
-                    {
-                        runFlagList[row.Run].value += ", ";
-                    }
-
-                    // add strike-thru for disabled flags
-                    if (row.Enabled)
-                    {
-                        runFlagList[row.Run].value += row.FlagType;
-                    }
-                    else
-                    {
-                        runFlagList[row.Run].value += '<span style="text-decoration: line-through;">' + row.FlagType + '</span>';
-                    }
-
-                    runFlagList[row.Run].count++;
-                }
-
-                // update the store records with the QC Flag values
-                store.each(function (record)
-                {
-                    var runFlag = runFlagList[record.get("RunRowId")];
-                    if (runFlag)
-                    {
-                        record.set("QCFlags", "<a>" + runFlag.value + "</a>");
-                    }
-                }, this);
-
-                // add cellclick event to the grid to trigger the QCFlagToggleWindow
-                this.on('cellclick', this.showQCFlagToggleWindow, this);
-
-                if (this.getEl().isMasked())
-                {
-                    this.getEl().unmask();
-                }
-            },
-            failure: function (info, response, options)
-            {
-                if (this.getEl().isMasked())
-                {
-                    this.getEl().unmask();
-                }
-
-                LABKEY.Utils.displayAjaxErrorResponse(response, options);
-            },
-            scope: this
-        })
-    },
-
-    showQCFlagToggleWindow: function (grid, rowIndex, colIndex, evnt)
-    {
-        var record = grid.getStore().getAt(rowIndex);
-        var fieldName = grid.getColumnModel().getDataIndex(colIndex);
-        var value = record.get(fieldName);
-        var prefix = this.controlType == 'Titration' ? 'Titration' : 'SinglePointControl';
-
-        if (fieldName == "QCFlags" && value != null)
-        {
-            var win = new LABKEY.QCFlagToggleWindow({
-                schemaName: "assay.Luminex." + LABKEY.QueryKey.encodePart(this.assayName),
-                queryName: "Analyte" + prefix + "QCFlags",
-                runId: record.get("RunRowId"),
-                analyte: this.analyte,
-                controlName: this.controlName,
-                controlType: this.controlType,
-                editable: true,
-                listeners: {
-                    scope: this,
-                    'saveSuccess': function ()
-                    {
-                        grid.getStore().reload();
-                        win.close();
-                    }
-                }
-            });
-            win.show();
-        }
-    },
-
-    dateRenderer: function (val)
-    {
-        return val ? new Date(val).format("Y-m-d") : null;
-    },
-
-    numberRenderer: function (val)
-    {
-        // if this is a very small number, display more decimal places
-        if (null == val)
-        {
-            return null;
-        }
-        else
-        {
-            if (val > 0 && val < 1)
-            {
-                return Ext.util.Format.number(Ext.util.Format.round(val, 6), '0.000000');
-            }
-            else
-            {
-                return Ext.util.Format.number(Ext.util.Format.round(val, 2), '0.00');
-            }
-        }
-    },
-
-    assayIdHrefRenderer: function (val, p, record)
-    {
-        var msg = Ext.util.Format.htmlEncode(val);
-        var url = LABKEY.ActionURL.buildURL('assay', 'assayDetailRedirect', LABKEY.container.path, {runId: record.get('RunRowId')});
-        return "<a href='" + url + "'>" + msg + "</a>";
-    },
-
-    encodingRenderer: function (value, p, record)
-    {
-        return $h(value);
-    },
-
-    flagsExcelRenderer: function (value)
-    {
-        if (value != null)
-        {
-            value = value.replace(/<a>/gi, "").replace(/<\/a>/gi, "");
-            value = value.replace(/<span style="text-decoration: line-through;">/gi, "-").replace(/<\/span>/gi, "-");
-        }
-        return value;
-    }
+    // exportData: function (type)
+    // {
+    //     // build up the JSON to pass to the export util
+    //     var exportJson = {
+    //         fileName: this.title + ".xls",
+    //         sheets: [
+    //             {
+    //                 name: 'data',
+    //                 // add a header section to the export with the graph parameter information
+    //                 data: [
+    //                     [this.controlType == 'Titration' ? 'Titration' : 'SinglePointControl', this.controlName],
+    //                     ['Analyte:', this.analyte],
+    //                     ['Isotype:', this.isotype],
+    //                     ['Conjugate:', this.conjugate],
+    //                     ['Export Date:', this.dateRenderer(new Date())],
+    //                     []
+    //                 ]
+    //             }
+    //         ]
+    //     };
+    //
+    //     // get all of the columns that are currently being shown in the grid (except for the checkbox column)
+    //     var columns = this.getColumnModel().getColumnsBy(function (c)
+    //     {
+    //         return !c.hidden && c.dataIndex != "";
+    //     });
+    //
+    //     // add the column header row to the export JSON object
+    //     var rowIndex = exportJson.sheets[0].data.length;
+    //     exportJson.sheets[0].data.push([]);
+    //     Ext.each(columns, function (col)
+    //     {
+    //         exportJson.sheets[0].data[rowIndex].push(col.header);
+    //     });
+    //
+    //     // loop through the grid store to put the data into the export JSON object
+    //     Ext.each(this.getStore().getRange(), function (row)
+    //     {
+    //         var rowIndex = exportJson.sheets[0].data.length;
+    //         exportJson.sheets[0].data[rowIndex] = [];
+    //
+    //         // loop through the column list to get the data for each column
+    //         var colIndex = 0;
+    //         Ext.each(columns, function (col)
+    //         {
+    //             // some of the columns may not be defined in the assay design, so set to null
+    //             var value = null;
+    //             if (null != row.get(col.dataIndex))
+    //             {
+    //                 value = row.get(col.dataIndex);
+    //             }
+    //
+    //             // render dates with the proper renderer
+    //             if (value instanceof Date)
+    //             {
+    //                 value = this.dateRenderer(value);
+    //             }
+    //             // render numbers with the proper rounding and format
+    //             if (typeof(value) == 'number')
+    //             {
+    //                 value = this.numberRenderer(value);
+    //             }
+    //             // render out of range values with an asterisk
+    //             var enabledStates = row.get(col.dataIndex + "QCFlagsEnabled");
+    //             if (enabledStates != null && (enabledStates.indexOf('t') > -1 || enabledStates.indexOf('1') > -1))
+    //             {
+    //                 value = "*" + value;
+    //             }
+    //
+    //             // render the flags in an excel friendly format
+    //             if (col.dataIndex == "QCFlags")
+    //             {
+    //                 value = this.flagsExcelRenderer(value);
+    //             }
+    //
+    //             // Issue 19019: specify that this value should be displayed as a string and not converted to a date
+    //             if (col.dataIndex == "RunName")
+    //             {
+    //                 value = {value: value, forceString: true};
+    //             }
+    //
+    //             exportJson.sheets[0].data[rowIndex][colIndex] = value;
+    //             colIndex++;
+    //         }, this);
+    //     }, this);
+    //
+    //     if (type == 'excel')
+    //     {
+    //         LABKEY.Utils.convertToExcel(exportJson);
+    //     }
+    //     else
+    //     {
+    //         LABKEY.Utils.convertToTable({
+    //             fileNamePrefix: this.title,
+    //             delim: 'TAB',
+    //             rows: exportJson.sheets[0].data
+    //         });
+    //     }
+    // },
+    //
+    // dateRenderer: function (val)
+    // {
+    //     return val ? new Date(val).format("Y-m-d") : null;
+    // },
+    //
+    // numberRenderer: function (val)
+    // {
+    //     // if this is a very small number, display more decimal places
+    //     if (null == val)
+    //     {
+    //         return null;
+    //     }
+    //     else
+    //     {
+    //         if (val > 0 && val < 1)
+    //         {
+    //             return Ext.util.Format.number(Ext.util.Format.round(val, 6), '0.000000');
+    //         }
+    //         else
+    //         {
+    //             return Ext.util.Format.number(Ext.util.Format.round(val, 2), '0.00');
+    //         }
+    //     }
+    // },
+    //
+    // flagsExcelRenderer: function (value)
+    // {
+    //     if (value != null)
+    //     {
+    //         value = value.replace(/<a>/gi, "").replace(/<\/a>/gi, "");
+    //         value = value.replace(/<span style="text-decoration: line-through;">/gi, "-").replace(/<\/span>/gi, "-");
+    //     }
+    //     return value;
+    // }
 });

--- a/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
@@ -105,8 +105,8 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.Component, {
     },
 
     configurePlotDataStore: function(baseFilters) {
-        // create a new store now that the graph params are selected
-        var storeConfig = {
+        this.storeLoading();
+        this.store = LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore({
             assayName: this.assayName,
             controlName: this.controlName,
             controlType: this.controlType,
@@ -117,19 +117,13 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.Component, {
             maxRows: !this.hasReportFilter() ? this.defaultRowSize : undefined,
             scope: this,
             loadListener: this.storeLoaded,
-        };
-
-        this.store = LABKEY.LeveyJenningsPlotHelper.getTrackingDataStore(storeConfig);
-
+        });
         this.store.on('exception', function(store, type, action, options, response){
             var errorJson = Ext.util.JSON.decode(response.responseText);
             if (errorJson.exception) {
                 Ext.get(document.querySelector('.ljTrendPlot').id).update("<span class='labkey-error'>" + errorJson.exception + "</span>");
             }
         });
-
-        this.storeLoading();
-        this.store.load();
     },
 
     storeLoading: function() {
@@ -186,8 +180,6 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.Component, {
                 }
             }
         });
-
-        this.configurePlotDataStore(filters);
 
         // enable the trending data grid
         this.enable();

--- a/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
@@ -212,6 +212,8 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.Component, {
                         conjugate: scope.conjugate,
                         networkExists: scope.networkExists,
                         protocolExists: scope.protocolExists,
+                        has4PLCurveFit: scope.has4PLCurveFit,
+                        has5PLCurveFit: scope.has5PLCurveFit,
                         listeners: {
                             'closeApplyGuideSetPanel': function (hasUpdated)
                             {

--- a/luminex/webapp/luminex/LeveyJenningsTrendPlotPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrendPlotPanel.js
@@ -175,8 +175,13 @@ LABKEY.LeveyJenningsTrendPlotPanel = Ext.extend(Ext.FormPanel, {
         this.setTrendPlotLoading();
     },
 
-    plotDataLoading: function()
+    plotDataLoading: function(store, hasGuideSetUpdates)
     {
+        if (hasGuideSetUpdates) {
+            this.guideSetRangeStoreLoadComplete = false;
+            this.guideSetRangeStore.load();
+        }
+
         this.setTrendPlotLoading();
     },
 


### PR DESCRIPTION
#### Rationale
The data grid on the Luminex Levey-Jennings report uses an Ext grid panel which limits some of the abilities that we normally see in LabKey grids, most notably the ability to page through results, customize the grid columns, and filter on arbitrary columns in the grid. This PR converts that grid to a LabKey DataRegion. This allows for the features mentioned and retains the ability to apply guide sets to data grid rows and view 4PL curve fits (for titration based reports).

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/588

#### Changes
* convert tracking data grid from Ext4 grid panel to LK QueryWebPart
* plot data query split to get metric data and guide set data separately
* add back "Apply Guide Set" button to the dataRegion buttonBar header
* add back "View 4PL Curves" button to the dataRegion buttonBar header
* data grid styling fix to remove extContainer styles from wrapping component
