### PR TITLE
Issue 49036: NAb PercentNeutralizationInitialDilution calculation incorrect for sample with method Concentration instead of Dilution

### DIFF
--- a/nab/src/org/labkey/nab/query/NabProtocolSchema.java
+++ b/nab/src/org/labkey/nab/query/NabProtocolSchema.java
@@ -200,7 +200,7 @@ public class NabProtocolSchema extends AssayProtocolSchema
 
             if (DilutionManager.NAB_SPECIMEN_TABLE_NAME.equalsIgnoreCase(tableType))
             {
-                return new NAbSpecimenTable(this, cf);
+                return new NAbSpecimenTable(this, cf, getProtocol());
             }
 
             if (DilutionManager.WELL_DATA_TABLE_NAME.equalsIgnoreCase(tableType))

--- a/nab/src/org/labkey/nab/query/NabRunDataTable.java
+++ b/nab/src/org/labkey/nab/query/NabRunDataTable.java
@@ -75,7 +75,7 @@ public class NabRunDataTable extends NabBaseTable
 
     public NabRunDataTable(final NabProtocolSchema schema, ContainerFilter cf, final ExpProtocol protocol)
     {
-        super(schema, new NAbSpecimenTable(schema, cf), cf, protocol);
+        super(schema, new NAbSpecimenTable(schema, cf, protocol), cf, protocol);
         _nabSpecimenTable = (NAbSpecimenTable) getRealTable();
 
         final AssayProvider provider = AssayService.get().getProvider(protocol);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49036
- backport from 23.7

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4936

#### Changes
* join from nab.NabSpecimen table to the sample type table to match on the InitialDilution value
