### PR TITLE
Clear miscellaneous warnings

### DIFF
--- a/nab/src/org/labkey/nab/view/nabQC.jsp
+++ b/nab/src/org/labkey/nab/view/nabQC.jsp
@@ -78,7 +78,7 @@
 %>
 
 <%
-    if (errorMsg.length() > 0)
+    if (!errorMsg.isEmpty())
     {
 %>
     <%=errorMsg%>


### PR DESCRIPTION
#### Rationale
Clear some IntelliJ warnings about preferred syntax, unused code, generics, etc. Also switch to `unsafeAppend()`.