### PR TITLE
Remove inline script from peptide/protein compare

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -715,7 +715,6 @@ ms2/src/org/labkey/ms2/pipeline/MS2PipelineManager.java -text
 ms2/src/org/labkey/ms2/pipeline/MS2PipelineProvider.java -text
 ms2/src/org/labkey/ms2/pipeline/MS2SearchForm.java -text
 ms2/src/org/labkey/ms2/pipeline/MS2SearchJobSupport.java -text
-ms2/src/org/labkey/ms2/pipeline/MSPictureUpgradeJob.java -text
 ms2/src/org/labkey/ms2/pipeline/PipelineController.java -text
 ms2/src/org/labkey/ms2/pipeline/ProteinProphetPipelineJob.java -text
 ms2/src/org/labkey/ms2/pipeline/ProteinProphetPipelineProvider.java -text
@@ -725,7 +724,6 @@ ms2/src/org/labkey/ms2/pipeline/SearchServiceImpl.java -text
 ms2/src/org/labkey/ms2/pipeline/Sqt2PinTask.java -text
 ms2/src/org/labkey/ms2/pipeline/TPPTask.java -text
 ms2/src/org/labkey/ms2/pipeline/UnknownMS2Run.java -text
-ms2/src/org/labkey/ms2/pipeline/attachMSPictureFiles.jsp -text
 ms2/src/org/labkey/ms2/pipeline/comet/Comet2014ParamsBuilder.java -text
 ms2/src/org/labkey/ms2/pipeline/comet/Comet2015ParamsBuilder.java -text
 ms2/src/org/labkey/ms2/pipeline/comet/CometDefaults.xml -text

--- a/ms2/src/org/labkey/ms2/compare/comparePeptideQueryOptions.jsp
+++ b/ms2/src/org/labkey/ms2/compare/comparePeptideQueryOptions.jsp
@@ -21,6 +21,11 @@
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.ms2.MS2Controller" %>
 <%@ page import="org.labkey.ms2.query.FilterView" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.peptideProphetProbability" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.peptideFilterType" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.ProphetFilterType.probability" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.ProphetFilterType.customView" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.targetProtein" %>
 <%@ page extends="org.labkey.api.jsp.JspBase"%>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -36,9 +41,9 @@ String peptideViewName = form.getPeptideCustomViewName(getViewContext());
     <input name="runList" type="hidden" value="<%= bean.getRunList() %>" />
     <input name="<%= MS2Controller.PeptideFilteringFormElements.targetURL %>" type="hidden" value="<%=h(bean.getTargetURL())%>" />
     <p>Peptides to include in the comparison:</p>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.peptideFilterType %>" value="<%= MS2Controller.ProphetFilterType.none %>"<%=checked(form.isNoPeptideFilter())%> /> All peptides</div>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.peptideFilterType %>" id="peptideProphetRadioButton" value="<%= MS2Controller.ProphetFilterType.probability %>"<%=checked(form.isPeptideProphetFilter())%>/> Peptides with PeptideProphet probability &ge; <input onfocus="document.getElementById('peptideProphetRadioButton').checked=true;" type="text" size="2" name="<%= MS2Controller.PeptideFilteringFormElements.peptideProphetProbability %>" value="<%=h(form.getPeptideProphetProbability())%>" /></div>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.peptideFilterType %>" id="<%= text(FilterView.PEPTIDES_CUSTOM_VIEW_RADIO_BUTTON) %>" value="<%= MS2Controller.ProphetFilterType.customView %>"<%=checked(form.isCustomViewPeptideFilter())%>/>
+    <div class="labkey-indented"><input type="radio" name="<%= peptideFilterType %>" value="<%= MS2Controller.ProphetFilterType.none %>"<%=checked(form.isNoPeptideFilter())%> /> All peptides</div>
+    <div class="labkey-indented"><input type="radio" name="<%= peptideFilterType %>" id="peptideProphetRadioButton" value="<%= probability %>"<%=checked(form.isPeptideProphetFilter())%>/> Peptides with PeptideProphet probability &ge; <input type="text" size="2" id="<%= peptideProphetProbability %>" name="<%= peptideProphetProbability %>" value="<%=h(form.getPeptideProphetProbability())%>" /></div>
+    <div class="labkey-indented"><input type="radio" name="<%= peptideFilterType %>" id="<%= text(FilterView.PEPTIDES_CUSTOM_VIEW_RADIO_BUTTON) %>" value="<%= customView %>"<%=checked(form.isCustomViewPeptideFilter())%>/>
         Peptides that meet the filter criteria in a custom grid:
         <% String peptideViewSelectId = bean.getPeptideView().renderViewList(request, out, peptideViewName); %>
         <%=link("Create or Edit").onClick("showViewDesigner('" + org.labkey.ms2.query.MS2Schema.HiddenTableType.PeptidesFilter + "', 'peptidesCustomizeView', " + PageFlowUtil.jsString(peptideViewSelectId) + "); return false;") %>
@@ -49,9 +54,14 @@ String peptideViewName = form.getPeptideCustomViewName(getViewContext());
     </div>
     <hr/>
     <p>
-        Optionally require that peptides have a sequence match in protein: <input type="text" size="30" name="<%= MS2Controller.PeptideFilteringFormElements.targetProtein %>" value="<%= h(form.getTargetProtein()==null ? "" : form.getTargetProtein()) %>" />
+        Optionally require that peptides have a sequence match in protein: <input type="text" size="30" name="<%= targetProtein %>" value="<%= h(form.getTargetProtein()==null ? "" : form.getTargetProtein()) %>" />
         <%=helpPopup("Protein Filter", "<p>Show only peptides whose sequences match against a specified protein. It need not be the protein mapped to the peptide by the search engine or ProteinProphet.</p><p>If no protein matches the name specified, or if multiple proteins match, this page will be redisplayed to correct the search.</p>", true)%>
     </p>
 
     <p><labkey:button text="Compare"/></p>
 </labkey:form>
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
+    LABKEY.Utils.onReady(function() {
+        document.getElementById('<%=peptideProphetProbability%>')['onfocus'] = function() { document.getElementById('peptideProphetRadioButton').checked = true; };
+    });
+</script>

--- a/ms2/src/org/labkey/ms2/compare/compareProteinProphetQueryOptions.jsp
+++ b/ms2/src/org/labkey/ms2/compare/compareProteinProphetQueryOptions.jsp
@@ -21,6 +21,20 @@
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.ms2.MS2Controller" %>
 <%@ page import="org.labkey.ms2.query.FilterView" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.proteinProphetProbability" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.peptideProphetProbability" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.proteinGroupFilterType" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.peptideFilterType" %>
+<%@ page import="static org.labkey.ms2.query.MS2Schema.HiddenTableType.ProteinGroupsFilter" %>
+<%@ page import="static org.labkey.ms2.query.MS2Schema.HiddenTableType.PeptidesFilter" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.ProphetFilterType.customView" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.ProphetFilterType.probability" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.pivotType" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.orCriteriaForEachRun" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PivotType.run" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PivotType.fraction" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.ProphetFilterType.none" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.targetURL" %>
 <%@ page extends="org.labkey.api.jsp.JspBase"%>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -35,17 +49,17 @@ String proteinGroupViewName = form.getProteinGroupCustomViewName(getViewContext(
 
 <labkey:form action="<%= new ActionURL(MS2Controller.ProteinDisambiguationRedirectAction.class, getContainer()) %>" name="peptideFilterForm">
     <input name="runList" type="hidden" value="<%= bean.getRunList() %>" />
-    <input name="<%= MS2Controller.PeptideFilteringFormElements.targetURL %>" type="hidden" value="<%=h(bean.getTargetURL())%>" />
+    <input name="<%= targetURL %>" type="hidden" value="<%=h(bean.getTargetURL())%>" />
     <p>This comparison view is based on ProteinProphet data so the runs must be associated with ProteinProphet data.
         All proteins in all ProteinProphet protein groups will be shown in the comparison, subject to the filter criteria.</p>
     <p style="width:100%" class="labkey-title-area-line"></p>
     <p>Protein groups to use in the comparison:</p>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.proteinGroupFilterType %>" value="<%= MS2Controller.ProphetFilterType.none %>"<%=checked(form.isNoProteinGroupFilter())%>/> All protein groups</div>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.proteinGroupFilterType %>" id="proteinProphetRadioButton" value="<%= MS2Controller.ProphetFilterType.probability %>"<%=checked(form.isProteinProphetFilter())%>/> Protein groups with ProteinProphet probability &ge; <input onfocus="document.getElementById('proteinProphetRadioButton').checked=true;" type="text" size="2" name="<%= MS2Controller.PeptideFilteringFormElements.proteinProphetProbability %>" value="<%=h(form.getProteinProphetProbability())%>" /></div>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.proteinGroupFilterType %>" id="<%= text(FilterView.PROTEIN_GROUPS_CUSTOM_VIEW_RADIO_BUTTON) %>" value="<%= MS2Controller.ProphetFilterType.customView %>"<%=checked(form.isCustomViewProteinGroupFilter())%>/>
+    <div class="labkey-indented"><input type="radio" name="<%= proteinGroupFilterType %>" value="<%= none %>"<%=checked(form.isNoProteinGroupFilter())%>/> All protein groups</div>
+    <div class="labkey-indented"><input type="radio" name="<%= proteinGroupFilterType %>" id="proteinProphetRadioButton" value="<%= probability %>"<%=checked(form.isProteinProphetFilter())%>/> Protein groups with ProteinProphet probability &ge; <input type="text" size="2" id="<%= proteinProphetProbability %>" name="<%= proteinProphetProbability %>" value="<%=h(form.getProteinProphetProbability())%>" /></div>
+    <div class="labkey-indented"><input type="radio" name="<%= proteinGroupFilterType %>" id="<%= text(FilterView.PROTEIN_GROUPS_CUSTOM_VIEW_RADIO_BUTTON) %>" value="<%= customView %>"<%=checked(form.isCustomViewProteinGroupFilter())%>/>
         Protein groups that meet the filter criteria in a custom view:
         <% String proteinGroupViewSelectId = bean.getProteinGroupView().renderViewList(request, out, proteinGroupViewName); %>
-        <%=link("Create or Edit View").onClick("showViewDesigner('" + org.labkey.ms2.query.MS2Schema.HiddenTableType.ProteinGroupsFilter + "', 'proteinGroupsCustomizeView', " + PageFlowUtil.jsString(proteinGroupViewSelectId) + "); return false;").id("editProteinGroupsViewLink") %>
+        <%=link("Create or Edit View").onClick("showViewDesigner('" + ProteinGroupsFilter + "', 'proteinGroupsCustomizeView', " + PageFlowUtil.jsString(proteinGroupViewSelectId) + "); return false;").id("editProteinGroupsViewLink") %>
 
         <br/>
         <br/>
@@ -53,12 +67,12 @@ String proteinGroupViewName = form.getProteinGroupCustomViewName(getViewContext(
     </div>
     <p style="width:100%" class="labkey-title-area-line"></p>
     <p>Peptide requirements for the protein groups:</p>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.peptideFilterType %>" value="<%= MS2Controller.ProphetFilterType.none %>"<%=checked(form.isNoPeptideFilter())%>/> All peptides</div>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.peptideFilterType %>" id="peptideProphetRadioButton" value="<%= MS2Controller.ProphetFilterType.probability %>"<%=checked(form.isPeptideProphetFilter())%>/> Peptides with PeptideProphet probability &ge; <input onfocus="document.getElementById('peptideProphetRadioButton').checked=true;" type="text" size="2" name="<%= MS2Controller.PeptideFilteringFormElements.peptideProphetProbability %>" value="<%=h(form.getPeptideProphetProbability())%>" /></div>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.peptideFilterType %>" id="<%= text(FilterView.PEPTIDES_CUSTOM_VIEW_RADIO_BUTTON) %>" value="<%= MS2Controller.ProphetFilterType.customView %>"<%=checked(form.isCustomViewPeptideFilter())%>/>
+    <div class="labkey-indented"><input type="radio" name="<%= peptideFilterType %>" value="<%= none %>"<%=checked(form.isNoPeptideFilter())%>/> All peptides</div>
+    <div class="labkey-indented"><input type="radio" name="<%= peptideFilterType %>" id="peptideProphetRadioButton" value="<%= probability %>"<%=checked(form.isPeptideProphetFilter())%>/> Peptides with PeptideProphet probability &ge; <input type="text" size="2" id="<%= peptideProphetProbability %>" name="<%= peptideProphetProbability %>" value="<%=h(form.getPeptideProphetProbability())%>" /></div>
+    <div class="labkey-indented"><input type="radio" name="<%= peptideFilterType %>" id="<%= text(FilterView.PEPTIDES_CUSTOM_VIEW_RADIO_BUTTON) %>" value="<%= customView %>"<%=checked(form.isCustomViewPeptideFilter())%>/>
         Peptides that meet the filter criteria in a custom view:
         <% String peptideViewSelectId = bean.getPeptideView().renderViewList(request, out, peptideViewName); %>
-        <%=link("Create or Edit View").onClick("showViewDesigner('" + org.labkey.ms2.query.MS2Schema.HiddenTableType.PeptidesFilter + "', 'peptidesCustomizeView', " + PageFlowUtil.jsString(peptideViewSelectId) + "); return false;") %>
+        <%=link("Create or Edit View").onClick("showViewDesigner('" + PeptidesFilter + "', 'peptidesCustomizeView', " + PageFlowUtil.jsString(peptideViewSelectId) + "); return false;") %>
 
         <br/>
         <br/>
@@ -68,16 +82,22 @@ String proteinGroupViewName = form.getProteinGroupCustomViewName(getViewContext(
     <p style="width:100%" class="labkey-title-area-line"></p>
 
     <p>Compare protein groups by:</p>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.pivotType %>" value="<%= MS2Controller.PivotType.run %>"<%=checked(MS2Controller.PivotType.run == form.getPivotTypeEnum())%> /> Run</div>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.pivotType %>" value="<%= MS2Controller.PivotType.fraction %>"<%=checked(MS2Controller.PivotType.fraction == form.getPivotTypeEnum())%> /> Fraction</div>
+    <div class="labkey-indented"><input type="radio" name="<%= pivotType %>" value="<%= run %>"<%=checked(run == form.getPivotTypeEnum())%> /> Run</div>
+    <div class="labkey-indented"><input type="radio" name="<%= pivotType %>" value="<%= fraction %>"<%=checked(fraction == form.getPivotTypeEnum())%> /> Fraction</div>
 
     <p style="width:100%" class="labkey-title-area-line"></p>
 
     <p>For each run or fraction:</p>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.orCriteriaForEachRun %>" value="false"<%=checked(!form.isOrCriteriaForEachRun())%> /> only show the protein if it meets the filter criteria in that run/fraction.</div>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.orCriteriaForEachRun %>" value="true" <%=checked(form.isOrCriteriaForEachRun())%> /> show the protein if the run/fraction contains that protein and the protein meets the filter criteria in any of the compared runs/fractions.</div>
+    <div class="labkey-indented"><input type="radio" name="<%= orCriteriaForEachRun %>" value="false"<%=checked(!form.isOrCriteriaForEachRun())%> /> only show the protein if it meets the filter criteria in that run/fraction.</div>
+    <div class="labkey-indented"><input type="radio" name="<%= orCriteriaForEachRun %>" value="true" <%=checked(form.isOrCriteriaForEachRun())%> /> show the protein if the run/fraction contains that protein and the protein meets the filter criteria in any of the compared runs/fractions.</div>
 
     <p style="width:100%" class="labkey-title-area-line"></p>
     <div class="labkey-indented"><input type="checkbox" name="normalizeProteinGroups"<%=checked(form.isNormalizeProteinGroups())%> value="true" /> Normalize protein groups across runs</div>
     <p><labkey:button text="Compare"/></p>
 </labkey:form>
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
+    LABKEY.Utils.onReady(function() {
+        document.getElementById('<%=proteinProphetProbability%>')['onfocus'] = function() { document.getElementById('proteinProphetRadioButton').checked = true; };
+        document.getElementById('<%=peptideProphetProbability%>')['onclick'] = function() { document.getElementById('peptideProphetRadioButton').checked = true; };
+    });
+</script>

--- a/ms2/src/org/labkey/ms2/compare/spectraCountOptions.jsp
+++ b/ms2/src/org/labkey/ms2/compare/spectraCountOptions.jsp
@@ -23,6 +23,12 @@
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.ms2.MS2Controller" %>
 <%@ page import="org.labkey.ms2.query.SpectraCountConfiguration" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.peptideFilterType" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.ProphetFilterType.probability" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.ProphetFilterType.customView" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.peptideProphetProbability" %>
+<%@ page import="static org.labkey.ms2.query.MS2Schema.HiddenTableType.PeptidesFilter" %>
+<%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.targetProtein" %>
 <%@ page extends="org.labkey.api.jsp.JspBase"%>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -62,9 +68,9 @@
         </div>
     </p>
     <p>There are three options for filtering the peptide identifications:</p>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.peptideFilterType %>" value="<%= MS2Controller.ProphetFilterType.none %>"<%=checked(form.isNoPeptideFilter())%> /> All peptides</div>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.peptideFilterType %>" id="peptideProphetRadioButton" value="<%= MS2Controller.ProphetFilterType.probability %>"<%=checked(form.isPeptideProphetFilter())%>/> Peptides with PeptideProphet probability &ge; <input onfocus="document.getElementById('peptideProphetRadioButton').checked=true;" type="text" size="2" name="<%= MS2Controller.PeptideFilteringFormElements.peptideProphetProbability %>" value="<%= form.getPeptideProphetProbability() == null ? HtmlString.EMPTY_STRING : h(form.getPeptideProphetProbability()) %>" /></div>
-    <div class="labkey-indented"><input type="radio" name="<%= MS2Controller.PeptideFilteringFormElements.peptideFilterType %>" id="customViewRadioButton" value="<%= MS2Controller.ProphetFilterType.customView %>"<%=checked(form.isCustomViewPeptideFilter())%>/>
+    <div class="labkey-indented"><input type="radio" name="<%= peptideFilterType %>" value="<%= MS2Controller.ProphetFilterType.none %>"<%=checked(form.isNoPeptideFilter())%> /> All peptides</div>
+    <div class="labkey-indented"><input type="radio" name="<%= peptideFilterType %>" id="peptideProphetRadioButton" value="<%= probability %>"<%=checked(form.isPeptideProphetFilter())%>/> Peptides with PeptideProphet probability &ge; <input type="text" size="2" id="<%= peptideProphetProbability %>" name="<%= peptideProphetProbability %>" value="<%= form.getPeptideProphetProbability() == null ? HtmlString.EMPTY_STRING : h(form.getPeptideProphetProbability()) %>" /></div>
+    <div class="labkey-indented"><input type="radio" name="<%= peptideFilterType %>" id="customViewRadioButton" value="<%= customView %>"<%=checked(form.isCustomViewPeptideFilter())%>/>
         Peptides that meet the filter criteria in a custom view:
         <% String peptideViewSelectId = bean.getPeptideView().renderViewList(request, out, peptideViewName); %>
 
@@ -72,10 +78,10 @@
             function viewSavedCallback(arg1, viewInfo)
             {
                 // Get the name of the newly saved view
-                var viewName = viewInfo.views[0].name;
+                const viewName = viewInfo.views[0].name;
                 // Make sure we're set to use the custom view
                 document.getElementById("customViewRadioButton").checked = true;
-                var viewNamesSelect = document.getElementById(<%=q(peptideViewSelectId)%>);
+                const viewNamesSelect = document.getElementById(<%=q(peptideViewSelectId)%>);
                 if (!viewNamesSelect)
                 {
                     window.location.reload();
@@ -83,7 +89,7 @@
                 else
                 {
                     // Check if it already exists in our list
-                    for (var i = 0; i < viewNamesSelect.options.length; i++)
+                    for (let i = 0; i < viewNamesSelect.options.length; i++)
                     {
                         if (viewNamesSelect.options[i].value === viewName)
                         {
@@ -99,15 +105,20 @@
         </script>
 
 
-        <%=link("Create or Edit View").onClick("showViewDesigner('" + org.labkey.ms2.query.MS2Schema.HiddenTableType.PeptidesFilter + "', 'peptidesCustomizeView', " + PageFlowUtil.jsString(peptideViewSelectId) + ", viewSavedCallback); return false;") %>
+        <%=link("Create or Edit View").onClick("showViewDesigner('" + PeptidesFilter + "', 'peptidesCustomizeView', " + PageFlowUtil.jsString(peptideViewSelectId) + ", viewSavedCallback); return false;") %>
 
         <br/>
         <br/>
         <span id="peptidesCustomizeView"></span>
     </div>
         <p>
-        Optionally require that peptides have a sequence match in protein: <input type="text" size="30" name="<%= MS2Controller.PeptideFilteringFormElements.targetProtein %>" value="<%= h(form.getTargetProtein()==null ? "" : form.getTargetProtein()) %>" />
+        Optionally require that peptides have a sequence match in protein: <input type="text" size="30" name="<%= targetProtein %>" value="<%= h(form.getTargetProtein()==null ? "" : form.getTargetProtein()) %>" />
         <%=helpPopup("Protein Filter", "<p>Show only peptides whose sequences match against a specified protein. It need not be the protein mapped to the peptide by the search engine or ProteinProphet.</p><p>If no protein matches the name specified, or if multiple proteins match, this page will be redisplayed to correct the search.</p>", true)%>
     </p>
     <p><labkey:button text="Compare"/></p>
 </labkey:form>
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
+    LABKEY.Utils.onReady(function() {
+        document.getElementById('<%=peptideProphetProbability%>')['onfocus'] = function() { document.getElementById('peptideProphetRadioButton').checked=true; };
+    });
+</script>

--- a/ms2/src/org/labkey/ms2/filterHeader.jsp
+++ b/ms2/src/org/labkey/ms2/filterHeader.jsp
@@ -65,7 +65,7 @@
         <tr>
             <td style="height: 100%; padding-right: 1em" id="ms2RunGrouping">
                 <fieldset>
-                    <legend style="margin-bottom: 2px;">Grouping</legend>
+                    <legend>Grouping</legend>
                     <table class="labkey-data-region-legacy">
                         <tr>
                             <td style="vertical-align: middle;" nowrap>

--- a/ms2/src/org/labkey/ms2/peptideview/AbstractMS2RunView.java
+++ b/ms2/src/org/labkey/ms2/peptideview/AbstractMS2RunView.java
@@ -114,13 +114,13 @@ public abstract class AbstractMS2RunView
         return _container;
     }
 
-    protected String getAJAXNestedGridURL()
+    protected ActionURL getAJAXNestedGridURL()
     {
         ActionURL groupURL = _url.clone();
         groupURL.setAction(MS2Controller.GetProteinGroupingPeptidesAction.class);
         groupURL.deleteParameter("proteinGroupingId");
 
-        return groupURL.addParameter("proteinGroupingId", null).toString();
+        return groupURL.addParameter("proteinGroupingId", null);
     }
     
     protected ButtonBar createButtonBar(String whatWeAreSelecting, DataRegion dataRegion)

--- a/ms2/src/org/labkey/ms2/peptideview/PepSearchView.jsp
+++ b/ms2/src/org/labkey/ms2/peptideview/PepSearchView.jsp
@@ -19,7 +19,6 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.ms2.PepSearchModel" %>
-<%@ page import="java.util.Map" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%

--- a/ms2/src/org/labkey/ms2/peptideview/QueryPeptideMS2RunView.java
+++ b/ms2/src/org/labkey/ms2/peptideview/QueryPeptideMS2RunView.java
@@ -119,20 +119,18 @@ public class QueryPeptideMS2RunView extends AbstractMS2RunView
         ColumnInfo desiredCol = pair.first;
         SQLFragment sql = pair.second;
 
+        SQLFragment result;
         if (queryView.getSelectedNestingOption() != null)
         {
-            SQLFragment result = new SQLFragment("SELECT SeqId FROM " + MS2Manager.getTableInfoProteinGroupMemberships() + " WHERE ProteinGroupId IN (");
-            result.append(sql);
-            result.append(") x");
-            return result;
+            result = new SQLFragment("SELECT SeqId FROM " + MS2Manager.getTableInfoProteinGroupMemberships() + " WHERE ProteinGroupId IN (");
         }
         else
         {
-            SQLFragment result = new SQLFragment("SELECT " + desiredCol.getAlias() + " FROM (");
-            result.append(sql);
-            result.append(") x");
-            return result;
+            result = new SQLFragment("SELECT " + desiredCol.getAlias() + " FROM (");
         }
+        result.append(sql);
+        result.append(") x");
+        return result;
     }
 
     @Override
@@ -166,13 +164,13 @@ public class QueryPeptideMS2RunView extends AbstractMS2RunView
 
     public class PeptideQueryView extends AbstractMS2QueryView
     {
-        private List<DisplayColumn> _additionalDisplayColumns = new ArrayList<>();
+        private final List<DisplayColumn> _additionalDisplayColumns = new ArrayList<>();
 
         public PeptideQueryView(MS2Schema schema, QuerySettings settings, boolean expanded, boolean forExport)
         {
             super(schema, settings, expanded, forExport,
-                    new QueryNestingOption(FieldKey.fromParts("ProteinProphetData", "ProteinGroupId"), FieldKey.fromParts("ProteinProphetData", "ProteinGroupId", "RowId"), getAJAXNestedGridURL()),
-                    new QueryNestingOption(FieldKey.fromParts("SeqId"), FieldKey.fromParts("SeqId", "SeqId"), getAJAXNestedGridURL()));
+                new QueryNestingOption(FieldKey.fromParts("ProteinProphetData", "ProteinGroupId"), FieldKey.fromParts("ProteinProphetData", "ProteinGroupId", "RowId"), getAJAXNestedGridURL()),
+                new QueryNestingOption(FieldKey.fromParts("SeqId"), FieldKey.fromParts("SeqId", "SeqId"), getAJAXNestedGridURL()));
             setShowDetailsColumn(false);
         }
 
@@ -236,11 +234,7 @@ public class QueryPeptideMS2RunView extends AbstractMS2RunView
             {
                 runTypes.add(run.getRunType());
             }
-            boolean highestScoreFlag = false;
-            if(_url.getParameter("highestScore") != null)
-            {
-                highestScoreFlag = true;
-            }
+            boolean highestScoreFlag = _url.getParameter("highestScore") != null;
             _peptidesTable =  new PeptidesTableInfo(schema, _url.clone(), ContainerFilter.current(schema.getContainer()), runTypes.toArray(new MS2RunType[0]), highestScoreFlag);
             // Manually apply the metadata
             _peptidesTable.overlayMetadata(_peptidesTable.getPublicName(), schema, new ArrayList<>());
@@ -275,11 +269,10 @@ public class QueryPeptideMS2RunView extends AbstractMS2RunView
 
         PeptideQueryView view = new PeptideQueryView(schema, settings, true, false);
         DataRegion region = view.createDataRegion();
-        if (!(region instanceof NestableDataRegion))
+        if (!(region instanceof NestableDataRegion rgn))
         {
             throw new NotFoundException("No nesting possible");
         }
-        NestableDataRegion rgn = (NestableDataRegion) region;
 
         DataRegion nestedRegion = rgn.getNestedRegion();
         GridView result = new GridView(nestedRegion, (BindException)null);


### PR DESCRIPTION
#### Rationale
Migrate some inline handlers, prefer `ActionURL` over `String`, fix some warnings, clean up `.gitattributes`

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4965