### PR TITLE
Move material query out from loop for nab views

### DIFF
--- a/nab/src/org/labkey/nab/NabAssayController.java
+++ b/nab/src/org/labkey/nab/NabAssayController.java
@@ -137,6 +137,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * User: jeckels
@@ -1272,11 +1273,22 @@ public class NabAssayController extends SpringActionController
                 }
 
                 DbSchema schema = DilutionManager.getSchema();
-                for (WellDataRow well : DilutionManager.getExcludedWellDataRows(run))
+
+                List<WellDataRow> wells = DilutionManager.getExcludedWellDataRows(run);
+                Set<String> specimenLsids = new HashSet<>();
+                for (WellDataRow well : wells)
+                {
+                    specimenLsids.add(well.getSpecimenLsid());
+                }
+
+                Map<String, ExpMaterial> specimenMaterials = ExperimentService.get().getExpMaterialsByLsid(specimenLsids)
+                        .stream().collect(Collectors.toMap(ExpMaterial::getLSID, material -> material));
+
+                for (WellDataRow well : wells)
                 {
                     // need the specimen name
                     String specimenName = null;
-                    ExpMaterial material = ExperimentService.get().getExpMaterial(well.getSpecimenLsid());
+                    ExpMaterial material = specimenMaterials.get(well.getSpecimenLsid());
                     if (material != null)
                     {
                         // try to find the specimen id entered for this run

--- a/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabDataHandler.java
@@ -45,9 +45,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * User: klum
@@ -212,6 +215,19 @@ public class SinglePlateDilutionNabDataHandler extends HighThroughputNabDataHand
         for (int nabSpecimenId : dataObjectIds)
             nabSpecimenIds.add(nabSpecimenId);
         List<NabSpecimen> nabSpecimens = NabManager.get().getNabSpecimens(nabSpecimenIds);
+
+        Set<String> specimenLsids = new HashSet<>();
+        for (NabSpecimen nabSpecimen : nabSpecimens)
+        {
+            String wellgroupName = nabSpecimen.getWellgroupName();
+            String specimenLsid = nabSpecimen.getSpecimenLsid();
+
+            if (wellgroupName != null || specimenLsid != null)
+                specimenLsids.add(specimenLsid);
+        }
+
+        Map<String, ExpMaterial> specimenMaterials = ExperimentService.get().getExpMaterialsByLsid(specimenLsids)
+                .stream().collect(Collectors.toMap(ExpMaterial::getLSID, material -> material));
         for (NabSpecimen nabSpecimen : nabSpecimens)
         {
             String wellgroupName = nabSpecimen.getWellgroupName();
@@ -222,7 +238,7 @@ public class SinglePlateDilutionNabDataHandler extends HighThroughputNabDataHand
                 continue;
 
             // get the virus name from the material input
-            ExpMaterial inputMaterial = ExperimentService.get().getExpMaterial(specimenLsid);
+            ExpMaterial inputMaterial = specimenMaterials.get(specimenLsid);
             if (inputMaterial != null)
             {
                 for (Map.Entry<PropertyDescriptor, Object> entry : inputMaterial.getPropertyValues().entrySet())


### PR DESCRIPTION
#### Rationale
datadog review reveals that nabassay specimen is queried in a loop. This PR moves the query for material out of the loop.

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/666
* https://github.com/LabKey/platform/pull/4875

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
