### PR TITLE
Reduce DB queries by reusing study visits, NAb runs and sample props

### DIFF
--- a/nab/src/org/labkey/nab/NabAssayRun.java
+++ b/nab/src/org/labkey/nab/NabAssayRun.java
@@ -50,7 +50,7 @@ import java.util.Set;
 
 public abstract class NabAssayRun extends DilutionAssayRun
 {
-    public NabAssayRun(DilutionAssayProvider provider, ExpRun run,
+    public NabAssayRun(DilutionAssayProvider<?> provider, ExpRun run,
                        User user, List<Integer> cutoffs, StatsService.CurveFitType renderCurveFitType)
     {
         super(provider, run, user, cutoffs, renderCurveFitType);

--- a/nab/src/org/labkey/nab/SinglePlateNabDataHandler.java
+++ b/nab/src/org/labkey/nab/SinglePlateNabDataHandler.java
@@ -94,7 +94,7 @@ public class SinglePlateNabDataHandler extends NabDataHandler implements Transfo
     }
 
     @Override
-    protected DilutionAssayRun createDilutionAssayRun(DilutionAssayProvider provider, ExpRun run, List<Plate> plates, User user,
+    protected DilutionAssayRun createDilutionAssayRun(DilutionAssayProvider<?> provider, ExpRun run, List<Plate> plates, User user,
                                                       List<Integer> sortedCutoffs, StatsService.CurveFitType fit)
     {
         return new SinglePlateNabAssayRun(provider, run, plates.get(0), user, sortedCutoffs, fit);
@@ -175,7 +175,7 @@ public class SinglePlateNabDataHandler extends NabDataHandler implements Transfo
 
     // Excel can only handle single sheets so this helper class abstracts away creating the loader for a specific sheet.
     // In addition we need to configure the loaders differently for parsing a list of data versus a grid of data without headers.
-    protected abstract class Load
+    protected abstract static class Load
     {
         abstract DataLoader createList() throws IOException, ExperimentException;
         abstract DataLoader createGrid() throws IOException, ExperimentException;
@@ -313,11 +313,11 @@ public class SinglePlateNabDataHandler extends NabDataHandler implements Transfo
                             virusData.add(well);
                     }
                 }
-                applyDilution(virusData, sampleInput, properties, reverseDirection);
+                applyDilution(virusData, sampleInput, properties, reverseDirection, sampleProperties);
             }
         }
         else
-            applyDilution(wells, sampleInput, properties, reverseDirection);
+            applyDilution(wells, sampleInput, properties, reverseDirection, sampleProperties);
     }
 
     @Override
@@ -363,11 +363,11 @@ public class SinglePlateNabDataHandler extends NabDataHandler implements Transfo
                     AssayProvider provider = AssayService.get().getProvider(protocol);
                     AssayProtocolSchema protocolSchema = provider.createProtocolSchema(null, protocol.getContainer(), protocol, null);
                     TableInfo virusTable = protocolSchema.createTable(DilutionManager.VIRUS_TABLE_NAME, null);
-                    if (virusTable instanceof FilteredTable)
+                    if (virusTable instanceof FilteredTable ft)
                     {
                         if (virusTable.getColumn(FieldKey.fromParts(NabVirusDomainKind.DATLSID_COLUMN_NAME)) != null)
                         {
-                            TableInfo table = ((FilteredTable) virusTable).getRealTable();
+                            TableInfo table = ft.getRealTable();
                             SimpleFilter dataLsidFilter = new SimpleFilter(FieldKey.fromString(NabVirusDomainKind.DATLSID_COLUMN_NAME), data.getLSID());
 
                             // delete the rows in the virus table associated with this run

--- a/nab/src/org/labkey/nab/multiplate/CrossPlateDilutionNabAssayRun.java
+++ b/nab/src/org/labkey/nab/multiplate/CrossPlateDilutionNabAssayRun.java
@@ -36,10 +36,10 @@ import java.util.Map;
  */
 public class CrossPlateDilutionNabAssayRun extends NabAssayRun
 {
-    protected List<Plate> _plates;
-    private DilutionSummary[] _dilutionSummaries;
+    protected final List<Plate> _plates;
+    private final DilutionSummary[] _dilutionSummaries;
 
-    public CrossPlateDilutionNabAssayRun(DilutionAssayProvider provider, ExpRun run, List<Plate> plates,
+    public CrossPlateDilutionNabAssayRun(DilutionAssayProvider<?> provider, ExpRun run, List<Plate> plates,
                                          User user, List<Integer> cutoffs, StatsService.CurveFitType renderCurveFitType)
     {
         super(provider, run, user, cutoffs, renderCurveFitType);
@@ -52,18 +52,13 @@ public class CrossPlateDilutionNabAssayRun extends NabAssayRun
         {
             for (WellGroup sample : plate.getWellGroups(WellGroup.Type.SPECIMEN))
             {
-                List<WellGroup> groups = sampleGroups.get(sample.getName());
-                if (groups == null)
-                {
-                    groups = new ArrayList<>();
-                    sampleGroups.put(sample.getName(), groups);
-                }
+                List<WellGroup> groups = sampleGroups.computeIfAbsent(sample.getName(), k -> new ArrayList<>());
                 groups.add(sample);
             }
         }
         int index = 0;
         for (Map.Entry<String, List<WellGroup>> sample : sampleGroups.entrySet())
-            _dilutionSummaries[index++] = new DilutionSummary(this, sample.getValue(), null, _renderedCurveFitType);
+            _dilutionSummaries[index++] = new DilutionSummary(this, sample.getValue(), null, _renderedCurveFitType, run.getContainer());
     }
 
     @Override

--- a/nab/src/org/labkey/nab/multiplate/CrossPlateDilutionNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/CrossPlateDilutionNabDataHandler.java
@@ -49,7 +49,7 @@ public class CrossPlateDilutionNabDataHandler extends HighThroughputNabDataHandl
     }
 
     @Override
-    protected Map<ExpMaterial, List<WellGroup>> getMaterialWellGroupMapping(DilutionAssayProvider provider, List<Plate> plates, Map<ExpMaterial,String> sampleInputs) throws ExperimentException
+    protected Map<ExpMaterial, List<WellGroup>> getMaterialWellGroupMapping(DilutionAssayProvider<?> provider, List<Plate> plates, Map<ExpMaterial,String> sampleInputs) throws ExperimentException
     {
         Map<String, ExpMaterial> nameToMaterial = new HashMap<>();
         for (Map.Entry<ExpMaterial,String> e : sampleInputs.entrySet())
@@ -81,7 +81,7 @@ public class CrossPlateDilutionNabDataHandler extends HighThroughputNabDataHandl
     }
 
     @Override
-    protected DilutionAssayRun createDilutionAssayRun(DilutionAssayProvider provider, ExpRun run, List<Plate> plates, User user, List<Integer> sortedCutoffs, StatsService.CurveFitType fit)
+    protected DilutionAssayRun createDilutionAssayRun(DilutionAssayProvider<?> provider, ExpRun run, List<Plate> plates, User user, List<Integer> sortedCutoffs, StatsService.CurveFitType fit)
     {
         return new CrossPlateDilutionNabAssayRun(provider, run, plates, user, sortedCutoffs, fit);
     }

--- a/nab/src/org/labkey/nab/multiplate/HighThroughputNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/HighThroughputNabDataHandler.java
@@ -85,7 +85,7 @@ public abstract class HighThroughputNabDataHandler extends NabDataHandler implem
             final int expectedCols = template.getColumns();
 
             List<double[][]> matrices = parse(dataFile, loader.getColumns(), loader.load(), expectedRows, expectedCols);
-            if (matrices == null || matrices.size() == 0)
+            if (matrices == null || matrices.isEmpty())
                 throw createParseError(dataFile, "No plate data found");
 
             int plateNumber = 1;
@@ -184,11 +184,13 @@ public abstract class HighThroughputNabDataHandler extends NabDataHandler implem
         List<WellData> wells = new ArrayList<>();
         // All well groups use the same plate template, so it's okay to just check the dilution direction of the first group:
         boolean reverseDirection = Boolean.parseBoolean((String) groups.get(0).getProperty(SampleProperty.ReverseDilutionDirection.name()));
+
+        Map<PropertyDescriptor,Object> sampleProperties = sampleInput.getPropertyValues();
+
         for (WellGroup group : groups)
         {
-            Map<PropertyDescriptor,Object> map = sampleInput.getPropertyValues();
             for (DomainProperty property : properties.values())
-                group.setProperty(property.getName(), map.get(property.getPropertyDescriptor()));
+                group.setProperty(property.getName(), sampleProperties.get(property.getPropertyDescriptor()));
 
             boolean hasExplicitOrder = true;
             List<? extends WellData> wellData = group.getWellData(true);
@@ -230,7 +232,7 @@ public abstract class HighThroughputNabDataHandler extends NabDataHandler implem
             wells.addAll(wellData);
         }
 
-        applyDilution(wells, sampleInput, properties, reverseDirection);
+        applyDilution(wells, sampleInput, properties, reverseDirection, sampleProperties);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Rendering NAb run detail pages executes a bunch of redundant DB queries, fetching the experiment run and the sample properties.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4750

#### Changes
* Fetch sample properties outside of a `for` loop instead of inside
* Pass in the container instead of querying for it (many times) via the run
* Misc code cleanup