### PR TITLE
Remove elisa multiplate experimental feature

### DIFF
--- a/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
+++ b/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
@@ -53,7 +53,6 @@ import org.labkey.api.qc.DataExchangeHandler;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.security.User;
-import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.study.assay.ParticipantVisitResolverType;
 import org.labkey.api.study.assay.SampleMetadataInputFormat;
 import org.labkey.api.study.assay.StudyParticipantVisitResolverType;
@@ -83,7 +82,6 @@ import java.util.stream.Collectors;
 
 import static org.labkey.api.exp.api.ExpProtocol.ASSAY_DOMAIN_DATA;
 import static org.labkey.api.exp.api.ExpProtocol.ASSAY_DOMAIN_RUN;
-import static org.labkey.elisa.ElisaModule.EXPERIMENTAL_MULTI_PLATE_SUPPORT;
 
 /**
  * User: klum
@@ -224,14 +222,11 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
 
         addProperty(domain, CONCENTRATION_UNITS_PROPERTY, "Concentration Units", PropertyType.STRING, "Units eg. (ug/ml)");
 
-        if (ExperimentalFeatureService.get().isFeatureEnabled(EXPERIMENTAL_MULTI_PLATE_SUPPORT))
-        {
-            Container lookupContainer = c.getProject();
-            DomainProperty method = addProperty(domain, CURVE_FIT_METHOD_PROPERTY, "Curve Fit Method", PropertyType.STRING);
-            method.setLookup(new Lookup(lookupContainer, AssaySchema.NAME + "." + getResourceName(), ElisaProviderSchema.CURVE_FIT_METHOD_TABLE_NAME));
-            method.setRequired(true);
-            method.setShownInUpdateView(false);
-        }
+        Container lookupContainer = c.getProject();
+        DomainProperty method = addProperty(domain, CURVE_FIT_METHOD_PROPERTY, "Curve Fit Method", PropertyType.STRING);
+        method.setLookup(new Lookup(lookupContainer, AssaySchema.NAME + "." + getResourceName(), ElisaProviderSchema.CURVE_FIT_METHOD_TABLE_NAME));
+        method.setRequired(true);
+        method.setShownInUpdateView(false);
 
         return result;
     }
@@ -324,10 +319,7 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
     @Override
     public SampleMetadataInputFormat[] getSupportedMetadataInputFormats()
     {
-        if (ExperimentalFeatureService.get().isFeatureEnabled(EXPERIMENTAL_MULTI_PLATE_SUPPORT))
-            return new SampleMetadataInputFormat[]{SampleMetadataInputFormat.MANUAL, SampleMetadataInputFormat.COMBINED};
-        else
-            return new SampleMetadataInputFormat[]{SampleMetadataInputFormat.MANUAL};
+        return new SampleMetadataInputFormat[]{SampleMetadataInputFormat.MANUAL, SampleMetadataInputFormat.COMBINED};
     }
 
     @Override

--- a/elisa/src/org/labkey/elisa/ElisaModule.java
+++ b/elisa/src/org/labkey/elisa/ElisaModule.java
@@ -26,7 +26,6 @@ import org.labkey.api.data.UpgradeCode;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
-import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.WebPartFactory;
 
@@ -85,11 +84,6 @@ public class ElisaModule extends DefaultModule
         AbstractPlateBasedAssayProvider provider = new ElisaAssayProvider();
 
         AssayService.get().registerAssayProvider(provider);
-
-        AdminConsole.addExperimentalFeatureFlag(EXPERIMENTAL_MULTI_PLATE_SUPPORT,
-                "ELISA Multi-plate, multi well data support",
-                "Allows ELISA assay import of high-throughput data file formats which contain multiple plates and multiple analyte values per well.",
-                false);
     }
 
     @NotNull

--- a/elisa/src/org/labkey/elisa/ElisaPlateTypeHandler.java
+++ b/elisa/src/org/labkey/elisa/ElisaPlateTypeHandler.java
@@ -17,18 +17,15 @@
 package org.labkey.elisa;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.plate.AbstractPlateTypeHandler;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.Container;
-import org.labkey.api.assay.plate.AbstractPlateTypeHandler;
-import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.Plate;
-import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.util.Pair;
 
 import java.util.Arrays;
 import java.util.List;
-
-import static org.labkey.elisa.ElisaModule.EXPERIMENTAL_MULTI_PLATE_SUPPORT;
 
 /**
  * User: klum
@@ -178,10 +175,7 @@ public class ElisaPlateTypeHandler extends AbstractPlateTypeHandler
     @Override
     public List<Pair<Integer, Integer>> getSupportedPlateSizes()
     {
-        if (ExperimentalFeatureService.get().isFeatureEnabled(EXPERIMENTAL_MULTI_PLATE_SUPPORT))
-            return List.of(new Pair<>(8, 12), new Pair<>(16, 24));
-        else
-            return List.of(new Pair<>(8, 12));
+        return List.of(new Pair<>(8, 12), new Pair<>(16, 24));
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We added support to the Elisa assay for a multi-plate import format including 4 parameter curve fitting. The feature was put under an experimental flag so we could get client feedback. It's been over 4 years and we have not heard any feedback although we understand that the client is using the new feature.

This PR removed the experimental flag and enables the new functionality by default.