### PR TITLE
48488: Elispot broken - rundata/data's metadata cannot be edited

### DIFF
--- a/elispotassay/src/org/labkey/elispot/query/ElispotAntigenCrosstabTable.java
+++ b/elispotassay/src/org/labkey/elispot/query/ElispotAntigenCrosstabTable.java
@@ -113,7 +113,7 @@ public class ElispotAntigenCrosstabTable extends CrosstabTable
         getMutableColumn("InstanceCount").setHidden(true);
         getMutableColumn("Run").setHidden(true);
         getMutableColumn("SpecimenLsid").setHidden(true);
-        setTitle("AntigenStats");
+        setName("AntigenStats");
     }
 
     @NotNull

--- a/elispotassay/src/org/labkey/elispot/query/ElispotRunAntigenTable.java
+++ b/elispotassay/src/org/labkey/elispot/query/ElispotRunAntigenTable.java
@@ -46,7 +46,7 @@ public class ElispotRunAntigenTable extends PlateBasedAssayRunDataTable
     {
         super(schema, StorageProvisioner.createTableInfo(domain), cf, protocol);
         setDescription("Contains one row per well for the \"" + protocol.getName() + "\" ELISpot assay design.");
-        setTitle("Antigen");
+        setName("Antigen");
         this.setPublic(false);
 
         // Add column for AntigenStats heading

--- a/elispotassay/src/org/labkey/elispot/query/ElispotRunDataTable.java
+++ b/elispotassay/src/org/labkey/elispot/query/ElispotRunDataTable.java
@@ -37,10 +37,12 @@ import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssaySchema;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.plate.PlateReader;
+import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.util.HtmlString;
 import org.labkey.elispot.ElispotAssayProvider;
 import org.labkey.elispot.ElispotDataHandler;
 import org.labkey.elispot.ElispotManager;
+import org.labkey.elispot.ElispotProtocolSchema;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,6 +62,7 @@ public class ElispotRunDataTable extends PlateBasedAssayRunDataTable
     {
         super(schema, table, cf, protocol);
 
+        setName("Data");
         setDescription("Contains one row per sample for the \"" + protocol.getName() + "\" ELISpot assay design.");
 
         // display column for spot counts
@@ -117,18 +120,9 @@ public class ElispotRunDataTable extends PlateBasedAssayRunDataTable
             }
         }
 
-        var antigenLsidColumn = getMutableColumn("AntigenLsid");
+        var antigenLsidColumn = getMutableColumn(FieldKey.fromParts("AntigenLsid"));
         antigenLsidColumn.setLabel("Antigen");
-        antigenLsidColumn.setFk(new LookupForeignKey( (String)null, "AntigenName")
-        {
-            @Override
-            public TableInfo getLookupTableInfo()
-            {
-                // TODO ContainerFilter
-                return ElispotManager.getTableInfoElispotAntigen(_protocol);
-            }
-        });
-
+        antigenLsidColumn.setFk(QueryForeignKey.from(getUserSchema(), getContainerFilter()).to(ElispotProtocolSchema.ANTIGEN_TABLE_NAME, "AntigenLsid", null));
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48488)

There were errors setting table metadata (among other things) because the table names used were the physical or provisioned tables versus the `UserSchema` names. Also, there was a similar problem with `AntigenLsid` FK.