### PR TITLE
Replace deprecated buildDir with layout.buildDirectory

### DIFF
--- a/flow/build.gradle
+++ b/flow/build.gradle
@@ -7,7 +7,7 @@ plugins {
 sourceSets {
     engine {
         java {
-            srcDirs = ['./enginesrc', "$project.buildDir/xb"]
+            srcDirs = ['./enginesrc', "${BuildUtils.getBuildDirPath(project)}/xb"]
         }
     }
 }
@@ -35,7 +35,7 @@ project.tasks.register("engineJar", Jar) {
         jar.archiveClassifier.set("engine")
         jar.from project.sourceSets.engine.output
         jar.archiveBaseName.set("${project.name}_engine")
-        jar.destinationDirectory = project.file(project.labkey.explodedModuleLibDir)
+        jar.destinationDirectory.set(project.file(project.labkey.explodedModuleLibDir))
         jar.dependsOn(project.tasks.schemasCompile)
 }
 


### PR DESCRIPTION
#### Rationale
In Gradle 8.3, the use of `project.buildDir` was [deprecated](https://docs.gradle.org/current/userguide/upgrading_version_8.html#project_builddir) in favor of `project.layout.buildDirectory`.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/185

#### Changes
* Replace usage of `buildDir`
* use `set` method for setting `destinationDirectory`
