### PR TITLE
Use non-deprecated JSON-related method and interface names

### DIFF
--- a/luminex/src/org/labkey/luminex/LuminexSaveExclusionsForm.java
+++ b/luminex/src/org/labkey/luminex/LuminexSaveExclusionsForm.java
@@ -20,7 +20,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.action.NewCustomApiForm;
+import org.labkey.api.action.ApiJsonForm;
 import org.labkey.api.action.NullSafeBindException;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.data.Container;
@@ -33,7 +33,7 @@ import org.springframework.validation.ObjectError;
 import java.util.ArrayList;
 import java.util.List;
 
-public class LuminexSaveExclusionsForm implements NewCustomApiForm
+public class LuminexSaveExclusionsForm implements ApiJsonForm
 {
     private Integer _assayId;
     private String _tableName;

--- a/ms2/gwtsrc/org/labkey/ms2/pipeline/client/InputXmlComposite.java
+++ b/ms2/gwtsrc/org/labkey/ms2/pipeline/client/InputXmlComposite.java
@@ -31,7 +31,7 @@ import org.labkey.api.gwt.client.util.StringUtils;
  */
 public abstract class InputXmlComposite extends SearchFormComposite
 {
-    protected TextAreaWrapable inputXmlTextArea = new TextAreaWrapable();
+    protected TextAreaWrappable inputXmlTextArea = new TextAreaWrappable();
     protected Hidden inputXmlHidden = new Hidden();
     protected HTML inputXmlHtml = new HTML();
     protected HorizontalPanel instance = new HorizontalPanel();
@@ -82,7 +82,6 @@ public abstract class InputXmlComposite extends SearchFormComposite
             instance.remove(inputXmlHtml);
             instance.add(inputXmlTextArea);
         }
-
     }
 
     @Override
@@ -133,13 +132,12 @@ public abstract class InputXmlComposite extends SearchFormComposite
         throw new UnsupportedOperationException();
     }
 
-    private class TextAreaWrapable extends TextArea
+    private static class TextAreaWrappable extends TextArea
     {
         public void setWrap(String wrapOption)
         {
-                Element textArea = getElement();
-                DOM.setElementAttribute(textArea,"wrap",wrapOption);
-
+            Element textArea = getElement();
+            DOM.setElementAttribute(textArea,"wrap", wrapOption);
         }
     }
 }

--- a/ms2/src/org/labkey/ms2/pipeline/PipelineController.java
+++ b/ms2/src/org/labkey/ms2/pipeline/PipelineController.java
@@ -356,7 +356,7 @@ public class PipelineController extends SpringActionController
                         getContainer(), getUser());
                 if (protocolNameLast != null && !"".equals(protocolNameLast))
                 {
-                    String[] protocolNames = protocolFactory.getProtocolNames(_root, _dirData, false);
+                    String[] protocolNames = protocolFactory.getProtocolNames(_root, _dirData.toPath(), false);
                     // Make sure it is still around.
                     if (Arrays.asList(protocolNames).contains(protocolNameLast))
                         form.setProtocol(protocolNameLast);

--- a/ms2/src/org/labkey/ms2/pipeline/SearchServiceImpl.java
+++ b/ms2/src/org/labkey/ms2/pipeline/SearchServiceImpl.java
@@ -17,8 +17,8 @@
 package org.labkey.ms2.pipeline;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.Container;
 import org.labkey.api.gwt.server.BaseRemoteService;
 import org.labkey.api.pipeline.PipeRoot;
@@ -275,7 +275,7 @@ public class SearchServiceImpl extends BaseRemoteService implements SearchServic
 
         PipeRoot root = getPipelineRoot();
 
-        String[] protocols = provider.getProtocolFactory().getProtocolNames(root, root.resolvePath(path), false);
+        String[] protocols = provider.getProtocolFactory().getProtocolNames(root, root.resolvePath(path).toPath(), false);
         for(String protName:protocols)
         {
             if(!protName.equals("default"))

--- a/nab/src/org/labkey/nab/NabAssayController.java
+++ b/nab/src/org/labkey/nab/NabAssayController.java
@@ -26,6 +26,7 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.labkey.api.action.ApiJsonForm;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
 import org.labkey.api.action.ExportAction;
@@ -33,7 +34,6 @@ import org.labkey.api.action.FormHandlerAction;
 import org.labkey.api.action.Marshal;
 import org.labkey.api.action.Marshaller;
 import org.labkey.api.action.MutatingApiAction;
-import org.labkey.api.action.NewCustomApiForm;
 import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.action.SimpleErrorView;
 import org.labkey.api.action.SimpleViewAction;
@@ -1221,7 +1221,7 @@ public class NabAssayController extends SpringActionController
         return String.format("%s-%s-%s", plate, row, col);
     }
 
-    public static class QCControlInfo implements NewCustomApiForm
+    public static class QCControlInfo implements ApiJsonForm
     {
         private final List<WellExclusion> _exclusions = new ArrayList<>();
         private int _runId;


### PR DESCRIPTION
#### Rationale
`getNewJsonObject()` and `NewCustomApiForm` have replacements with better names

Also, remove some uses of File-taking methods in favor of Path-taking variants