### PR TITLE
Remove deprecated ContainerFilter.getSQLFragment

### DIFF
--- a/elispotassay/src/org/labkey/elispot/query/PlateBasedAssayRunDataTable.java
+++ b/elispotassay/src/org/labkey/elispot/query/PlateBasedAssayRunDataTable.java
@@ -87,9 +87,6 @@ public abstract class PlateBasedAssayRunDataTable extends FilteredTable<AssaySch
         });
         addColumn(runColumn);
 
-//        ColumnInfo objectUriColumn = getColumn("ObjectUri");
-//        Domain antigenDomain = ((ElispotAssayProvider)provider).getAntigenWellGroupDomain(protocol);
-//        PropertyDescriptor materialProperty = antigenDomain.getPropertyByName("SpecimenLsid").getPropertyDescriptor();
         final boolean hasMaterialSpecimenPropertyColumnDecorator = hasMaterialSpecimenPropertyColumnDecorator();
         String sampleDomainURI = AbstractAssayProvider.getDomainURIForPrefix(protocol, AbstractPlateBasedAssayProvider.ASSAY_DOMAIN_SAMPLE_WELLGROUP);
         final ExpSampleType sampleType = SampleTypeService.get().getSampleType(sampleDomainURI);
@@ -151,11 +148,8 @@ public abstract class PlateBasedAssayRunDataTable extends FilteredTable<AssaySch
     protected void applyContainerFilter(ContainerFilter filter)
     {
         // There isn't a container column directly on this table so do a special filter
-        if (getContainer() != null)
-        {
-            FieldKey containerColumn = FieldKey.fromParts("Run", "Folder");
-            clearConditions(containerColumn);
-            addCondition(filter.getSQLFragment(getSchema(), new SQLFragment("(SELECT d.Container FROM exp.ExperimentRun d WHERE d.RowId = RunId)"), getContainer()), containerColumn);
-        }
+        FieldKey containerColumn = FieldKey.fromParts("Run", "Folder");
+        clearConditions(containerColumn);
+        addCondition(filter.getSQLFragment(getSchema(), new SQLFragment("(SELECT d.Container FROM exp.ExperimentRun d WHERE d.RowId = RunId)")), containerColumn);
     }
 }

--- a/luminex/src/org/labkey/luminex/LeveyJenningsMenuView.java
+++ b/luminex/src/org/labkey/luminex/LeveyJenningsMenuView.java
@@ -65,7 +65,7 @@ public class LeveyJenningsMenuView extends JspView<LeveyJenningsMenuView.Bean>
     {
         super("/org/labkey/luminex/view/leveyJenningsMenu.jsp");
         ContainerFilter.AllFolders containerFilter = new ContainerFilter.AllFolders(getViewContext().getUser());
-        SQLFragment containerSQL = containerFilter.getSQLFragment(LuminexProtocolSchema.getSchema(), new SQLFragment("r.Container"), getViewContext().getContainer());
+        SQLFragment containerSQL = containerFilter.getSQLFragment(LuminexProtocolSchema.getSchema(), new SQLFragment("r.Container"));
 
         SQLFragment titrationSQL = new SQLFragment("SELECT DISTINCT t.Name FROM ");
         titrationSQL.append(LuminexProtocolSchema.getTableInfoTitration(), "t");

--- a/microarray/src/org/labkey/microarray/matrix/FeatureDataTable.java
+++ b/microarray/src/org/labkey/microarray/matrix/FeatureDataTable.java
@@ -113,7 +113,7 @@ public class FeatureDataTable extends FilteredTable<ExpressionMatrixProtocolSche
         {
             FieldKey containerColumn = FieldKey.fromParts("Run", "Folder");
             clearConditions(containerColumn);
-            addCondition(filter.getSQLFragment(getSchema(), new SQLFragment("(SELECT d.Container FROM exp.Data d WHERE d.RowId = DataId)"), getContainer()), containerColumn);
+            addCondition(filter.getSQLFragment(getSchema(), new SQLFragment("(SELECT d.Container FROM exp.Data d WHERE d.RowId = DataId)")), containerColumn);
         }
     }
 

--- a/ms2/src/org/labkey/ms2/query/MS2Schema.java
+++ b/ms2/src/org/labkey/ms2/query/MS2Schema.java
@@ -703,7 +703,7 @@ public class MS2Schema extends UserSchema
                 SQLFragment sql = new SQLFragment("Run IN (SELECT r.Run FROM ");
                 sql.append(MS2Manager.getTableInfoRuns(), "r");
                 sql.append(" WHERE ");
-                sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("r.Container"), MS2Schema.this.getContainer()));
+                sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("r.Container")));
                 sql.append(")");
                 addCondition(sql, containerFieldKey);
             }

--- a/ms2/src/org/labkey/ms2/query/ProteinGroupTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/ProteinGroupTableInfo.java
@@ -422,7 +422,7 @@ public class ProteinGroupTableInfo extends FilteredTable<MS2Schema>
         sql.append(" WHERE Run IN (SELECT Run FROM ");
         sql.append(MS2Manager.getTableInfoRuns(), "r");
         sql.append(" WHERE ");
-        sql.append(getContainerFilter().getSQLFragment(getSchema(), new SQLFragment("Container"), getContainer()));
+        sql.append(getContainerFilter().getSQLFragment(getSchema(), new SQLFragment("Container")));
         sql.append(" AND Deleted = ?");
         sql.add(Boolean.FALSE);
         if (runs != null)

--- a/viability/src/org/labkey/viability/ViabilityAssaySchema.java
+++ b/viability/src/org/labkey/viability/ViabilityAssaySchema.java
@@ -545,7 +545,7 @@ public class ViabilityAssaySchema extends AssayProtocolSchema
                         "WHERE result.ProtocolID = ? AND ");
             filter.add(getProtocol().getRowId());
 
-            filter.append(containerFilter.getSQLFragment(getSchema(), new SQLFragment("result.Container"), getContainer()));
+            filter.append(containerFilter.getSQLFragment(getSchema(), new SQLFragment("result.Container")));
 
             filter.append(")");
             filter.appendComment("</ResultSpecimens.applyContainerFilter>", getSqlDialect());


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/platform/pull/5073 for rationale.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5073

#### Changes
* Remove `ContainerFilter.getSQLFragment(DbSchema, SQLFragment, Container)` and replace usages with calls to `ContainerFilter.getSQLFragment(DbSchema, SQLFragment)`.
