### PR TITLE
Centralize test handling of toggling experiment run graph

### DIFF
--- a/ms2/test/src/org/labkey/test/ms2/AbstractMS2SearchEngineTest.java
+++ b/ms2/test/src/org/labkey/test/ms2/AbstractMS2SearchEngineTest.java
@@ -133,9 +133,7 @@ public abstract class AbstractMS2SearchEngineTest extends MS2TestBase
 
         log("Verify graph view");
         pushLocation();
-        Locator.linkWithSpan("Toggle Beta Graph (new!)").waitForElement(getDriver(), 4000)
-                .click();
-        LineageGraph graphComponent = new LineageGraph.LineageGraphFinder(getDriver()).waitFor();
+        LineageGraph graphComponent = LineageGraph.showLineageGraph(getDriver());
 
         // navigate to the details page for CAexample_mini.mzXML.image..itms.png
         graphComponent.getDetailGroup("Data Children")

--- a/ms2/test/src/org/labkey/test/ms2/QuantitationTest.java
+++ b/ms2/test/src/org/labkey/test/ms2/QuantitationTest.java
@@ -84,9 +84,7 @@ public class QuantitationTest extends AbstractXTandemTest
         // Jump to the flow chart view
         clickAndWait(Locator.tagWithAttribute("a", "title", "Experiment run graph"));
 
-        Locator.linkWithSpan("Toggle Beta Graph (new!)").waitForElement(getDriver(), 4000)
-                .click();
-        LineageGraph graph = new LineageGraph.LineageGraphFinder(getDriver()).waitFor();
+        LineageGraph graph = LineageGraph.showLineageGraph(getDriver());
 
         graph.getDetailGroup("Data Children").getItem(SAMPLE_BASE_NAME + ".libra.tsv").clickOverViewLink(true);
         assertElementPresent(Locator.linkWithText("libra Protein Quantitation"));


### PR DESCRIPTION
#### Rationale
Moving the handling of the "Toggle Beta Graph (new!)" button into the LineageGraph should make it easier to maintain.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1466

#### Changes
* Centralize test handling of toggling experiment run graph
