### PR TITLE
Combine Plate/PlateTemplate and WellGroup/WellGroupTemplate interfaces

### DIFF
--- a/elisa/src/org/labkey/elisa/AbstractElisaImportHelper.java
+++ b/elisa/src/org/labkey/elisa/AbstractElisaImportHelper.java
@@ -44,7 +44,7 @@ public abstract class AbstractElisaImportHelper implements ElisaImportHelper
         if (_specimenGroupMap == null)
         {
             _specimenGroupMap = new HashMap<>();
-            Plate template = _provider.getPlateTemplate(_protocol.getContainer(), _protocol);
+            Plate template = _provider.getPlate(_protocol.getContainer(), _protocol);
             for (WellGroup sample : template.getWellGroups(WellGroup.Type.SPECIMEN))
             {
                 for (Position pos : sample.getPositions())

--- a/elisa/src/org/labkey/elisa/AbstractElisaImportHelper.java
+++ b/elisa/src/org/labkey/elisa/AbstractElisaImportHelper.java
@@ -2,12 +2,11 @@ package org.labkey.elisa;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayUploadXarContext;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateBasedAssayProvider;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.Well;
 import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.statistics.CurveFit;
 import org.labkey.api.exp.api.ExpMaterial;
@@ -45,8 +44,8 @@ public abstract class AbstractElisaImportHelper implements ElisaImportHelper
         if (_specimenGroupMap == null)
         {
             _specimenGroupMap = new HashMap<>();
-            PlateTemplate template = _provider.getPlateTemplate(_protocol.getContainer(), _protocol);
-            for (WellGroupTemplate sample : template.getWellGroups(WellGroup.Type.SPECIMEN))
+            Plate template = _provider.getPlateTemplate(_protocol.getContainer(), _protocol);
+            for (WellGroup sample : template.getWellGroups(WellGroup.Type.SPECIMEN))
             {
                 for (Position pos : sample.getPositions())
                     _specimenGroupMap.put(pos, sample.getName());

--- a/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
+++ b/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
@@ -28,10 +28,10 @@ import org.labkey.api.assay.AssayTableMetadata;
 import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.assay.actions.AssayRunUploadForm;
 import org.labkey.api.assay.plate.AbstractPlateBasedAssayProvider;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateBasedDataExchangeHandler;
 import org.labkey.api.assay.plate.PlateReader;
 import org.labkey.api.assay.plate.PlateSamplePropertyHelper;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlExecutor;
@@ -331,7 +331,7 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
     }
 
     @Override
-    protected PlateSamplePropertyHelper createSampleFilePropertyHelper(Container c, ExpProtocol protocol, List<? extends DomainProperty> sampleProperties, PlateTemplate template, SampleMetadataInputFormat inputFormat)
+    protected PlateSamplePropertyHelper createSampleFilePropertyHelper(Container c, ExpProtocol protocol, List<? extends DomainProperty> sampleProperties, Plate template, SampleMetadataInputFormat inputFormat)
     {
         // some of the sample properties are calculated versus collected
         List<DomainProperty> properties = sampleProperties.stream()

--- a/elisa/src/org/labkey/elisa/ElisaPlateTypeHandler.java
+++ b/elisa/src/org/labkey/elisa/ElisaPlateTypeHandler.java
@@ -17,16 +17,15 @@
 package org.labkey.elisa;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.Container;
 import org.labkey.api.assay.plate.AbstractPlateTypeHandler;
 import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.PlateTemplate;
-import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.util.Pair;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.labkey.elisa.ElisaModule.EXPERIMENTAL_MULTI_PLATE_SUPPORT;
@@ -58,9 +57,9 @@ public class ElisaPlateTypeHandler extends AbstractPlateTypeHandler
     }
 
     @Override
-    public PlateTemplate createTemplate(@Nullable String templateTypeName, Container container, int rowCount, int colCount)
+    public Plate createTemplate(@Nullable String templateTypeName, Container container, int rowCount, int colCount)
     {
-        PlateTemplate template = PlateService.get().createPlateTemplate(container, getAssayType(), rowCount, colCount);
+        Plate template = PlateService.get().createPlateTemplate(container, getAssayType(), rowCount, colCount);
 
         template.addWellGroup(STANDARDS_CONTROL_SAMPLE, WellGroup.Type.CONTROL,
                 PlateService.get().createPosition(container, 0, 0),
@@ -125,9 +124,9 @@ public class ElisaPlateTypeHandler extends AbstractPlateTypeHandler
         return template;
     }
 
-    private PlateTemplate createHighThroughputPlate(Container container, int rowCount, int colCount)
+    private Plate createHighThroughputPlate(Container container, int rowCount, int colCount)
     {
-        PlateTemplate template = PlateService.get().createPlateTemplate(container, getAssayType(), rowCount, colCount);
+        Plate template = PlateService.get().createPlateTemplate(container, getAssayType(), rowCount, colCount);
 
         // control well groups
         template.addWellGroup(STANDARDS_CONTROL_SAMPLE, WellGroup.Type.CONTROL,

--- a/elisa/src/org/labkey/elisa/ElisaSampleFilePropertyHelper.java
+++ b/elisa/src/org/labkey/elisa/ElisaSampleFilePropertyHelper.java
@@ -2,10 +2,9 @@ package org.labkey.elisa;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.plate.PlateSampleFilePropertyHelper;
-import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PositionImpl;
 import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -31,7 +30,7 @@ public class ElisaSampleFilePropertyHelper extends PlateSampleFilePropertyHelper
     public static final String WELL_LOCATION_COLUMN_NAME = "Well";
     public static final String SPOT_COLUMN_NAME = "Spot";
 
-    public ElisaSampleFilePropertyHelper(Container container, ExpProtocol protocol, List<? extends DomainProperty> domainProperties, PlateTemplate template, SampleMetadataInputFormat inputFormat)
+    public ElisaSampleFilePropertyHelper(Container container, ExpProtocol protocol, List<? extends DomainProperty> domainProperties, Plate template, SampleMetadataInputFormat inputFormat)
     {
         super(container, protocol, domainProperties, template, inputFormat);
     }
@@ -103,7 +102,7 @@ public class ElisaSampleFilePropertyHelper extends PlateSampleFilePropertyHelper
             // need to adjust the column value to be 0 based to match the template locations
             position.setColumn(position.getColumn()-1);
 
-            for (WellGroupTemplate wellGroup : _template.getWellGroups(position))
+            for (WellGroup wellGroup : _template.getWellGroups(position))
             {
                 if (wellGroup.getType() == WellGroup.Type.SPECIMEN)
                     return HighThroughputImportHelper.getSpecimenGroupKey(plateName, analyteNum, wellGroup.getName());

--- a/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
+++ b/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
@@ -6,12 +6,10 @@ import org.labkey.api.assay.AssayUploadXarContext;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateBasedAssayProvider;
 import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.PositionImpl;
 import org.labkey.api.assay.plate.Well;
 import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.data.statistics.CurveFit;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpMaterial;
@@ -36,7 +34,7 @@ public class HighThroughputImportHelper extends AbstractElisaImportHelper
     private static final Logger LOG = LogManager.getLogger(HighThroughputImportHelper.class);
 
     private Map<String, AnalytePlate> _plateMap = new HashMap<>();
-    private PlateTemplate _plateTemplate;
+    private Plate _plateTemplate;
 
     public HighThroughputImportHelper(AssayUploadXarContext context, PlateBasedAssayProvider provider, ExpProtocol protocol, File dataFile) throws ExperimentException
     {
@@ -176,12 +174,12 @@ public class HighThroughputImportHelper extends AbstractElisaImportHelper
         private Map<Integer, Map<String, Double>> _stdConcentrations = new HashMap<>();
         private Map<Integer, double[][]> _dataMap = new HashMap<>();
         private String _plateName;
-        private PlateTemplate _plateTemplate;
+        private Plate _plateTemplate;
         // contains the mapping of (well/analyte) to extra row data to merge during data import
         private Map<String, Map<String, Object>> _extraWellData = new HashMap<>();
         public static final String CONTROL_ID_COLUMN = "Sample";
 
-        public AnalytePlate(String plateName, PlateTemplate plateTemplate)
+        public AnalytePlate(String plateName, Plate plateTemplate)
         {
             _plateName = plateName;
             _plateTemplate = plateTemplate;
@@ -207,7 +205,7 @@ public class HighThroughputImportHelper extends AbstractElisaImportHelper
 
         public void setStdConcentration(Position position, Integer spot, Double concentration)
         {
-            for (WellGroupTemplate wellGroup : _plateTemplate.getWellGroups(position))
+            for (WellGroup wellGroup : _plateTemplate.getWellGroups(position))
             {
                 if (wellGroup.getType() == WellGroup.Type.REPLICATE)
                 {
@@ -241,7 +239,7 @@ public class HighThroughputImportHelper extends AbstractElisaImportHelper
             // need to adjust the column value to be 0 based to match the template locations
             position.setColumn(position.getColumn()-1);
 
-            for (WellGroupTemplate wellGroup : _plateTemplate.getWellGroups(position))
+            for (WellGroup wellGroup : _plateTemplate.getWellGroups(position))
             {
                 if (wellGroup.getType() == WellGroup.Type.CONTROL)
                 {

--- a/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
+++ b/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
@@ -44,7 +44,7 @@ public class HighThroughputImportHelper extends AbstractElisaImportHelper
 
     private void ensureData() throws ExperimentException
     {
-        _plateTemplate = _provider.getPlateTemplate(_protocol.getContainer(), _protocol);
+        _plateTemplate = _provider.getPlate(_protocol.getContainer(), _protocol);
         DataLoaderFactory factory = DataLoaderService.get().findFactory(_dataFile, null);
         try (DataLoader loader = factory.createLoader(_dataFile, true))
         {

--- a/elisa/src/org/labkey/elisa/ManualImportHelper.java
+++ b/elisa/src/org/labkey/elisa/ManualImportHelper.java
@@ -49,7 +49,7 @@ public class ManualImportHelper extends AbstractElisaImportHelper
         PlateReader reader = _provider.getPlateReader(BioTekPlateReader.LABEL);
         if (reader != null)
         {
-            Plate template = _provider.getPlateTemplate(_protocol.getContainer(), _protocol);
+            Plate template = _provider.getPlate(_protocol.getContainer(), _protocol);
             double[][] cellValues = reader.loadFile(template, _dataFile);
             if (cellValues == null)
             {

--- a/elisa/src/org/labkey/elisa/ManualImportHelper.java
+++ b/elisa/src/org/labkey/elisa/ManualImportHelper.java
@@ -7,7 +7,6 @@ import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateBasedAssayProvider;
 import org.labkey.api.assay.plate.PlateReader;
 import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.Well;
 import org.labkey.api.assay.plate.WellGroup;
@@ -50,7 +49,7 @@ public class ManualImportHelper extends AbstractElisaImportHelper
         PlateReader reader = _provider.getPlateReader(BioTekPlateReader.LABEL);
         if (reader != null)
         {
-            PlateTemplate template = _provider.getPlateTemplate(_protocol.getContainer(), _protocol);
+            Plate template = _provider.getPlateTemplate(_protocol.getContainer(), _protocol);
             double[][] cellValues = reader.loadFile(template, _dataFile);
             if (cellValues == null)
             {

--- a/elisa/src/org/labkey/elisa/actions/ElisaUploadWizardAction.java
+++ b/elisa/src/org/labkey/elisa/actions/ElisaUploadWizardAction.java
@@ -184,7 +184,7 @@ public class ElisaUploadWizardAction extends PlateBasedUploadWizardAction<ElisaR
 
     protected PlateConcentrationPropertyHelper createConcentrationPropertyHelper(Container container, ExpProtocol protocol, ElisaAssayProvider provider)
     {
-        Plate template = provider.getPlateTemplate(container, protocol);
+        Plate template = provider.getPlate(container, protocol);
         return new PlateConcentrationPropertyHelper(provider.getConcentrationWellGroupDomain(protocol).getProperties(), template);
     }
 

--- a/elisa/src/org/labkey/elisa/actions/ElisaUploadWizardAction.java
+++ b/elisa/src/org/labkey/elisa/actions/ElisaUploadWizardAction.java
@@ -22,7 +22,7 @@ import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.assay.PreviouslyUploadedDataCollector;
 import org.labkey.api.assay.actions.PlateBasedUploadWizardAction;
 import org.labkey.api.assay.plate.PlateSamplePropertyHelper;
-import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
 import org.labkey.api.data.Container;
@@ -184,7 +184,7 @@ public class ElisaUploadWizardAction extends PlateBasedUploadWizardAction<ElisaR
 
     protected PlateConcentrationPropertyHelper createConcentrationPropertyHelper(Container container, ExpProtocol protocol, ElisaAssayProvider provider)
     {
-        PlateTemplate template = provider.getPlateTemplate(container, protocol);
+        Plate template = provider.getPlateTemplate(container, protocol);
         return new PlateConcentrationPropertyHelper(provider.getConcentrationWellGroupDomain(protocol).getProperties(), template);
     }
 

--- a/elisa/src/org/labkey/elisa/actions/PlateConcentrationPropertyHelper.java
+++ b/elisa/src/org/labkey/elisa/actions/PlateConcentrationPropertyHelper.java
@@ -16,10 +16,9 @@
 package org.labkey.elisa.actions;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.exp.SamplePropertyHelper;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.property.DomainProperty;
@@ -37,12 +36,12 @@ import java.util.TreeSet;
  * User: klum
  * Date: 10/14/12
  */
-public class PlateConcentrationPropertyHelper extends SamplePropertyHelper<WellGroupTemplate>
+public class PlateConcentrationPropertyHelper extends SamplePropertyHelper<WellGroup>
 {
     private Set<String> _controlNames;
-    private final PlateTemplate _template;
+    private final Plate _template;
 
-    public PlateConcentrationPropertyHelper(List<? extends DomainProperty> domainProperties, PlateTemplate template)
+    public PlateConcentrationPropertyHelper(List<? extends DomainProperty> domainProperties, Plate template)
     {
         super(domainProperties);
         _template = template;
@@ -51,7 +50,7 @@ public class PlateConcentrationPropertyHelper extends SamplePropertyHelper<WellG
         if (template != null)
         {
             Map<String, Position> controls = new HashMap<>();
-            for (WellGroupTemplate group : template.getWellGroups())
+            for (WellGroup group : template.getWellGroups())
             {
                 if (group.getType() == WellGroup.Type.CONTROL)
                 {
@@ -60,7 +59,7 @@ public class PlateConcentrationPropertyHelper extends SamplePropertyHelper<WellG
                 }
             }
 
-            for (WellGroupTemplate group : template.getWellGroups())
+            for (WellGroup group : template.getWellGroups())
             {
                 if (group.getType() == WellGroup.Type.REPLICATE)
                 {
@@ -75,10 +74,10 @@ public class PlateConcentrationPropertyHelper extends SamplePropertyHelper<WellG
     }
 
     @Override
-    protected WellGroupTemplate getObject(int index, @NotNull Map<DomainProperty, String> sampleProperties, @NotNull Set<ExpMaterial> parentMaterials)
+    protected WellGroup getObject(int index, @NotNull Map<DomainProperty, String> sampleProperties, @NotNull Set<ExpMaterial> parentMaterials)
     {
         int i = 0;
-        for (WellGroupTemplate wellgroup : _template.getWellGroups())
+        for (WellGroup wellgroup : _template.getWellGroups())
         {
             if (wellgroup.getType() == WellGroup.Type.CONTROL)
             {

--- a/elispotassay/src/org/labkey/elispot/ElispotController.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotController.java
@@ -311,7 +311,7 @@ public class ElispotController extends SpringActionController
             ExpProtocol protocol = run.getProtocol();
 
             ElispotAssayProvider provider = (ElispotAssayProvider) AssayService.get().getProvider(protocol);
-            Plate template = provider.getPlateTemplate(getContainer(), protocol);
+            Plate template = provider.getPlate(getContainer(), protocol);
 
             String plateReaderName = null;
             for (ObjectProperty prop : run.getObjectProperties().values())

--- a/elispotassay/src/org/labkey/elispot/ElispotController.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotController.java
@@ -47,7 +47,7 @@ import org.labkey.api.query.QuerySettings;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.actions.AssayHeaderView;
 import org.labkey.api.assay.AssayProtocolSchema;
@@ -208,7 +208,7 @@ public class ElispotController extends SpringActionController
     }
 
     private List<WellInfo> createWellInfoList(ExpRun run, ExpProtocol protocol, AbstractPlateBasedAssayProvider provider,
-                                              PlateTemplate template, PlateReader reader)
+                                              Plate template, PlateReader reader)
     {
         List<WellInfo> wellInfos = new ArrayList<>();
 
@@ -311,7 +311,7 @@ public class ElispotController extends SpringActionController
             ExpProtocol protocol = run.getProtocol();
 
             ElispotAssayProvider provider = (ElispotAssayProvider) AssayService.get().getProvider(protocol);
-            PlateTemplate template = provider.getPlateTemplate(getContainer(), protocol);
+            Plate template = provider.getPlateTemplate(getContainer(), protocol);
 
             String plateReaderName = null;
             for (ObjectProperty prop : run.getObjectProperties().values())

--- a/elispotassay/src/org/labkey/elispot/ElispotDataExchangeHandler.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotDataExchangeHandler.java
@@ -49,7 +49,7 @@ public class ElispotDataExchangeHandler extends PlateBasedDataExchangeHandler
         ElispotRunUploadForm form = (ElispotRunUploadForm)context;
 
         ElispotAssayProvider provider = form.getProvider();
-        Plate template = provider.getPlateTemplate(form.getContainer(), form.getProtocol());
+        Plate template = provider.getPlate(form.getContainer(), form.getProtocol());
 
         // add in the specimen information, the data will be serialized to a tsv and the file
         // location will be added to the run properties file.
@@ -67,7 +67,7 @@ public class ElispotDataExchangeHandler extends PlateBasedDataExchangeHandler
         if (provider instanceof ElispotAssayProvider)
         {
             ElispotAssayProvider plateProvider = (ElispotAssayProvider)provider;
-            Plate template = plateProvider.getPlateTemplate(viewContext.getContainer(), protocol);
+            Plate template = plateProvider.getPlate(viewContext.getContainer(), protocol);
             if (template != null)
             {
                 List<? extends DomainProperty> props = plateProvider.getSampleWellGroupDomain(protocol).getProperties();

--- a/elispotassay/src/org/labkey/elispot/ElispotDataExchangeHandler.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotDataExchangeHandler.java
@@ -17,12 +17,12 @@
 package org.labkey.elispot;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.assay.plate.PlateBasedDataExchangeHandler;
-import org.labkey.api.assay.plate.PlateTemplate;
-import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayRunUploadContext;
 import org.labkey.api.assay.AssayService;
@@ -49,7 +49,7 @@ public class ElispotDataExchangeHandler extends PlateBasedDataExchangeHandler
         ElispotRunUploadForm form = (ElispotRunUploadForm)context;
 
         ElispotAssayProvider provider = form.getProvider();
-        PlateTemplate template = provider.getPlateTemplate(form.getContainer(), form.getProtocol());
+        Plate template = provider.getPlateTemplate(form.getContainer(), form.getProtocol());
 
         // add in the specimen information, the data will be serialized to a tsv and the file
         // location will be added to the run properties file.
@@ -67,7 +67,7 @@ public class ElispotDataExchangeHandler extends PlateBasedDataExchangeHandler
         if (provider instanceof ElispotAssayProvider)
         {
             ElispotAssayProvider plateProvider = (ElispotAssayProvider)provider;
-            PlateTemplate template = plateProvider.getPlateTemplate(viewContext.getContainer(), protocol);
+            Plate template = plateProvider.getPlateTemplate(viewContext.getContainer(), protocol);
             if (template != null)
             {
                 List<? extends DomainProperty> props = plateProvider.getSampleWellGroupDomain(protocol).getProperties();

--- a/elispotassay/src/org/labkey/elispot/ElispotDataHandler.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotDataHandler.java
@@ -19,7 +19,7 @@ package org.labkey.elispot;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.statistics.MathStat;
@@ -39,10 +39,8 @@ import org.labkey.api.qc.DataLoaderSettings;
 import org.labkey.api.qc.TransformDataHandler;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.Well;
-import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.assay.actions.UploadWizardAction;
 import org.labkey.api.assay.AbstractAssayProvider;
 import org.labkey.api.assay.AssayDataType;
@@ -108,7 +106,7 @@ public class ElispotDataHandler extends AbstractElispotDataHandler implements Tr
             ExpProtocol protocol = ExperimentService.get().getExpProtocol(run.getProtocol().getLSID());
             Container container = _data.getContainer();
             ElispotAssayProvider provider = (ElispotAssayProvider)AssayService.get().getProvider(protocol);
-            PlateTemplate template = provider.getPlateTemplate(container, protocol);
+            Plate template = provider.getPlateTemplate(container, protocol);
 
             Map<String, DomainProperty> runProperties = new HashMap<>();
             for (DomainProperty column : provider.getRunDomain(protocol).getProperties())
@@ -229,7 +227,7 @@ public class ElispotDataHandler extends AbstractElispotDataHandler implements Tr
         return datas;
     }
 
-    public static Map<PlateInfo, Plate> initializePlates(ExpProtocol protocol, File dataFile, PlateTemplate template, PlateReader reader) throws ExperimentException
+    public static Map<PlateInfo, Plate> initializePlates(ExpProtocol protocol, File dataFile, Plate template, PlateReader reader) throws ExperimentException
     {
         AssayProvider provider = AssayService.get().getProvider(protocol);
         Map<PlateInfo, Plate> plateMap = new HashMap<>();

--- a/elispotassay/src/org/labkey/elispot/ElispotDataHandler.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotDataHandler.java
@@ -106,7 +106,7 @@ public class ElispotDataHandler extends AbstractElispotDataHandler implements Tr
             ExpProtocol protocol = ExperimentService.get().getExpProtocol(run.getProtocol().getLSID());
             Container container = _data.getContainer();
             ElispotAssayProvider provider = (ElispotAssayProvider)AssayService.get().getProvider(protocol);
-            Plate template = provider.getPlateTemplate(container, protocol);
+            Plate template = provider.getPlate(container, protocol);
 
             Map<String, DomainProperty> runProperties = new HashMap<>();
             for (DomainProperty column : provider.getRunDomain(protocol).getProperties())

--- a/elispotassay/src/org/labkey/elispot/ElispotPlateTypeHandler.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotPlateTypeHandler.java
@@ -25,11 +25,9 @@ import org.labkey.api.security.User;
 import org.labkey.api.assay.plate.AbstractPlateTypeHandler;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.Well;
 import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.assay.plate.PlateReader;
 import org.labkey.api.util.Pair;
 
@@ -75,9 +73,9 @@ public class ElispotPlateTypeHandler extends AbstractPlateTypeHandler
     }
 
     @Override
-    public PlateTemplate createTemplate(@Nullable String templateTypeName, Container container, int rowCount, int colCount)
+    public Plate createTemplate(@Nullable String templateTypeName, Container container, int rowCount, int colCount)
     {
-        PlateTemplate template = PlateService.get().createPlateTemplate(container, getAssayType(), rowCount, colCount);
+        Plate template = PlateService.get().createPlateTemplate(container, getAssayType(), rowCount, colCount);
 
         // for the default elispot plate, we pre-populate it with specimen and antigen groups
         if (templateTypeName != null && templateTypeName.equals(DEFAULT_PLATE))
@@ -124,11 +122,11 @@ public class ElispotPlateTypeHandler extends AbstractPlateTypeHandler
     }
 
     @Override
-    public void validateTemplate(Container container, User user, PlateTemplate template) throws ValidationException
+    public void validateTemplate(Container container, User user, Plate template) throws ValidationException
     {
         boolean hasBackgroundWell = false;
 
-        for (WellGroupTemplate group : template.getWellGroups())
+        for (WellGroup group : template.getWellGroups())
         {
             if (group.getType() == WellGroup.Type.CONTROL)
             {

--- a/elispotassay/src/org/labkey/elispot/ElispotUploadWizardAction.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotUploadWizardAction.java
@@ -148,7 +148,7 @@ public class ElispotUploadWizardAction extends UploadWizardAction<ElispotRunUplo
 
     public PlateAntigenPropertyHelper createAntigenPropertyHelper(Container container, ExpProtocol protocol, ElispotAssayProvider provider)
     {
-        Plate template = provider.getPlateTemplate(container, protocol);
+        Plate template = provider.getPlate(container, protocol);
         Set<DomainProperty> domainProperties = new LinkedHashSet<>();
         Domain domain = provider.getAntigenWellGroupDomain(protocol);
         domainProperties.add(domain.getPropertyByName(ElispotAssayProvider.ANTIGENNAME_PROPERTY_NAME));
@@ -300,7 +300,7 @@ public class ElispotUploadWizardAction extends UploadWizardAction<ElispotRunUplo
                     form.getUploadedData();
                     ElispotAssayProvider provider = form.getProvider();
 
-                    Plate template = provider.getPlateTemplate(getContainer(), form.getProtocol());
+                    Plate template = provider.getPlate(getContainer(), form.getProtocol());
                     if (template == null)
                     {
                         errors.reject(SpringActionController.ERROR_MSG, "The template for this assay is either missing or invalid.");
@@ -503,7 +503,7 @@ public class ElispotUploadWizardAction extends UploadWizardAction<ElispotRunUplo
                 if (data.size() != 1)
                     throw new ExperimentException("Elispot should only upload a single file per run.");
 
-                Plate template = provider.getPlateTemplate(form.getContainer(), form.getProtocol());
+                Plate template = provider.getPlate(form.getContainer(), form.getProtocol());
                 Map<PlateInfo, Plate> plates = Collections.EMPTY_MAP;
                 PlateReader reader = null;
 

--- a/elispotassay/src/org/labkey/elispot/ElispotUploadWizardAction.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotUploadWizardAction.java
@@ -37,7 +37,6 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.assay.plate.Plate;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.actions.UploadWizardAction;
 import org.labkey.api.assay.AbstractAssayProvider;
 import org.labkey.api.assay.AssayUrls;
@@ -149,7 +148,7 @@ public class ElispotUploadWizardAction extends UploadWizardAction<ElispotRunUplo
 
     public PlateAntigenPropertyHelper createAntigenPropertyHelper(Container container, ExpProtocol protocol, ElispotAssayProvider provider)
     {
-        PlateTemplate template = provider.getPlateTemplate(container, protocol);
+        Plate template = provider.getPlateTemplate(container, protocol);
         Set<DomainProperty> domainProperties = new LinkedHashSet<>();
         Domain domain = provider.getAntigenWellGroupDomain(protocol);
         domainProperties.add(domain.getPropertyByName(ElispotAssayProvider.ANTIGENNAME_PROPERTY_NAME));
@@ -301,7 +300,7 @@ public class ElispotUploadWizardAction extends UploadWizardAction<ElispotRunUplo
                     form.getUploadedData();
                     ElispotAssayProvider provider = form.getProvider();
 
-                    PlateTemplate template = provider.getPlateTemplate(getContainer(), form.getProtocol());
+                    Plate template = provider.getPlateTemplate(getContainer(), form.getProtocol());
                     if (template == null)
                     {
                         errors.reject(SpringActionController.ERROR_MSG, "The template for this assay is either missing or invalid.");
@@ -504,7 +503,7 @@ public class ElispotUploadWizardAction extends UploadWizardAction<ElispotRunUplo
                 if (data.size() != 1)
                     throw new ExperimentException("Elispot should only upload a single file per run.");
 
-                PlateTemplate template = provider.getPlateTemplate(form.getContainer(), form.getProtocol());
+                Plate template = provider.getPlateTemplate(form.getContainer(), form.getProtocol());
                 Map<PlateInfo, Plate> plates = Collections.EMPTY_MAP;
                 PlateReader reader = null;
 

--- a/elispotassay/src/org/labkey/elispot/PlateAnalytePropertyHelper.java
+++ b/elispotassay/src/org/labkey/elispot/PlateAnalytePropertyHelper.java
@@ -18,7 +18,7 @@ package org.labkey.elispot;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.AssayDataCollector;
 import org.labkey.api.assay.plate.PlateReader;
-import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.SamplePropertyHelper;
 import org.labkey.api.exp.api.ExpMaterial;
@@ -50,7 +50,7 @@ public class PlateAnalytePropertyHelper extends SamplePropertyHelper<String>
         {
             File file = dataFiles.get(AssayDataCollector.PRIMARY_FILE);
             PlateReader reader;
-            PlateTemplate template = form.getProvider().getPlateTemplate(form.getContainer(), form.getProtocol());
+            Plate template = form.getProvider().getPlateTemplate(form.getContainer(), form.getProtocol());
 
             // populate property name to value map
             Map<String, String> runPropMap = new HashMap<>();

--- a/elispotassay/src/org/labkey/elispot/PlateAnalytePropertyHelper.java
+++ b/elispotassay/src/org/labkey/elispot/PlateAnalytePropertyHelper.java
@@ -50,7 +50,7 @@ public class PlateAnalytePropertyHelper extends SamplePropertyHelper<String>
         {
             File file = dataFiles.get(AssayDataCollector.PRIMARY_FILE);
             PlateReader reader;
-            Plate template = form.getProvider().getPlateTemplate(form.getContainer(), form.getProtocol());
+            Plate template = form.getProvider().getPlate(form.getContainer(), form.getProtocol());
 
             // populate property name to value map
             Map<String, String> runPropMap = new HashMap<>();

--- a/elispotassay/src/org/labkey/elispot/PlateAntigenPropertyHelper.java
+++ b/elispotassay/src/org/labkey/elispot/PlateAntigenPropertyHelper.java
@@ -18,9 +18,8 @@ package org.labkey.elispot;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.AbstractAssayProvider;
-import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.exp.SamplePropertyHelper;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.property.DomainProperty;
@@ -37,9 +36,9 @@ import java.util.Set;
 public class PlateAntigenPropertyHelper extends SamplePropertyHelper<String>
 {
     private List<String> _antigenNames;
-    private final PlateTemplate _template;
+    private final Plate _template;
 
-    public PlateAntigenPropertyHelper(List<? extends DomainProperty> antigenDomainProperties, PlateTemplate template)
+    public PlateAntigenPropertyHelper(List<? extends DomainProperty> antigenDomainProperties, Plate template)
     {
         super(antigenDomainProperties);
         _template = template;
@@ -47,7 +46,7 @@ public class PlateAntigenPropertyHelper extends SamplePropertyHelper<String>
 
         if (template != null)
         {
-            for (WellGroupTemplate wellgroup : template.getWellGroups())
+            for (WellGroup wellgroup : template.getWellGroups())
             {
                 if (wellgroup.getType() == WellGroup.Type.ANTIGEN)
                 {
@@ -61,7 +60,7 @@ public class PlateAntigenPropertyHelper extends SamplePropertyHelper<String>
     protected String getObject(int index, @NotNull Map<DomainProperty, String> sampleProperties, @NotNull Set<ExpMaterial> parentMaterials)
     {
         int i = 0;
-        for (WellGroupTemplate wellgroup : _template.getWellGroups())
+        for (WellGroup wellgroup : _template.getWellGroups())
         {
             if (wellgroup.getType() == WellGroup.Type.ANTIGEN)
             {

--- a/elispotassay/src/org/labkey/elispot/pipeline/BackgroundSubtractionJob.java
+++ b/elispotassay/src/org/labkey/elispot/pipeline/BackgroundSubtractionJob.java
@@ -17,6 +17,7 @@ package org.labkey.elispot.pipeline;
 
 import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
@@ -29,9 +30,7 @@ import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.assay.plate.Plate;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.Position;
-import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.assay.actions.UploadWizardAction;
 import org.labkey.api.assay.AbstractAssayProvider;
 import org.labkey.api.assay.AssayProvider;
@@ -181,7 +180,7 @@ public class BackgroundSubtractionJob extends PipelineJob
 
     private Plate initializePlate(PlateBasedAssayProvider provider, ExpRun run, PlateReader reader) throws ExperimentException
     {
-        PlateTemplate template = provider.getPlateTemplate(run.getContainer(), run.getProtocol());
+        Plate template = provider.getPlateTemplate(run.getContainer(), run.getProtocol());
         List<? extends ExpData> data = run.getOutputDatas(ExperimentService.get().getDataType(ElispotDataHandler.NAMESPACE));
 
         if (reader != null)

--- a/elispotassay/src/org/labkey/elispot/pipeline/BackgroundSubtractionJob.java
+++ b/elispotassay/src/org/labkey/elispot/pipeline/BackgroundSubtractionJob.java
@@ -180,7 +180,7 @@ public class BackgroundSubtractionJob extends PipelineJob
 
     private Plate initializePlate(PlateBasedAssayProvider provider, ExpRun run, PlateReader reader) throws ExperimentException
     {
-        Plate template = provider.getPlateTemplate(run.getContainer(), run.getProtocol());
+        Plate template = provider.getPlate(run.getContainer(), run.getProtocol());
         List<? extends ExpData> data = run.getOutputDatas(ExperimentService.get().getDataType(ElispotDataHandler.NAMESPACE));
 
         if (reader != null)

--- a/elispotassay/src/org/labkey/elispot/plate/AIDPlateReader.java
+++ b/elispotassay/src/org/labkey/elispot/plate/AIDPlateReader.java
@@ -15,7 +15,7 @@
  */
 package org.labkey.elispot.plate;
 
-import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateUtils;
 import org.labkey.api.assay.plate.TextPlateReader;
 import org.labkey.api.exp.ExperimentException;
@@ -55,7 +55,7 @@ public class AIDPlateReader extends TextPlateReader
     }
 
     @Override
-    public double[][] loadFile(PlateTemplate template, File dataFile) throws ExperimentException
+    public double[][] loadFile(Plate template, File dataFile) throws ExperimentException
     {
         String fileName = dataFile.getName().toLowerCase();
         if (fileName.endsWith(".xls") || fileName.endsWith(".xlsx"))
@@ -77,7 +77,7 @@ public class AIDPlateReader extends TextPlateReader
     }
 
     @Override
-    public Map<String, double[][]> loadMultiGridFile(PlateTemplate template, File dataFile) throws ExperimentException
+    public Map<String, double[][]> loadMultiGridFile(Plate template, File dataFile) throws ExperimentException
     {
         String fileName = dataFile.getName().toLowerCase();
         if (fileName.endsWith(".xls") || fileName.endsWith(".xlsx"))

--- a/nab/src/org/labkey/nab/AbstractNabManager.java
+++ b/nab/src/org/labkey/nab/AbstractNabManager.java
@@ -16,12 +16,11 @@
 package org.labkey.nab;
 
 import org.labkey.api.assay.dilution.DilutionManager;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.PlateTemplate;
 
-import java.sql.SQLException;
 import java.util.List;
 
 /**
@@ -32,11 +31,11 @@ public class AbstractNabManager extends DilutionManager
 {
     public static final String DEFAULT_TEMPLATE_NAME = "NAb: 5 specimens in duplicate";
 
-    public synchronized PlateTemplate ensurePlateTemplate(Container container, User user) throws Exception
+    public synchronized Plate ensurePlateTemplate(Container container, User user) throws Exception
     {
         NabPlateTypeHandler nabHandler = new NabPlateTypeHandler();
-        PlateTemplate template;
-        List<? extends PlateTemplate> templates = PlateService.get().getPlateTemplates(container);
+        Plate template;
+        List<Plate> templates = PlateService.get().getPlateTemplates(container);
         if (templates.isEmpty())
         {
             template = nabHandler.createTemplate(NabPlateTypeHandler.SINGLE_PLATE_TYPE, container, 8, 12);

--- a/nab/src/org/labkey/nab/NabAssayController.java
+++ b/nab/src/org/labkey/nab/NabAssayController.java
@@ -65,12 +65,10 @@ import org.labkey.api.assay.nab.view.RunDetailsAction;
 import org.labkey.api.assay.nab.view.RunDetailsHeaderView;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateSampleFilePropertyHelper;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.PositionImpl;
 import org.labkey.api.assay.plate.WellData;
 import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
@@ -524,11 +522,11 @@ public class NabAssayController extends SpringActionController
     {
         private final Container _container;
         private final Domain _sampleDomain;
-        private final List<WellGroupTemplate> _sampleGroups;
+        private final List<WellGroup> _sampleGroups;
         private final Domain _virusDomain;
-        private final List<WellGroupTemplate> _virusGroups;
+        private final List<WellGroup> _virusGroups;
 
-        public SampleTemplateWriter(Container container, Domain sampleDomain, List<WellGroupTemplate> sampleGroups, Domain virusDomain, List<WellGroupTemplate> virusGroups)
+        public SampleTemplateWriter(Container container, Domain sampleDomain, List<WellGroup> sampleGroups, Domain virusDomain, List<WellGroup> virusGroups)
         {
             _sampleDomain = sampleDomain;
             _sampleGroups = sampleGroups;
@@ -581,11 +579,11 @@ public class NabAssayController extends SpringActionController
 
             // Render the rows (i.e. well group names, virus group names, and default property values):
             int rowNum = 1;
-            for (WellGroupTemplate sampleGroup : _sampleGroups)
+            for (WellGroup sampleGroup : _sampleGroups)
             {
                 if (_virusGroups.size() > 0)
                 {
-                    for (WellGroupTemplate virusGroup : _virusGroups)
+                    for (WellGroup virusGroup : _virusGroups)
                         renderRow(sheet, headers, columnToDefaultValue, rowNum++, sampleGroup, virusGroup);
                 }
                 else
@@ -593,7 +591,7 @@ public class NabAssayController extends SpringActionController
             }
         }
 
-        private void renderRow(Sheet sheet, List<String> headers, Map<String, Object> columnToDefaultValue, int rowNum, WellGroupTemplate sample, @Nullable WellGroupTemplate virus)
+        private void renderRow(Sheet sheet, List<String> headers, Map<String, Object> columnToDefaultValue, int rowNum, WellGroup sample, @Nullable WellGroup virus)
         {
             Row row = sheet.createRow(rowNum);
             for (int column = 0; column < headers.size(); column++)
@@ -649,15 +647,15 @@ public class NabAssayController extends SpringActionController
             NabAssayProvider nabProvider = ((NabAssayProvider) provider);
             Domain sampleDomain = nabProvider.getSampleWellGroupDomain(protocol);
             Domain virusDomain = nabProvider.getVirusWellGroupDomain(protocol);
-            PlateTemplate template = nabProvider.getPlateTemplate(context.getContainer(), protocol);
+            Plate template = nabProvider.getPlateTemplate(context.getContainer(), protocol);
             if (template == null)
             {
                 throw new NotFoundException("The plate template for this assay design could not be found.  It may have been deleted by an administrator.");
             }
 
-            List<WellGroupTemplate> sampleGroups = new ArrayList<>();
-            List<WellGroupTemplate> virusGroups = new ArrayList<>();
-            for (WellGroupTemplate group : template.getWellGroups())
+            List<WellGroup> sampleGroups = new ArrayList<>();
+            List<WellGroup> virusGroups = new ArrayList<>();
+            for (WellGroup group : template.getWellGroups())
             {
                 if (group.getType() == WellGroup.Type.SPECIMEN)
                     sampleGroups.add(group);

--- a/nab/src/org/labkey/nab/NabAssayController.java
+++ b/nab/src/org/labkey/nab/NabAssayController.java
@@ -647,7 +647,7 @@ public class NabAssayController extends SpringActionController
             NabAssayProvider nabProvider = ((NabAssayProvider) provider);
             Domain sampleDomain = nabProvider.getSampleWellGroupDomain(protocol);
             Domain virusDomain = nabProvider.getVirusWellGroupDomain(protocol);
-            Plate template = nabProvider.getPlateTemplate(context.getContainer(), protocol);
+            Plate template = nabProvider.getPlate(context.getContainer(), protocol);
             if (template == null)
             {
                 throw new NotFoundException("The plate template for this assay design could not be found.  It may have been deleted by an administrator.");

--- a/nab/src/org/labkey/nab/NabAssayProvider.java
+++ b/nab/src/org/labkey/nab/NabAssayProvider.java
@@ -31,8 +31,8 @@ import org.labkey.api.assay.actions.PlateUploadForm;
 import org.labkey.api.assay.dilution.AbstractDilutionAssayProvider;
 import org.labkey.api.assay.dilution.DilutionDataHandler;
 import org.labkey.api.assay.nab.NabSpecimen;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateSamplePropertyHelper;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SQLFragment;
@@ -356,7 +356,7 @@ public class NabAssayProvider extends AbstractDilutionAssayProvider<NabRunUpload
 
     public PlateSamplePropertyHelper getVirusPropertyHelper(PlateUploadForm context, boolean insertView)
     {
-        PlateTemplate template = getPlateTemplate(context.getContainer(), context.getProtocol());
+        Plate template = getPlateTemplate(context.getContainer(), context.getProtocol());
         try
         {
             AssayProvider provider = context.getProvider();

--- a/nab/src/org/labkey/nab/NabAssayProvider.java
+++ b/nab/src/org/labkey/nab/NabAssayProvider.java
@@ -356,7 +356,7 @@ public class NabAssayProvider extends AbstractDilutionAssayProvider<NabRunUpload
 
     public PlateSamplePropertyHelper getVirusPropertyHelper(PlateUploadForm context, boolean insertView)
     {
-        Plate template = getPlateTemplate(context.getContainer(), context.getProtocol());
+        Plate template = getPlate(context.getContainer(), context.getProtocol());
         try
         {
             AssayProvider provider = context.getProvider();

--- a/nab/src/org/labkey/nab/NabPlateTypeHandler.java
+++ b/nab/src/org/labkey/nab/NabPlateTypeHandler.java
@@ -18,13 +18,12 @@ package org.labkey.nab;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.dilution.SampleProperty;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.data.Container;
 import org.labkey.api.assay.plate.AbstractPlateTypeHandler;
 import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.util.Pair;
 import org.labkey.nab.multiplate.HighThroughputNabDataHandler;
 
@@ -86,9 +85,9 @@ public class NabPlateTypeHandler extends AbstractPlateTypeHandler
     }
 
     @Override
-    public PlateTemplate createTemplate(@Nullable String templateTypeName, Container container, int rowCount, int colCount)
+    public Plate createTemplate(@Nullable String templateTypeName, Container container, int rowCount, int colCount)
     {
-        PlateTemplate template = PlateService.get().createPlateTemplate(container, getAssayType(), rowCount, colCount);
+        Plate template = PlateService.get().createPlateTemplate(container, getAssayType(), rowCount, colCount);
 
         if (templateTypeName != null && templateTypeName.equalsIgnoreCase(HIGH_THROUGHPUT_SINGLEDILUTION_PLATE_TYPE))
             return createHighThroughputSingleDilutionTemplate(template, container, rowCount, colCount);
@@ -115,7 +114,7 @@ public class NabPlateTypeHandler extends AbstractPlateTypeHandler
             {
                 int firstCol = (sample * 2) + 2;
                 // create the overall specimen group, consisting of two adjacent columns:
-                WellGroupTemplate sampleGroup = template.addWellGroup("Specimen " + (sample + 1), WellGroup.Type.SPECIMEN,
+                WellGroup sampleGroup = template.addWellGroup("Specimen " + (sample + 1), WellGroup.Type.SPECIMEN,
                         PlateService.get().createPosition(container, 0, firstCol),
                         PlateService.get().createPosition(container, template.getRows() - 1, firstCol + 1));
 //                sampleGroup.setProperty(prop.name(), "");
@@ -153,7 +152,7 @@ public class NabPlateTypeHandler extends AbstractPlateTypeHandler
         return template;
     }
 
-    private PlateTemplate createHighThroughputSingleDilutionTemplate(PlateTemplate template, Container c, int rowCount, int colCount)
+    private Plate createHighThroughputSingleDilutionTemplate(Plate template, Container c, int rowCount, int colCount)
     {
         template.addWellGroup(NabManager.VIRUS_CONTROL_SAMPLE, WellGroup.Type.CONTROL,
                 PlateService.get().createPosition(c, 0, 0),
@@ -207,7 +206,7 @@ public class NabPlateTypeHandler extends AbstractPlateTypeHandler
                     positions.add(PlateService.get().createPosition(c, row + (rowGroup % 2), col));
                     positions.add(PlateService.get().createPosition(c, row + (rowGroup % 2) + 2, col));
 
-                    WellGroupTemplate wg = template.addWellGroup("Specimen " + sampleIndex + "-" + replicateIndex++, WellGroup.Type.REPLICATE, positions);
+                    WellGroup wg = template.addWellGroup("Specimen " + sampleIndex + "-" + replicateIndex++, WellGroup.Type.REPLICATE, positions);
 
                     // add an explicit order property to override the natural ordering
                     wg.setProperty(HighThroughputNabDataHandler.REPLICATE_GROUP_ORDER_PROPERTY, String.valueOf(replicateGroupIndex++));
@@ -218,7 +217,7 @@ public class NabPlateTypeHandler extends AbstractPlateTypeHandler
         return template;
     }
 
-    private PlateTemplate createMultiVirusTemplate(PlateTemplate template, Container c, int rowCount, int colCount)
+    private Plate createMultiVirusTemplate(Plate template, Container c, int rowCount, int colCount)
     {
         assert 16 == rowCount && 24 == colCount: "Only 16x24 multi-virus supported";
         PlateService plateService = PlateService.get();
@@ -282,7 +281,7 @@ public class NabPlateTypeHandler extends AbstractPlateTypeHandler
                 WellGroup.Type.REPLICATE, WellGroup.Type.OTHER);
     }
 
-    private PlateTemplate create20Sample4VirusScreeningTemplate(PlateTemplate template, Container c, int rowCount, int colCount)
+    private Plate create20Sample4VirusScreeningTemplate(Plate template, Container c, int rowCount, int colCount)
     {
         assert 16 == rowCount && 24 == colCount: "Only 16x24 multi-virus supported";
         PlateService plateService = PlateService.get();
@@ -370,7 +369,7 @@ public class NabPlateTypeHandler extends AbstractPlateTypeHandler
         return template;
     }
 
-    private PlateTemplate create240Sample1VirusScreeningTemplate(PlateTemplate template, Container c, int rowCount, int colCount)
+    private Plate create240Sample1VirusScreeningTemplate(Plate template, Container c, int rowCount, int colCount)
     {
         assert 16 == rowCount && 24 == colCount: "Only 16x24 multi-virus supported";
         PlateService plateService = PlateService.get();

--- a/nab/src/org/labkey/nab/NabRunPropertyMap.java
+++ b/nab/src/org/labkey/nab/NabRunPropertyMap.java
@@ -19,13 +19,13 @@ import org.json.JSONObject;
 import org.labkey.api.assay.dilution.DilutionAssayRun;
 import org.labkey.api.assay.dilution.DilutionSummary;
 import org.labkey.api.assay.nab.NabSpecimen;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.statistics.FitFailedException;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.Well;
-import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.exp.api.ExpMaterial;
 
 import java.util.ArrayList;

--- a/nab/src/org/labkey/nab/NabVirusFilePropertyHelper.java
+++ b/nab/src/org/labkey/nab/NabVirusFilePropertyHelper.java
@@ -19,9 +19,8 @@ import org.labkey.api.data.Container;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.DomainProperty;
-import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.assay.plate.PlateSampleFilePropertyHelper;
 import org.labkey.api.study.assay.SampleMetadataInputFormat;
 
@@ -36,7 +35,7 @@ public class NabVirusFilePropertyHelper extends PlateSampleFilePropertyHelper
 {
     public static final String VIRUS_WELLGROUP_COLUMN = "VirusWellGroup";
 
-    public NabVirusFilePropertyHelper(Container c, ExpProtocol protocol, List<? extends DomainProperty> sampleProperties, PlateTemplate template)
+    public NabVirusFilePropertyHelper(Container c, ExpProtocol protocol, List<? extends DomainProperty> sampleProperties, Plate template)
     {
         super(c, protocol, sampleProperties, template, SampleMetadataInputFormat.FILE_BASED);
         _wellgroupType = WellGroup.Type.VIRUS;
@@ -59,7 +58,7 @@ public class NabVirusFilePropertyHelper extends PlateSampleFilePropertyHelper
     }
 
     @Override
-    protected void validateMetadataRow(Map<String, Object> row, String wellGroupName, WellGroupTemplate wellgroup)
+    protected void validateMetadataRow(Map<String, Object> row, String wellGroupName, WellGroup wellgroup)
     {
         // no-op
     }

--- a/nab/src/org/labkey/nab/NabVirusPropertyHelper.java
+++ b/nab/src/org/labkey/nab/NabVirusPropertyHelper.java
@@ -16,13 +16,13 @@
 package org.labkey.nab;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.security.User;
-import org.labkey.api.assay.plate.PlateTemplate;
-import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.assay.actions.AssayRunUploadForm;
 import org.labkey.api.assay.actions.UploadWizardAction;
 import org.labkey.api.assay.plate.PlateSamplePropertyHelper;
@@ -42,7 +42,7 @@ public class NabVirusPropertyHelper extends PlateSamplePropertyHelper
 {
     private SampleMetadataInputFormat _metadataInputFormat;
 
-    public NabVirusPropertyHelper(List<? extends DomainProperty> virusDomainProperties, PlateTemplate template, SampleMetadataInputFormat metadataInputFormat)
+    public NabVirusPropertyHelper(List<? extends DomainProperty> virusDomainProperties, Plate template, SampleMetadataInputFormat metadataInputFormat)
     {
         super(virusDomainProperties, template, WellGroup.Type.VIRUS);
         _metadataInputFormat = metadataInputFormat;

--- a/nab/src/org/labkey/nab/PlateParserTests.java
+++ b/nab/src/org/labkey/nab/PlateParserTests.java
@@ -19,7 +19,7 @@ import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
@@ -42,13 +42,13 @@ public class PlateParserTests
         _context = new Mockery();
     }
 
-    public double[][] parse(File file, PlateTemplate template) throws ExperimentException
+    public double[][] parse(File file, Plate template) throws ExperimentException
     {
         SinglePlateNabDataHandler handler = new SinglePlateNabDataHandler();
         return handler.getCellValues(file, template);
     }
 
-    public void assertCells(String nabFile, double[][] expected, File file, PlateTemplate template) throws ExperimentException
+    public void assertCells(String nabFile, double[][] expected, File file, Plate template) throws ExperimentException
     {
         double[][] actual = parse(file, template);
         if (actual == null)
@@ -79,11 +79,11 @@ public class PlateParserTests
     }
 
     // Create a plate template that has enough information to parse the data file
-    public PlateTemplate template(String name, final int rows, final int columns)
+    public Plate template(String name, final int rows, final int columns)
     {
         synchronized (_context)
         {
-            final PlateTemplate template = _context.mock(PlateTemplate.class, name);
+            final Plate template = _context.mock(Plate.class, name);
             _context.checking(new Expectations()
             {{
                 allowing(template).getRows();
@@ -123,7 +123,7 @@ public class PlateParserTests
             File expectedFile = JunitUtil.getSampleData(null, test.second);
 
             final double[][] expected = parseExpected(expectedFile);
-            PlateTemplate template = template(nabFile.getName(), expected.length, expected[0].length);
+            Plate template = template(nabFile.getName(), expected.length, expected[0].length);
             assertCells(test.first, expected, nabFile, template);
         }
     }

--- a/nab/src/org/labkey/nab/SinglePlateNabAssayRun.java
+++ b/nab/src/org/labkey/nab/SinglePlateNabAssayRun.java
@@ -21,6 +21,7 @@ import org.labkey.api.assay.dilution.DilutionAssayProvider;
 import org.labkey.api.assay.dilution.DilutionDataHandler;
 import org.labkey.api.assay.dilution.DilutionManager;
 import org.labkey.api.assay.dilution.DilutionSummary;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.SimpleFilter;
@@ -36,7 +37,6 @@ import org.labkey.api.security.User;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.Position;
-import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.assay.AssayProtocolSchema;
 
 import java.util.ArrayList;

--- a/nab/src/org/labkey/nab/SinglePlateNabDataHandler.java
+++ b/nab/src/org/labkey/nab/SinglePlateNabDataHandler.java
@@ -29,7 +29,6 @@ import org.labkey.api.assay.dilution.DilutionAssayRun;
 import org.labkey.api.assay.dilution.DilutionManager;
 import org.labkey.api.assay.dilution.SampleProperty;
 import org.labkey.api.assay.plate.Plate;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.PlateUtils;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.WellData;
@@ -102,7 +101,7 @@ public class SinglePlateNabDataHandler extends NabDataHandler implements Transfo
     }
 
     @Override
-    protected double[][] getCellValues(final File dataFile, PlateTemplate nabTemplate) throws ExperimentException
+    protected double[][] getCellValues(final File dataFile, Plate nabTemplate) throws ExperimentException
     {
         final int expectedRows = nabTemplate.getRows();
         final int expectedCols = nabTemplate.getColumns();

--- a/nab/src/org/labkey/nab/multiplate/CrossPlateDilutionNabAssayRun.java
+++ b/nab/src/org/labkey/nab/multiplate/CrossPlateDilutionNabAssayRun.java
@@ -15,11 +15,11 @@
  */
 package org.labkey.nab.multiplate;
 
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.security.User;
 import org.labkey.api.assay.plate.Plate;
-import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.assay.dilution.DilutionAssayProvider;
 import org.labkey.api.assay.dilution.DilutionSummary;
 import org.labkey.nab.NabAssayRun;

--- a/nab/src/org/labkey/nab/multiplate/CrossPlateDilutionNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/CrossPlateDilutionNabDataHandler.java
@@ -17,6 +17,7 @@ package org.labkey.nab.multiplate;
 
 import org.labkey.api.assay.dilution.DilutionAssayProvider;
 import org.labkey.api.assay.dilution.DilutionAssayRun;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.DataType;
@@ -24,7 +25,6 @@ import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.security.User;
 import org.labkey.api.assay.plate.Plate;
-import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.assay.AssayDataType;
 import org.labkey.api.util.FileType;
 

--- a/nab/src/org/labkey/nab/multiplate/HighThroughputNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/HighThroughputNabDataHandler.java
@@ -23,10 +23,8 @@ import org.labkey.api.assay.dilution.SampleProperty;
 import org.labkey.api.assay.dilution.WellDataRow;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.WellData;
 import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.XarContext;
@@ -70,7 +68,7 @@ public abstract class HighThroughputNabDataHandler extends NabDataHandler implem
     protected static final String LOCATION_COLUMNN_HEADER = "Well Location";
 
     @Override
-    protected List<Plate> createPlates(File dataFile, PlateTemplate template) throws ExperimentException
+    protected List<Plate> createPlates(File dataFile, Plate template) throws ExperimentException
     {
         DataLoader loader = null;
         try
@@ -111,7 +109,7 @@ public abstract class HighThroughputNabDataHandler extends NabDataHandler implem
     }
 
     @Override
-    protected List<Plate> createPlates(ExpRun run, PlateTemplate template, boolean recalcStats) throws ExperimentException
+    protected List<Plate> createPlates(ExpRun run, Plate template, boolean recalcStats) throws ExperimentException
     {
         List<WellDataRow> wellDataRows = DilutionManager.getWellDataRows(run);
         if (wellDataRows.isEmpty())
@@ -148,7 +146,7 @@ public abstract class HighThroughputNabDataHandler extends NabDataHandler implem
     }
 
     @Override
-    protected double[][] getCellValues(final File dataFile, PlateTemplate nabTemplate)
+    protected double[][] getCellValues(final File dataFile, Plate nabTemplate)
     {
         throw new IllegalStateException("getCellValues should not be called for High Throughput handlers.");
     }
@@ -200,7 +198,7 @@ public abstract class HighThroughputNabDataHandler extends NabDataHandler implem
                 {
                     // it's possible to override the natural ordering of the replicate well groups by adding a replicate
                     // well group property : 'Group Order' with a numeric value in the plate template
-                    String order = (String)((WellGroupTemplate)well).getProperty(REPLICATE_GROUP_ORDER_PROPERTY);
+                    String order = (String)((WellGroup)well).getProperty(REPLICATE_GROUP_ORDER_PROPERTY);
                     if (!NumberUtils.isDigits(order))
                     {
                         hasExplicitOrder = false;
@@ -218,10 +216,10 @@ public abstract class HighThroughputNabDataHandler extends NabDataHandler implem
             {
                 wellData.sort((Comparator<WellData>) (w1, w2) ->
                 {
-                    if ((w1 instanceof WellGroupTemplate) && (w2 instanceof WellGroupTemplate))
+                    if ((w1 instanceof WellGroup) && (w2 instanceof WellGroup))
                     {
-                        String order1 = (String) ((WellGroupTemplate) w1).getProperty(REPLICATE_GROUP_ORDER_PROPERTY);
-                        String order2 = (String) ((WellGroupTemplate) w2).getProperty(REPLICATE_GROUP_ORDER_PROPERTY);
+                        String order1 = (String) ((WellGroup) w1).getProperty(REPLICATE_GROUP_ORDER_PROPERTY);
+                        String order2 = (String) ((WellGroup) w2).getProperty(REPLICATE_GROUP_ORDER_PROPERTY);
 
                         return NumberUtils.toInt(order1, 0) - NumberUtils.toInt(order2, 0);
                     }

--- a/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabAssayProvider.java
+++ b/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabAssayProvider.java
@@ -18,27 +18,21 @@ package org.labkey.nab.multiplate;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.dilution.DilutionDataHandler;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
-import org.labkey.api.query.QuerySettings;
 import org.labkey.api.security.User;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.PlateSamplePropertyHelper;
 import org.labkey.api.study.assay.SampleMetadataInputFormat;
-import org.labkey.api.assay.query.ResultsQueryView;
-import org.labkey.api.assay.query.RunListQueryView;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.ViewContext;
 import org.labkey.nab.NabAssayProvider;
 import org.labkey.nab.NabRunUploadForm;
 import org.labkey.nab.query.NabProtocolSchema;
-import org.springframework.validation.BindException;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -108,7 +102,7 @@ public class SinglePlateDilutionNabAssayProvider extends HighThroughputNabAssayP
     }
 
     @Override
-    protected PlateSamplePropertyHelper createSampleFilePropertyHelper(Container c, ExpProtocol protocol, List<? extends DomainProperty> sampleProperties, PlateTemplate template, SampleMetadataInputFormat inputFormat)
+    protected PlateSamplePropertyHelper createSampleFilePropertyHelper(Container c, ExpProtocol protocol, List<? extends DomainProperty> sampleProperties, Plate template, SampleMetadataInputFormat inputFormat)
     {
         if (inputFormat == SampleMetadataInputFormat.MANUAL)
             return new PlateSamplePropertyHelper(sampleProperties, template);

--- a/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabAssayRun.java
+++ b/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabAssayRun.java
@@ -18,13 +18,13 @@ package org.labkey.nab.multiplate;
 import org.labkey.api.assay.dilution.DilutionAssayProvider;
 import org.labkey.api.assay.dilution.DilutionSummary;
 import org.labkey.api.assay.nab.Luc5Assay;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.security.User;
 import org.labkey.api.assay.plate.Plate;
-import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.nab.NabAssayProvider;
 import org.labkey.nab.NabAssayRun;
 

--- a/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabDataHandler.java
@@ -22,7 +22,6 @@ import org.labkey.api.assay.dilution.DilutionSummary;
 import org.labkey.api.assay.nab.NabSpecimen;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.PlateTemplate;
 import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.exp.ExperimentException;
@@ -67,7 +66,7 @@ public class SinglePlateDilutionNabDataHandler extends HighThroughputNabDataHand
     }
 
     @Override
-    protected List<Plate> createPlates(File dataFile, PlateTemplate template) throws ExperimentException
+    protected List<Plate> createPlates(File dataFile, Plate template) throws ExperimentException
     {
         DataLoader loader = null;
         try

--- a/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionSamplePropertyHelper.java
+++ b/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionSamplePropertyHelper.java
@@ -16,8 +16,8 @@
 package org.labkey.nab.multiplate;
 
 import org.labkey.api.assay.plate.PlateSampleFilePropertyHelper;
-import org.labkey.api.assay.plate.PlateTemplate;
-import org.labkey.api.assay.plate.WellGroupTemplate;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -40,7 +40,7 @@ import java.util.Map;
  */
 public class SinglePlateDilutionSamplePropertyHelper extends PlateSampleFilePropertyHelper
 {
-    public SinglePlateDilutionSamplePropertyHelper(Container c, ExpProtocol protocol, List<? extends DomainProperty> sampleProperties, PlateTemplate template, SampleMetadataInputFormat inputFormat)
+    public SinglePlateDilutionSamplePropertyHelper(Container c, ExpProtocol protocol, List<? extends DomainProperty> sampleProperties, Plate template, SampleMetadataInputFormat inputFormat)
     {
         super(c, protocol, sampleProperties, template, inputFormat);
     }
@@ -62,7 +62,7 @@ public class SinglePlateDilutionSamplePropertyHelper extends PlateSampleFileProp
         Map<String, Map<DomainProperty, String>> allProperties = new HashMap<>();
         try (ExcelLoader loader = new ExcelLoader(metadataFile, true))
         {
-            Map<String, WellGroupTemplate> sampleGroupNames = getSampleWellGroupNameMap();
+            Map<String, WellGroup> sampleGroupNames = getSampleWellGroupNameMap();
 
             // issue #19539 -- now addressed by larger default value for _scanAheadLineCount
 
@@ -93,7 +93,7 @@ public class SinglePlateDilutionSamplePropertyHelper extends PlateSampleFileProp
                 {
                     wellGroupName = String.valueOf(row.get(wellGroupColumnName));
                 }
-                WellGroupTemplate wellgroup = wellGroupName != null ? sampleGroupNames.get(wellGroupName) : null;
+                WellGroup wellgroup = wellGroupName != null ? sampleGroupNames.get(wellGroupName) : null;
 
                 if (wellgroup != null)
                 {

--- a/nab/src/org/labkey/nab/query/NabWellDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabWellDataTable.java
@@ -29,9 +29,8 @@ import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.query.ExprColumn;
-import org.labkey.api.assay.plate.PlateTemplate;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.plate.WellGroupTemplate;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.query.QueryForeignKey;
@@ -90,7 +89,7 @@ public class NabWellDataTable extends NabBaseTable
         if (provider instanceof NabAssayProvider)
         {
             NabAssayProvider nabAssayProvider = (NabAssayProvider)provider;
-            PlateTemplate template = nabAssayProvider.getPlateTemplate(getContainer(), _protocol);
+            Plate template = nabAssayProvider.getPlateTemplate(getContainer(), _protocol);
             if (null != template)
             {
                 addWellNameColumn(template.getRows());
@@ -127,35 +126,35 @@ public class NabWellDataTable extends NabBaseTable
         addColumn(new ExprColumn(this, "WellName", sql, JdbcType.VARCHAR, row, column));
     }
 
-    private void addWellgroupPropertyColumns(PlateTemplate plateTemplate)
+    private void addWellgroupPropertyColumns(Plate plateTemplate)
     {
-        Map<WellGroup.Type, Map<String, WellGroupTemplate>> wellGroupTemplateMap = plateTemplate.getWellGroupTemplateMap();
-        Map<String, WellGroupTemplate> controlTemplates = wellGroupTemplateMap.get(WellGroup.Type.CONTROL);
+        Map<WellGroup.Type, Map<String, WellGroup>> wellGroupTemplateMap = plateTemplate.getWellGroupTemplateMap();
+        Map<String, WellGroup> controlTemplates = wellGroupTemplateMap.get(WellGroup.Type.CONTROL);
         if (null != controlTemplates && !controlTemplates.isEmpty())
         {
             addWellgroupPropertyColumns(controlTemplates, CONTROL_WELLGROUP_NAME);
         }
-        Map<String, WellGroupTemplate> virusTemplates = wellGroupTemplateMap.get(WellGroup.Type.VIRUS);
+        Map<String, WellGroup> virusTemplates = wellGroupTemplateMap.get(WellGroup.Type.VIRUS);
         if (null != virusTemplates && !virusTemplates.isEmpty())
         {
             addWellgroupPropertyColumns(virusTemplates, VIRUS_WELLGROUP_NAME);
         }
-        Map<String, WellGroupTemplate> specimenTemplates = wellGroupTemplateMap.get(WellGroup.Type.SPECIMEN);
+        Map<String, WellGroup> specimenTemplates = wellGroupTemplateMap.get(WellGroup.Type.SPECIMEN);
         if (null != specimenTemplates && !specimenTemplates.isEmpty())
         {
             addWellgroupPropertyColumns(specimenTemplates, SPECIMEN_WELLGROUP_NAME);
         }
-        Map<String, WellGroupTemplate> replicateTemplates = wellGroupTemplateMap.get(WellGroup.Type.REPLICATE);
+        Map<String, WellGroup> replicateTemplates = wellGroupTemplateMap.get(WellGroup.Type.REPLICATE);
         if (null != replicateTemplates && !replicateTemplates.isEmpty())
         {
             addWellgroupPropertyColumns(replicateTemplates, REPLICATE_WELLGROUP_NAME);
         }
     }
 
-    private void addWellgroupPropertyColumns(Map<String, WellGroupTemplate> wellgroupTemplates, String wellgroupNameColumnName)
+    private void addWellgroupPropertyColumns(Map<String, WellGroup> wellgroupTemplates, String wellgroupNameColumnName)
     {
         Map<String, Map<String, Object>> propertyMap = new CaseInsensitiveHashMap<>();        // Map propertyName -> (Map wellGroupName -> propertyValue)
-        for (WellGroupTemplate template : wellgroupTemplates.values())
+        for (WellGroup template : wellgroupTemplates.values())
         {
             for (String propertyName : template.getPropertyNames())
             {

--- a/nab/src/org/labkey/nab/query/NabWellDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabWellDataTable.java
@@ -89,7 +89,7 @@ public class NabWellDataTable extends NabBaseTable
         if (provider instanceof NabAssayProvider)
         {
             NabAssayProvider nabAssayProvider = (NabAssayProvider)provider;
-            Plate template = nabAssayProvider.getPlateTemplate(getContainer(), _protocol);
+            Plate template = nabAssayProvider.getPlate(getContainer(), _protocol);
             if (null != template)
             {
                 addWellNameColumn(template.getRows());


### PR DESCRIPTION
#### Rationale
Previously, assay plates had maintained the following hierarchy:
- `Plate\PlateTemplate` interfaces and classes
- `WellGroup\WellGroupTemplate` interfaces and classes

The intended distinction between the template versus non-template was that a template implied that no data had been associated with a plate's wells and the minute you added data to the plate it was no longer a template. However, well data associated with a plate was never stored to the database and while there was a `template` field in the `PlateTable` that was also never associated with the distinction. It wasn't too problematic since in existing implementations this never mattered. With `AbDisc` this now changes.

The abstraction also never worked and these classes tended to be used interchangeably with plenty of downcasting and implementation assumptions.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/4604

#### Changes
- Combine the `Plate\PlateTemplate` interfaces so only `Plate` exists
- Combine the `PlateImpl\PlateTemplateImpl` classes so only `PlateImpl` exists
- Combine the `WellGroup\WellGroupTemplate` interfaces so only `WellGroup` exists
- Combine the `WellGroupImpl\WellGroupTemplateImpl` classes so only `WellGroupImpl` remains
