### PR TITLE
Override the delete button for runs to confirm if data is being used

### DIFF
--- a/flow/src/org/labkey/flow/controllers/run/RunController.java
+++ b/flow/src/org/labkey/flow/controllers/run/RunController.java
@@ -33,6 +33,7 @@ import org.labkey.api.attachments.BaseDownloadAction;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.RowMapFactory;
+import org.labkey.api.data.Container;
 import org.labkey.api.data.DataRegionSelection;
 import org.labkey.api.data.TSVMapWriter;
 import org.labkey.api.data.TSVWriter;
@@ -82,6 +83,7 @@ import org.labkey.flow.data.FlowRun;
 import org.labkey.flow.data.FlowWell;
 import org.labkey.flow.persist.AnalysisSerializer;
 import org.labkey.flow.persist.AttributeSet;
+import org.labkey.flow.query.FlowTableType;
 import org.labkey.flow.view.ExportAnalysisForm;
 import org.labkey.flow.view.ExportAnalysisManifest;
 import org.springframework.validation.BindException;
@@ -196,6 +198,20 @@ public class RunController extends BaseFlowController
                 root.addChild(experiment.getLabel(), experiment.urlShow());
 
             root.addChild("Runs");
+        }
+
+        public static ActionURL getFcsFileRunsURL(Container c)
+        {
+            return new ActionURL(RunController.ShowRunsAction.class, c)
+                    .addParameter("query.FCSFileCount~neq", 0)
+                    .addParameter("query.ProtocolStep~eq", "Keywords")
+                    .addParameter("runTableType", FlowTableType.FCSFiles.name());
+        }
+        public static ActionURL getFCSAnalysisRunsURL(Container c)
+        {
+            return new ActionURL(RunController.ShowRunsAction.class, c)
+                .addParameter("query.FCSAnalysisCount~neq", 0)
+                .addParameter("runTableType", FlowTableType.FCSAnalyses.name());
         }
     }
 

--- a/flow/src/org/labkey/flow/controllers/run/RunController.java
+++ b/flow/src/org/labkey/flow/controllers/run/RunController.java
@@ -49,7 +49,6 @@ import org.labkey.api.pipeline.PipelineValidationException;
 import org.labkey.api.security.RequiresLogin;
 import org.labkey.api.security.RequiresNoPermission;
 import org.labkey.api.security.RequiresPermission;
-import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.FileNameUniquifier;
@@ -83,7 +82,6 @@ import org.labkey.flow.data.FlowRun;
 import org.labkey.flow.data.FlowWell;
 import org.labkey.flow.persist.AnalysisSerializer;
 import org.labkey.flow.persist.AttributeSet;
-import org.labkey.flow.query.FlowQueryForm;
 import org.labkey.flow.view.ExportAnalysisForm;
 import org.labkey.flow.view.ExportAnalysisManifest;
 import org.springframework.validation.BindException;
@@ -203,42 +201,6 @@ public class RunController extends BaseFlowController
             root.addChild("Runs");
         }
     }
-
-//    @RequiresLogin
-//    @RequiresPermission(ReadPermission.class)
-//    public class DeleteAction extends FormViewAction<RunsForm>
-//    {
-//
-//        @Override
-//        public void validateCommand(RunsForm target, Errors errors)
-//        {
-//
-//        }
-//
-//        @Override
-//        public ModelAndView getView(RunsForm runsForm, boolean reshow, BindException errors) throws Exception
-//        {
-//            return new ConfirmDeleteView;
-//        }
-//
-//        @Override
-//        public boolean handlePost(RunsForm runsForm, BindException errors) throws Exception
-//        {
-//            return false;
-//        }
-//
-//        @Override
-//        public URLHelper getSuccessURL(RunsForm runsForm)
-//        {
-//            return null;
-//        }
-//
-//        @Override
-//        public void addNavTrail(NavTree root)
-//        {
-//
-//        }
-//    }
 
         @RequiresLogin
     @RequiresPermission(ReadPermission.class)

--- a/flow/src/org/labkey/flow/controllers/run/RunController.java
+++ b/flow/src/org/labkey/flow/controllers/run/RunController.java
@@ -49,6 +49,7 @@ import org.labkey.api.pipeline.PipelineValidationException;
 import org.labkey.api.security.RequiresLogin;
 import org.labkey.api.security.RequiresNoPermission;
 import org.labkey.api.security.RequiresPermission;
+import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.FileNameUniquifier;
@@ -82,6 +83,7 @@ import org.labkey.flow.data.FlowRun;
 import org.labkey.flow.data.FlowWell;
 import org.labkey.flow.persist.AnalysisSerializer;
 import org.labkey.flow.persist.AttributeSet;
+import org.labkey.flow.query.FlowQueryForm;
 import org.labkey.flow.view.ExportAnalysisForm;
 import org.labkey.flow.view.ExportAnalysisManifest;
 import org.springframework.validation.BindException;
@@ -202,8 +204,43 @@ public class RunController extends BaseFlowController
         }
     }
 
+//    @RequiresLogin
+//    @RequiresPermission(ReadPermission.class)
+//    public class DeleteAction extends FormViewAction<RunsForm>
+//    {
+//
+//        @Override
+//        public void validateCommand(RunsForm target, Errors errors)
+//        {
+//
+//        }
+//
+//        @Override
+//        public ModelAndView getView(RunsForm runsForm, boolean reshow, BindException errors) throws Exception
+//        {
+//            return new ConfirmDeleteView;
+//        }
+//
+//        @Override
+//        public boolean handlePost(RunsForm runsForm, BindException errors) throws Exception
+//        {
+//            return false;
+//        }
+//
+//        @Override
+//        public URLHelper getSuccessURL(RunsForm runsForm)
+//        {
+//            return null;
+//        }
+//
+//        @Override
+//        public void addNavTrail(NavTree root)
+//        {
+//
+//        }
+//    }
 
-    @RequiresLogin
+        @RequiresLogin
     @RequiresPermission(ReadPermission.class)
     public class DownloadAction extends SimpleViewAction<DownloadRunForm>
     {

--- a/flow/src/org/labkey/flow/controllers/run/RunController.java
+++ b/flow/src/org/labkey/flow/controllers/run/RunController.java
@@ -202,7 +202,7 @@ public class RunController extends BaseFlowController
         }
     }
 
-        @RequiresLogin
+    @RequiresLogin
     @RequiresPermission(ReadPermission.class)
     public class DownloadAction extends SimpleViewAction<DownloadRunForm>
     {

--- a/flow/src/org/labkey/flow/controllers/run/RunsForm.java
+++ b/flow/src/org/labkey/flow/controllers/run/RunsForm.java
@@ -36,6 +36,7 @@ public class RunsForm extends FlowQueryForm
     private int _experimentId;
     private int _scriptId;
 
+    private FlowTableType _runTableType;
     public int getExperimentId()
     {
         return _experimentId;
@@ -54,6 +55,16 @@ public class RunsForm extends FlowQueryForm
     public void setScriptId(int scriptId)
     {
         _scriptId = scriptId;
+    }
+
+    public FlowTableType getRunTableType()
+    {
+        return _runTableType;
+    }
+
+    public void setRunTableType(FlowTableType runTableType)
+    {
+        _runTableType = runTableType;
     }
 
     @Override
@@ -83,6 +94,15 @@ public class RunsForm extends FlowQueryForm
     public QuerySettings createQuerySettings(UserSchema schema)
     {
         QuerySettings ret = super.createQuerySettings(schema);
+        if (getRunTableType() == FlowTableType.FCSAnalyses)
+        {
+            ret.setSelectionKey(FlowTableType.FCSAnalyses.name());
+        }
+        else if (getRunTableType() == FlowTableType.FCSFiles)
+        {
+            ret.setSelectionKey(FlowTableType.FCSFiles.name());
+        }
+
         if (ret.getQueryName() == null)
         {
             ret.setQueryName(FlowTableType.Runs.toString());

--- a/flow/src/org/labkey/flow/query/FlowQuerySettings.java
+++ b/flow/src/org/labkey/flow/query/FlowQuerySettings.java
@@ -26,7 +26,6 @@ public class FlowQuerySettings extends QuerySettings
     }
 
     private ShowGraphs _showGraphs;
-    private boolean _subtractBackground;
 
     protected FlowQuerySettings(String dataRegionName)
     {
@@ -63,7 +62,6 @@ public class FlowQuerySettings extends QuerySettings
                 }
             }
         }
-        _subtractBackground = _getParameter(param("subtractBackground")) != null;
     }
 
     public ShowGraphs getShowGraphs()
@@ -73,15 +71,5 @@ public class FlowQuerySettings extends QuerySettings
     public void setShowGraphs(ShowGraphs showGraphs)
     {
         _showGraphs = showGraphs;
-    }
-
-    public boolean getSubtractBackground()
-    {
-        return _subtractBackground;
-    }
-
-    public void setSubtractBackground(boolean subtractBackground)
-    {
-        _subtractBackground = subtractBackground;
     }
 }

--- a/flow/src/org/labkey/flow/view/FlowQueryView.java
+++ b/flow/src/org/labkey/flow/view/FlowQueryView.java
@@ -26,8 +26,11 @@ import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.MenuButton;
 import org.labkey.api.data.PanelButton;
 import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.portal.ProjectUrls;
+import org.labkey.api.query.QueryAction;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.InsertPermission;
@@ -223,6 +226,19 @@ public class FlowQueryView extends QueryView
     public FlowSchema getSchema()
     {
         return (FlowSchema) super.getSchema();
+    }
+
+    @Override
+    public boolean showDeleteButtonConfirmationText()
+    {
+        return !getSettings().getQueryName().equalsIgnoreCase(FlowTableType.Runs.name());
+    }
+
+    @Override
+    public ActionButton createDeleteButton(boolean showConfirmation)
+    {
+        setDeleteURL(ExperimentUrls.get().getDeleteSelectedExpRunsURL(getContainer(), getReturnURL()).toContainerRelativeURL());
+        return super.createDeleteButton(showConfirmation);
     }
 
     @Override

--- a/flow/src/org/labkey/flow/view/FlowQueryView.java
+++ b/flow/src/org/labkey/flow/view/FlowQueryView.java
@@ -202,11 +202,6 @@ public class FlowQueryView extends QueryView
         }
     }
 
-    protected boolean subtractBackground()
-    {
-        return getSettings().getSubtractBackground();
-    }
-
     @Override
     public boolean showDeleteButton()
     {

--- a/flow/src/org/labkey/flow/view/FlowQueryView.java
+++ b/flow/src/org/labkey/flow/view/FlowQueryView.java
@@ -237,7 +237,14 @@ public class FlowQueryView extends QueryView
     @Override
     public ActionButton createDeleteButton(boolean showConfirmation)
     {
-        setDeleteURL(ExperimentUrls.get().getDeleteSelectedExpRunsURL(getContainer(), getReturnURL()).toContainerRelativeURL());
+        return createDeleteButton(showConfirmation, true);
+    }
+
+    protected ActionButton createDeleteButton(boolean showConfirmation, boolean useExpRunsURL)
+    {
+        // The Analysis "folder" table needs to use the getDeleteProtocolURL, the FCSRuns and FCSAnalysis 'views' need the getDeleteSelectedExpRunsURL
+        if (useExpRunsURL)
+            setDeleteURL(ExperimentUrls.get().getDeleteSelectedExpRunsURL(getContainer(), getReturnURL()).toContainerRelativeURL());
         return super.createDeleteButton(showConfirmation);
     }
 

--- a/flow/src/org/labkey/flow/webparts/AnalysesWebPart.java
+++ b/flow/src/org/labkey/flow/webparts/AnalysesWebPart.java
@@ -85,4 +85,9 @@ public class AnalysesWebPart extends FlowQueryView
         }
     }
 
+    @Override
+    public ActionButton createDeleteButton(boolean showConfirmation)
+    {
+        return super.createDeleteButton(showConfirmation, false);
+    }
 }

--- a/flow/src/org/labkey/flow/webparts/FlowOverview.java
+++ b/flow/src/org/labkey/flow/webparts/FlowOverview.java
@@ -165,9 +165,7 @@ public class FlowOverview extends Overview
             ActionURL urlShowFCSFiles = FlowTableType.FCSFiles.urlFor(getUser(), getContainer(), QueryAction.executeQuery)
                     .addParameter("query.Original~eq", "true");
             status.append("<a href=\"").append(h(urlShowFCSFiles)).append("\">").append(_fcsFileCount).append(" FCS files</a> have been imported.");
-            ActionURL urlShowRuns = new ActionURL(RunController.ShowRunsAction.class, getContainer())
-                    .addParameter("query.FCSFileCount~neq", 0)
-                    .addParameter("query.ProtocolStep~eq", "Keywords");
+            ActionURL urlShowRuns = RunController.ShowRunsAction.getFcsFileRunsURL(getContainer());
             if (_fcsRunCount == 1)
             {
                 status.append(" These are in <a href=\"").append(h(urlShowRuns)).append("\">1 run</a>.");

--- a/flow/src/org/labkey/flow/webparts/FlowSummary.jsp
+++ b/flow/src/org/labkey/flow/webparts/FlowSummary.jsp
@@ -86,11 +86,8 @@
     FlowExperiment[] _experiments = FlowExperiment.getAnalysesAndWorkspace(c);
     Arrays.sort(_experiments);
 
-    ActionURL fcsFileRunsURL = new ActionURL(RunController.ShowRunsAction.class, c)
-            .addParameter("query.FCSFileCount~neq", 0)
-            .addParameter("query.ProtocolStep~eq", "Keywords");
-    ActionURL fcsAnalysisRunsURL = new ActionURL(RunController.ShowRunsAction.class, c)
-            .addParameter("query.FCSAnalysisCount~neq", 0);
+    ActionURL fcsFileRunsURL = RunController.ShowRunsAction.getFcsFileRunsURL(c);
+    ActionURL fcsAnalysisRunsURL = RunController.ShowRunsAction.getFCSAnalysisRunsURL(c);
     ActionURL compMatricesURL = FlowTableType.CompensationMatrices.urlFor(user, c, QueryAction.executeQuery);
 
     final int DISPLAY_MAX_ROWS = 15;


### PR DESCRIPTION
#### Rationale
[Issue 48308: Flow: warn when deleting flow run with fcs files linked to study](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48308)

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/1713

#### Changes
* Overrode the delete button's action url
