### PR TITLE
Optimize flow queries for index utilization

### DIFF
--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -1585,7 +1585,7 @@ public class FlowManager
     {
         String sqlFCSRunCount = """
                 SELECT COUNT (r.RowId) FROM exp.experimentrun r
-                WHERE exp.ExperimentRun.RowId IN (SELECT d.runid FROM exp.data d INNER JOIN flow.object o ON
+                WHERE r.RowId IN (SELECT d.runid FROM exp.data d INNER JOIN flow.object o ON
                 o.dataid = d.rowid
                 AND d.container = ?
                 AND d.container = o.container

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -1573,23 +1573,24 @@ public class FlowManager
     public int getRunCount(Container container, ObjectType type)
     {
         String sqlFCSRunCount = """
-                SELECT COUNT (exp.ExperimentRun.RowId) FROM exp.experimentrun
-                WHERE exp.ExperimentRun.RowId IN (SELECT exp.data.runid FROM exp.data INNER JOIN flow.object ON flow.object.dataid = exp.data.rowid
-                AND exp.data.container = ?
-                AND flow.object.container = ?
-                AND flow.object.typeid = ?)""";
-        return new SqlSelector(getSchema(), sqlFCSRunCount, container.getId(), container.getId(), type.getTypeId()).getObject(Integer.class);
+                SELECT COUNT (DISTINCT d.runid) FROM exp.data d INNER JOIN flow.object o ON
+                o.dataid = d.rowid
+                AND d.container = ?
+                AND d.container = o.container
+                AND o.typeid = ?""";
+        return new SqlSelector(getSchema(), sqlFCSRunCount, container.getId(), type.getTypeId()).getObject(Integer.class);
     }
 
     public int getFCSRunCount(Container container)
     {
         String sqlFCSRunCount = """
-                SELECT COUNT (exp.ExperimentRun.RowId) FROM exp.experimentrun
-                WHERE exp.ExperimentRun.RowId IN (SELECT exp.data.runid FROM exp.data INNER JOIN flow.object ON flow.object.dataid = exp.data.rowid
-                AND exp.data.container = ?
-                AND flow.object.container = ?
-                AND flow.object.typeid = ?) AND exp.ExperimentRun.FilePathRoot IS NOT NULL""";
-        return new SqlSelector(getSchema(), sqlFCSRunCount, container.getId(), container.getId(), ObjectType.fcsKeywords.getTypeId()).getObject(Integer.class);
+                SELECT COUNT (r.RowId) FROM exp.experimentrun r
+                WHERE exp.ExperimentRun.RowId IN (SELECT d.runid FROM exp.data d INNER JOIN flow.object o ON
+                o.dataid = d.rowid
+                AND d.container = ?
+                AND d.container = o.container
+                AND o.typeid = ?) AND r.FilePathRoot IS NOT NULL""";
+        return new SqlSelector(getSchema(), sqlFCSRunCount, container.getId(), ObjectType.fcsKeywords.getTypeId()).getObject(Integer.class);
     }
 
     public void deleteContainer(Container container)


### PR DESCRIPTION
#### Rationale
FlowManager.getRunCount() is taking ~10 seconds to run on labkey.org

#### Changes
* Avoid extra join to run table that doesn't add anything
* Change container filtering in the hope of better utilization of existing indices