### PR TITLE
Issue 47734: SQLException from bad JDBC parameter order viewing MS2 runs

### DIFF
--- a/ms2/src/org/labkey/ms2/query/FastaRunMappingTable.java
+++ b/ms2/src/org/labkey/ms2/query/FastaRunMappingTable.java
@@ -53,9 +53,9 @@ public class FastaRunMappingTable extends FilteredTable<MS2Schema>
         SQLFragment sql = new SQLFragment("Run IN (SELECT r.Run FROM ");
         sql.append(MS2Manager.getTableInfoRuns(), "r");
         sql.append(" WHERE r.Deleted = ? AND ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("r.Container"), _userSchema.getContainer()));
-        sql.append(")");
         sql.add(false);
+        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("r.Container")));
+        sql.append(")");
         addCondition(sql, CONTAINER_FIELD_KEY);
     }
 }


### PR DESCRIPTION
#### Rationale
We're not reliably ordering the JDBC parameter values when assembling the SQLFragment for FASTA files

#### Changes
* Add the boolean value before we append the container SQLFragment