### PR TITLE
Add a metric to measure how often study linkage is changed when importing flow data

### DIFF
--- a/flow/src/org/labkey/flow/controllers/executescript/AnalysisScriptController.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/AnalysisScriptController.java
@@ -41,6 +41,7 @@ import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
+import org.labkey.api.usageMetrics.SimpleMetricsService;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.URIUtil;
@@ -55,6 +56,7 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.view.template.PageConfig;
+import org.labkey.flow.FlowModule;
 import org.labkey.flow.FlowPreference;
 import org.labkey.flow.analysis.model.ExternalAnalysis;
 import org.labkey.flow.analysis.model.FCS;
@@ -1357,6 +1359,12 @@ public class AnalysisScriptController extends BaseFlowController
             }
 
             Container targetStudy = getTargetStudy(form.getTargetStudy(), errors);
+            if (form.getStudyChanged())
+            {
+                // Estabilish & increment a metric to measure usage of the Study Linkage feature of the Flow data import process
+                SimpleMetricsService.get().increment(FlowModule.NAME, "SampleImport", "StudyLinkChanged");
+            }
+
             if (errors.hasErrors())
                 return;
 

--- a/flow/src/org/labkey/flow/controllers/executescript/ImportAnalysisForm.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/ImportAnalysisForm.java
@@ -62,6 +62,18 @@ public class ImportAnalysisForm implements HasAllowBindParameter
     private String[] keywordDir;
     private boolean confirm;
 
+    private boolean studyChanged = false;
+
+    public void setStudyChanged(boolean studyChanged)
+    {
+        this.studyChanged = studyChanged;
+    }
+
+    public boolean getStudyChanged()
+    {
+        return this.studyChanged;
+    }
+
     public int getStep()
     {
         return step;

--- a/flow/src/org/labkey/flow/controllers/executescript/importAnalysisChooseAnalysis.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/importAnalysisChooseAnalysis.jsp
@@ -52,6 +52,7 @@
 <input type="hidden" name="selectAnalysisEngine" id="selectAnalysisEngine" value="<%=form.getSelectAnalysisEngine()%>">
 
 <input type="hidden" name="importGroupNames" value="<%=h(form.getImportGroupNames())%>"/>
+<input type="hidden" name="studyChanged" id="studyChanged" value="<%=h(form.getStudyChanged())%>" />
 
 <p>
 <hr/>
@@ -232,7 +233,7 @@ if (form.getKeywordDir() != null && form.getKeywordDir().length > 0 && StudyPubl
         <div style="padding-left: 2em; padding-bottom: 1em;">
             <br>
             Choose a target study folder:<br>
-            <%=select().name("targetStudy").className(null).addOptions(targetStudies).selected(text(form.getTargetStudy()))
+            <%=select().name("targetStudy").className(null).addOptions(targetStudies).selected(text(form.getTargetStudy())).onChange("document.getElementById('studyChanged').value = true;")
             %>
 <%--            <select id="targetStudy" name="targetStudy">--%>
 <%--                <labkey:options value="<%=text(form.getTargetStudy())%>" map="<%=targetStudies%>"/>--%>


### PR DESCRIPTION
#### Rationale
As part of [48856](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48856) we want to identify how often are Flow samples/results linked to studies, and specifically how often is a non-default study selected.

#### Changes
* add metric that tracks how often the linked Study is changed when FCS files are imported 