### PR TITLE
Use posts to go back in the Flow wizard

### DIFF
--- a/flow/src/org/labkey/flow/controllers/executescript/ImportAnalysisForm.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/ImportAnalysisForm.java
@@ -37,6 +37,7 @@ public class ImportAnalysisForm implements HasAllowBindParameter
     
     // unicode small comma (probably not in the gate name so is safer than comma as a separator char in LovCombo)
     public static final String PARAMETER_SEPARATOR = "\ufe50";
+    private boolean goBack = false;
 
     public enum SelectFCSFileOption implements SafeToRenderEnum
     {
@@ -205,6 +206,16 @@ public class ImportAnalysisForm implements HasAllowBindParameter
     public void setConfirm(boolean confirm)
     {
         this.confirm = confirm;
+    }
+
+    public boolean isGoBack()
+    {
+        return goBack;
+    }
+
+    public void setGoBack(boolean goBack)
+    {
+        this.goBack = goBack;
     }
 
 

--- a/flow/src/org/labkey/flow/controllers/executescript/importAnalysis.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/importAnalysis.jsp
@@ -25,6 +25,7 @@
 <%@ page import="java.util.Iterator" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="static org.labkey.flow.controllers.executescript.AnalysisScriptController.ImportAnalysisStep.CONFIRM" %>
+<%@ page import="static org.labkey.flow.controllers.executescript.AnalysisScriptController.BACK_BUTTON_ACTION" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -106,11 +107,12 @@
         }
     %>
 
+<input type="hidden" name="goBack" id="goBack" value="false">
 <% if (form.getWizardStep().getNumber() < CONFIRM.getNumber()) { %>
 <p>
     <%= button("Cancel").href(cancelUrl) %>
     &nbsp;&nbsp;
-    <%=generateBackButton()%>
+    <%= button("Back").submit(true).primary(false).onClick(BACK_BUTTON_ACTION) %>
     <%= button("Next").submit(true) %>
 </p>
 
@@ -122,7 +124,7 @@
 <p>
     <%= button("Cancel").href(cancelUrl) %>
     &nbsp;&nbsp;
-    <%=generateBackButton()%>
+    <%= button("Back").submit(true).primary(false).onClick(BACK_BUTTON_ACTION) %>
     <%= button("Next").submit(true) %>
 </p>
     

--- a/flow/src/org/labkey/flow/controllers/executescript/importAnalysisConfirm.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/importAnalysisConfirm.jsp
@@ -24,7 +24,6 @@
 <%@ page import="org.labkey.api.portal.ProjectUrls" %>
 <%@ page import="org.labkey.api.query.FieldKey" %>
 <%@ page import="org.labkey.api.query.QueryAction" %>
-<%@ page import="org.labkey.api.query.QueryParam" %>
 <%@ page import="org.labkey.api.query.QueryView" %>
 <%@ page import="org.labkey.api.study.Study" %>
 <%@ page import="org.labkey.api.study.StudyService" %>
@@ -32,19 +31,17 @@
 <%@ page import="org.labkey.api.view.ViewContext" %>
 <%@ page import="org.labkey.flow.analysis.model.ISampleInfo" %>
 <%@ page import="org.labkey.flow.analysis.model.IWorkspace" %>
-<%@ page import="org.labkey.flow.controllers.executescript.AnalysisEngine" %>
 <%@ page import="org.labkey.flow.controllers.executescript.ImportAnalysisForm" %>
 <%@ page import="org.labkey.flow.controllers.executescript.SelectedSamples" %>
 <%@ page import="org.labkey.flow.data.FlowExperiment" %>
-<%@ page import="org.labkey.flow.data.FlowRun" %>
 <%@ page import="org.labkey.flow.query.FlowSchema" %>
 <%@ page import="org.labkey.flow.query.FlowTableType" %>
-<%@ page import="java.io.File" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.HashSet" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.Set" %>
+<%@ page import="static org.labkey.flow.controllers.executescript.AnalysisScriptController.BACK_BUTTON_ACTION" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     ImportAnalysisForm form = (ImportAnalysisForm)getModelBean();
@@ -189,6 +186,6 @@
 <p>
     <%= button("Cancel").href(cancelUrl) %>
     &nbsp;&nbsp;
-    <%=generateBackButton()%>
+    <%= button("Back").submit(true).primary(false).onClick(BACK_BUTTON_ACTION) %>
     <%= button("Finish").submit(true) %>
 </p>


### PR DESCRIPTION
#### Rationale
[Issue 48203: Flow import analysis workflow: Selecting BACK button results in "Confirm Form Resubmission" page error](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48203)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4793

#### Changes
* Make the back buttons do a POST of the form 