### PR TITLE
Fix some inline handlers

### DIFF
--- a/flow/src/org/labkey/flow/view/GraphColumn.java
+++ b/flow/src/org/labkey/flow/view/GraphColumn.java
@@ -26,8 +26,7 @@ import org.labkey.api.data.DataRegion;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.settings.AppProps;
-import org.labkey.api.util.DOM;
-import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.DOM.Renderable;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
@@ -188,8 +187,8 @@ public class GraphColumn extends DataColumn
             else
             {
                 ActionURL urlGraph = urlGraph(objectId, graphSpec, ctx.getContainer());
-                HtmlString iconHtml = DOM.createHtmlFragment(IMG(at(width, 32).at(height, 32).at(title, graphSpec).at(src, urlGraph)));
-                HtmlString imageHtml = DOM.createHtmlFragment(IMG(at(src, urlGraph)));
+                Renderable iconHtml = IMG(at(width, 32).at(height, 32).at(title, graphSpec).at(src, urlGraph));
+                Renderable imageHtml = IMG(at(src, urlGraph));
                 PageFlowUtil.popupHelp(imageHtml, graphSpec).link(iconHtml).width(310).appendTo(out);
             }
         }

--- a/flow/src/org/labkey/flow/view/setGraphSize.jsp
+++ b/flow/src/org/labkey/flow/view/setGraphSize.jsp
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 %>
+<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.flow.FlowPreference" %>
 <%@ page import="java.util.LinkedHashMap" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -30,7 +30,7 @@
 %>
 <%
     String graphSize = FlowPreference.graphSize.getValue(request);
-    Map<String, String> sizes = new LinkedHashMap();
+    Map<String, String> sizes = new LinkedHashMap<>();
     sizes.put("300", "Large Graphs");
     sizes.put("200", "Medium Graphs");
     sizes.put("150", "Small Graphs");
@@ -142,7 +142,7 @@
 <%
 for (Map.Entry<String, String> entry : sizes.entrySet()) { %>
     <div class="labkey-graph-size">
-        <%=link(h(entry.getValue())).addClass(entry.getKey().equals(graphSize) ? "labkey-selected-link" : "").onClick("setGraphSize(" + h(entry.getKey()) + ")")%>
+        <%=link(entry.getValue()).addClass(entry.getKey().equals(graphSize) ? "labkey-selected-link" : "").onClick("setGraphSize(" + entry.getKey() + ")")%>
     </div>
 <% } %>
 <img id="updateGraphSize" height="1" width="1" src="<%=getWebappURL("_.gif")%>">

--- a/ms2/src/org/labkey/ms2/mascotConfig.jsp
+++ b/ms2/src/org/labkey/ms2/mascotConfig.jsp
@@ -40,7 +40,7 @@
         {
             var preferenceForm = document.forms['preferences'];
             var mascotForm = document.forms['mascottest'];
-            if (preferenceForm.mascotServer.value.length == 0)
+            if (preferenceForm.mascotServer.value.length === 0)
             {
                 alert("Please specify your Mascot server before testing.");
                 try {preferenceForm.mascotServer.focus();} catch(x){}
@@ -55,6 +55,10 @@
             mascotForm.submit();
         };
     })();
+
+    LABKEY.Utils.onReady(function(){
+        document.getElementById('testMascot')['onclick'] = testMascot;
+    });
 </script>
 
 <labkey:form name="preferences" enctype="multipart/form-data" method="post">
@@ -90,7 +94,7 @@
         </tr>
         <tr>
             <td></td>
-            <td><%=link("Test Mascot settings").href("javascript:testMascot()")%>
+            <td><%=link("Test Mascot settings").id("testMascot")%>
             </td>
         </tr>
 


### PR DESCRIPTION
#### Rationale
Eliminate `testMascot()` inline handler. `HtmlString` -> `Renderable`.