### PR TITLE
Luminex test failures on MSSQL related to wait time for apply guide set modal grid

### DIFF
--- a/luminex/test/src/org/labkey/test/util/luminex/LuminexGuideSetHelper.java
+++ b/luminex/test/src/org/labkey/test/util/luminex/LuminexGuideSetHelper.java
@@ -223,7 +223,7 @@ public class LuminexGuideSetHelper
         WebElement selectedRunsGrid = Locator.byClass("selectedRunsGrid").waitForElement(applyGuideSetWindow, WAIT_FOR_JAVASCRIPT);
         for (String network : networks)
         {
-            Locator.byClass("x-grid3-cell").withText(network).waitForElement(selectedRunsGrid, WAIT_FOR_JAVASCRIPT);
+            Locator.byClass("x-grid3-cell").withText(network).waitForElement(selectedRunsGrid, WAIT_FOR_JAVASCRIPT * 3);
         }
 
         WebElement guideSetsGrid = Locator.byClass("guideSetsGrid").waitForElement(applyGuideSetWindow, WAIT_FOR_JAVASCRIPT);


### PR DESCRIPTION
#### Rationale
A couple Luminex tests have been failing on MSSQL because of the loading of the apply guide set modal grid. When viewed locally, this grid loads very quickly. This PR increases the wait time for that grid to load.

#### Changes
* increase the wait time for apply guide set dialog grid to load
