### PR TITLE
Issue 48499: Use preferred SecurityPolicyManager.savePolicy() variant

### DIFF
--- a/flow/src/org/labkey/flow/controllers/FlowController.java
+++ b/flow/src/org/labkey/flow/controllers/FlowController.java
@@ -251,7 +251,7 @@ public class FlowController extends BaseFlowController
                 return false;
             }
 
-            destContainer = ContainerManager.createContainer(parent, folderName);
+            destContainer = ContainerManager.createContainer(parent, folderName, getUser());
             destContainer.setActiveModules(getContainer().getActiveModules(), getUser());
             destContainer.setFolderType(getContainer().getFolderType(), getUser(), errors);
             destContainer.setDefaultModule(flowModule);


### PR DESCRIPTION
#### Rationale
We're uneven in terms of the validation and auditing we do for saving SecurityPolicies and related updates, and want to be more consistent.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4704

#### Changes
* Let modules register ContainerSecurableResourceProviders instead of having Container know about them all
* Remove the `savePolicy` and `createContainer` methods that don't take a user, check permissions, or log for audit purposes
* Introduce `User.getAdminServiceUser()` for `sudo` like scenarios or when we're doing an operation not initiated by a user, like bootstrapping the server
* Update callers