### PR TITLE
Migrate inline handlers

### DIFF
--- a/flow/src/org/labkey/flow/controllers/attribute/createAlias.jsp
+++ b/flow/src/org/labkey/flow/controllers/attribute/createAlias.jsp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.flow.controllers.attribute.AttributeController" %>
 <%@ page import="org.labkey.flow.controllers.protocol.ProtocolController" %>
@@ -57,7 +56,7 @@ Create alias for <%=h(entry.getType().name())%>: <%=h(entry.getName())%>
     <labkey:input type="hidden" id="allowCaseChangeAlias" name="allowCaseChangeAlias" value="false"/>
 </labkey:form>
 
-<script nonce="<%=getScriptNonce()%>">
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
     var errorEl = document.getElementById('form-errors');
     function showError(msg) {
         errorEl.innerHTML = '<div class="labkey-error">' + LABKEY.Utils.encodeHtml(msg) + '</div>';

--- a/flow/src/org/labkey/flow/controllers/editscript/editAnalysis.jsp
+++ b/flow/src/org/labkey/flow/controllers/editscript/editAnalysis.jsp
@@ -29,16 +29,21 @@
     Collection<SubsetSpec> subsets = form.getFlowScript().getSubsets();
 %>
 <labkey:errors/>
-<script nonce="<%=getScriptNonce()%>">
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
     var STATS = [];
-    <% for (StatisticSpec.STAT stat : StatisticSpec.STAT.values()) { %>
+
+    LABKEY.Utils.onReady(function(){
+        document.getElementById('addStat')['onclick'] = addStat;
+        document.getElementById('addGraph')['onclick'] = addGraph;
+        <% for (StatisticSpec.STAT stat : StatisticSpec.STAT.values()) { %>
         STATS.push({
             name: <%=h(stat.name())%>,
             shortName: <%=h(stat.getShortName())%>,
             longName: <%=h(stat.getLongName())%>,
             parameterRequired: <%= stat.isParameterRequired() %>
         });
-    <% } %>
+        <% } %>
+    });
 
     function addStat()
     {
@@ -190,7 +195,7 @@
                 <td>
                     <input id="stat_parameter2">
                 </td>
-                <td><input type="button" onclick="addStat()" value="Add Statistic"></td>
+                <td><input id="addStat" type="button" value="Add Statistic"></td>
             </tr>
         </table>
 
@@ -224,13 +229,13 @@
                         <% } %>
                     </select>
                 </td>
-                <td><input type="button" onclick="addGraph()" value="Add Graph"></td>
+                <td><input id="addGraph" type="button" value="Add Graph"></td>
             </tr>
         </table>
     </p>
     <p>
         <b>Additional Subsets</b><br>
-        Use this textbox to specify boolean expressions involving subsets that you want to calculate statistics for.
+        Use this text box to specify boolean expressions involving subsets that you want to calculate statistics for.
         A boolean subset expression has parentheses around it, and uses the operators '&' (and), '|' (or), and '!' (not).
         Example:<br>
         Lymph/CD4/CD8/(IFNg+&!IL2+)<br>

--- a/flow/src/org/labkey/flow/controllers/editscript/editCompensationCalculation.jsp
+++ b/flow/src/org/labkey/flow/controllers/editscript/editCompensationCalculation.jsp
@@ -36,12 +36,12 @@ function o() { var o = {}; for (var i = 0; i < arguments.length; i += 2) o[argum
 var parameters = <%= javascriptArray(form.parameters) %>
 var AutoComp = {};
 <%
-    boolean hasAutoCompScripts = form.workspace.getAutoCompensationScripts().size() > 0;
+    boolean hasAutoCompScripts = !form.workspace.getAutoCompensationScripts().isEmpty();
     for (AutoCompensationScript autoComp : form.workspace.getAutoCompensationScripts())
     {
         %>AutoComp[<%=q(autoComp.getName())%>]={<%
 
-        // 'criteria' : [ primarykKeyword, secondaryKeyword, secondaryValue ]
+        // 'criteria' : [ primaryKeyword, secondaryKeyword, secondaryValue ]
         AutoCompensationScript.MatchingCriteria criteria = autoComp.getCriteria();
         if (criteria != null)
         {
@@ -110,7 +110,7 @@ var keywordValueSubsetListMap = KV;
         %>
         <labkey:panel title="Choose AutoCompensation script">
             <p>Your FlowJo workspace contains AutoCompensation scripts; you can optionally
-            select a script from the drop down below to quickly populate the compensation
+            select a script from the drop-down list below to quickly populate the compensation
             calculation form fields.</p>
             <select id="selectAutoCompScript" name="selectAutoCompScript">
             <%
@@ -126,7 +126,7 @@ var keywordValueSubsetListMap = KV;
 <% } %>
 
         <labkey:panel title="Analyze FCS Files where">
-            <p>Filters may optionally be applied to this analysis script.  The set of keyword and
+            <p>Filters may optionally be applied to this analysis script. The set of keyword and
             value pairs <i>must all</i> match in the FCS header to be included in the analysis.
             You can change the filter later by editing the script settings from the
             analysis script start page.</p>
@@ -178,9 +178,9 @@ var keywordValueSubsetListMap = KV;
             which are to be used to identify the compensation control in experiment runs.</p>
             <p><b>If you do not see the keyword you are looking for:</b><br>
             This page only allows you to choose keyword/value pairs that uniquely identify a
-            sample in the workspace.  If you do not see the keyword that you would like to use,
+            sample in the workspace. If you do not see the keyword that you would like to use,
             this might be because the workspace that you uploaded contained more than one sample
-            with that keyword value.  Use FlowJo to save a workspace template with AutoCompensation scripts or
+            with that keyword value. Use FlowJo to save a workspace template with AutoCompensation scripts or
             a workspace containing only one set of compensation controls, and upload that new workspace.
             </p>
             <table class="labkey-data-region-legacy labkey-show-borders">
@@ -200,8 +200,10 @@ var keywordValueSubsetListMap = KV;
                     <td><%=unsafe(selectKeywordValues(Sign.negative, i))%></td>
                     <td>
                         <%=unsafe(selectSubsets(Sign.negative, i))%>
-                        <% if (i == 0) { %>
-                            <input class="labkey-button" type="button" value="Universal" onclick="universalNegative()">
+                        <% if (i == 0) {
+                            addHandler("universalNegative", "click", "universalNegative()");
+                        %>
+                            <input class="labkey-button" id="universalNegative" type="button" value="Universal">
                         <% } %>
                     </td>
                 </tr>
@@ -219,9 +221,9 @@ if (analysisNames.length > 0)
             <p>You can choose to use the gating from either the sample identified
             by the unique keyword/value pair from the compensation
             calculation above <i>or</i> from one of the named groups in the workspace.</p>
-            <p>By default, the sample's gating will be used.  However, if this is a
+            <p>By default, the sample's gating will be used. However, if this is a
             <b>workspace template</b>, you will most likely need to select a group name
-            from the drop down that has gating for the given subsets.</p>
+            from the drop-down list that has gating for the given subsets.</p>
             <select name="selectGroupName" title="Use gating either from the sample or from a group">
                 <option value="" title="Use gating from the sample identified by the Keyword/Value pair">Sample</option>
                 <% for (String group : analysisNames)

--- a/flow/src/org/labkey/flow/controllers/editscript/editScript.jsp
+++ b/flow/src/org/labkey/flow/controllers/editscript/editScript.jsp
@@ -29,7 +29,7 @@
 <% if (error != null) { %>
 <p class="labkey-error"><%=unsafe(PageFlowUtil.filter(error.getMessage(), true).replaceAll("\\n", "<br>"))%></p>
 <% if (error.getLine() != 0) { %>
-<script nonce="<%=getScriptNonce()%>">
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
     function findOffset(text, line, column)
     {
         var offset = 0;

--- a/flow/src/org/labkey/flow/controllers/executescript/importAnalysisReviewSamples.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/importAnalysisReviewSamples.jsp
@@ -58,7 +58,7 @@
                 if (sampleInfo != null)
                     groupSamples.put(sampleInfo.getLabel(), new String[] { sampleInfo.getSampleId(), sampleInfo.getLabel() });
             }
-            if (group.isAllSamples() || groupSamples.size() > 0)
+            if (group.isAllSamples() || !groupSamples.isEmpty())
             {
                 String groupName = group.getGroupName().toString();
                 groups.put(groupName, groupSamples.values());
@@ -100,10 +100,10 @@
 </p>
 <% } %>
 <hr/>
-<script nonce="<%=getScriptNonce()%>">
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
     var samples = <%=new JSONArray(samples)%>;
     var groups = <%=new JSONObject(groups)%>;
-    var importedGroup = <%=q(form.getImportGroupNames().length() > 0 ? form.getImportGroupNameList().get(0) : "All Samples")%>;
+    var importedGroup = <%=q(!form.getImportGroupNames().isEmpty() ? form.getImportGroupNameList().get(0) : "All Samples")%>;
 </script>
 
 <%

--- a/flow/src/org/labkey/flow/view/exportAnalysis.jsp
+++ b/flow/src/org/labkey/flow/view/exportAnalysis.jsp
@@ -50,7 +50,7 @@
     String selectionType = bean.getSelectionType() == null ? "runs" : bean.getSelectionType();
     ActionURL exportURL = urlFor(RunController.ExportAnalysis.class).addParameter("selectionType", selectionType);
 %>
-<script nonce="<%=getScriptNonce()%>">
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
     function toggleShortNames(checked)
     {
         var checkboxes = document.getElementsByName("useShortStatNames");

--- a/ms2/src/org/labkey/ms2/decoySummary.jsp
+++ b/ms2/src/org/labkey/ms2/decoySummary.jsp
@@ -129,7 +129,7 @@
         </tr>
     </table>
 </labkey:form>
-<script nonce="<%=getScriptNonce()%>">
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
     LABKEY.Utils.onReady(function() {
         document.getElementById("desiredFdr")['onchange'] = function() {
             setFilterParameter(this.value);


### PR DESCRIPTION
#### Rationale
Strict CSPs don't like inline handlers. Neither does TeamCity.

Also update `<script>` tags for consistency. And eliminate some IntelliJ warnings.