### PR TITLE
Avoid unnecessary Gradle task configuration

### DIFF
--- a/flow/build.gradle
+++ b/flow/build.gradle
@@ -39,6 +39,6 @@ project.tasks.register("engineJar", Jar) {
         jar.dependsOn(project.tasks.schemasCompile)
 }
 
-project.tasks.engineJar.dependsOn(project.engineClasses)
-project.tasks.assemble.dependsOn(project.tasks.engineJar)
-project.tasks.module.dependsOn(project.tasks.engineJar)
+project.tasks.named('engineJar').configure { dependsOn(project.engineClasses) }
+project.tasks.named('assemble').configure { dependsOn(project.tasks.engineJar) }
+project.tasks.named('module').configure { dependsOn(project.tasks.engineJar) }


### PR DESCRIPTION
#### Rationale
Using [task configuration avoidance APIs](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) can make builds more efficient.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/171

#### Changes
* Update gradle task references to avoid unnecessary configuration