### PR TITLE
Eliminate use of deprecated LimitedUser() method

### DIFF
--- a/elisa/src/org/labkey/elisa/ElisaUpgradeCode.java
+++ b/elisa/src/org/labkey/elisa/ElisaUpgradeCode.java
@@ -46,7 +46,7 @@ public class ElisaUpgradeCode implements UpgradeCode
                     protocols.addAll(AssayService.get().getAssayProtocols(container));
             }
 
-            User upgradeUser = new LimitedUser(UserManager.getGuestUser(), new int[0], Collections.singleton(RoleManager.getRole(SiteAdminRole.class)), false);
+            User upgradeUser = new LimitedUser(UserManager.getGuestUser(), Collections.singleton(RoleManager.getRole(SiteAdminRole.class)));
             for (ExpProtocol protocol : protocols)
             {
                 AssayProvider provider = AssayService.get().getProvider(protocol);


### PR DESCRIPTION
#### Rationale
Use the simpler constructor that doesn't take an `int[]` parameter

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4721