### PR TITLE
Fix intermittent LuminexExclusionRetentionTest failure

### DIFF
--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -525,7 +525,7 @@ public abstract class LuminexTest extends BaseWebDriverTest
     protected void replaceFileInAssayRun(File original, File newFile)
     {
         //Add spot for new file
-        click(Locator.xpath("//a[contains(@class, 'labkey-file-add-icon-enabled')]"));
+        waitAndClick(Locator.xpath("//a[contains(@class, 'labkey-file-add-icon-enabled')]"));
         //remove old file
         click(Locator.xpath("//tr[td/span/text() = '" + original.getName() + "']" +
                 "/td/a[contains(@class, 'labkey-file-remove-icon-enabled')]"));


### PR DESCRIPTION
#### Rationale
We're seeing intermittent failures in this test, likely because it's not being patient enough for the page to render

https://teamcity.labkey.org/test/-389611128835446163?currentProjectId=LabkeyTrunk_DailySuites&expandTestHistoryChartSection=true

#### Changes
* Wait before clicking