### PR TITLE
Backport: Don't show delete option (#671)

### DIFF
--- a/flow/src/org/labkey/flow/view/FlowQueryView.java
+++ b/flow/src/org/labkey/flow/view/FlowQueryView.java
@@ -205,6 +205,13 @@ public class FlowQueryView extends QueryView
     }
 
     @Override
+    public boolean showDeleteButton()
+    {
+        // Don't allow delete for individual FCS files or for wsp samples (which we represent as FCSAnalyses)
+        return !(getSettings().getQueryName().equalsIgnoreCase(FlowTableType.FCSFiles.name()) || getSettings().getQueryName().equalsIgnoreCase(FlowTableType.FCSAnalyses.name()));
+    }
+
+    @Override
     protected URLHelper urlChangeView()
     {
         URLHelper ret = super.urlChangeView();


### PR DESCRIPTION
#### Rationale
Back port https://github.com/LabKey/commonAssays/pull/671 to snapshot branch

#### Changes
* hide delete button when looking at flow FCS and analysis files/samples