### PR TITLE
Don't extend Locators class

### DIFF
--- a/luminex/test/src/org/labkey/test/components/luminex/dialogs/SinglepointExclusionDialog.java
+++ b/luminex/test/src/org/labkey/test/components/luminex/dialogs/SinglepointExclusionDialog.java
@@ -16,12 +16,9 @@
 package org.labkey.test.components.luminex.dialogs;
 
 import org.labkey.test.Locator;
-import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.ExtHelper;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 
 /**
  * Created by iansigmon on 12/29/16.
@@ -31,7 +28,6 @@ public class SinglepointExclusionDialog extends BaseExclusionDialog
     protected static final String MENU_BUTTON_ITEM = "Exclude Singlepoint Unknowns";
     private static final String TITLE = "Exclude Singlepoint Unknowns from Analysis";
 
-    Elements _elements;
     protected SinglepointExclusionDialog(WebDriver driver)
     {
         super(driver);
@@ -85,18 +81,4 @@ public class SinglepointExclusionDialog extends BaseExclusionDialog
         sleep(500);
     }
 
-    protected Elements elements()
-    {
-        if (_elements == null)
-            _elements = new Elements();
-        return _elements;
-    }
-
-    public class Elements extends LabKeyPage.ElementCache
-    {
-    }
-
-    public static class Locators extends org.labkey.test.Locators
-    {
-    }
 }

--- a/luminex/test/src/org/labkey/test/components/luminex/importwizard/AnalytePropertiesWebPart.java
+++ b/luminex/test/src/org/labkey/test/components/luminex/importwizard/AnalytePropertiesWebPart.java
@@ -23,7 +23,6 @@ public class AnalytePropertiesWebPart extends WebPartPanel
 {
     private static final String TITLE = "Analyte Properties";
 
-    private Elements _elements;
     protected AnalytePropertiesWebPart(WebElement componentElement, WebDriver driver)
     {
         super(componentElement, driver);
@@ -48,19 +47,4 @@ public class AnalytePropertiesWebPart extends WebPartPanel
         }
     }
 
-    public Elements elements()
-    {
-        if (_elements == null)
-            _elements = new Elements();
-        return _elements;
-    }
-
-    public class Elements extends WebPartPanel.ElementCache
-    {
-
-    }
-
-    public static class Locators extends org.labkey.test.Locators
-    {
-    }
 }

--- a/luminex/test/src/org/labkey/test/components/luminex/importwizard/BatchPropertiesWebPart.java
+++ b/luminex/test/src/org/labkey/test/components/luminex/importwizard/BatchPropertiesWebPart.java
@@ -20,11 +20,10 @@ import org.labkey.test.components.WebPartPanel;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
-public class BatchPropertiesWebPart extends WebPartPanel
+public class BatchPropertiesWebPart extends WebPartPanel<BatchPropertiesWebPart.Elements>
 {
     private static final String TITLE = "Batch Properties";
 
-    private Elements _elements;
     protected BatchPropertiesWebPart(WebElement componentElement, WebDriver driver)
     {
         super(componentElement, driver);
@@ -37,7 +36,7 @@ public class BatchPropertiesWebPart extends WebPartPanel
 
     public void checkSampleInfo()
     {
-        elements().sampleInfoRadioButton.click();
+        elementCache().sampleInfoRadioButton.click();
     }
 
     public static class BatchPropertiesWebPartFinder extends WebPartFinder<BatchPropertiesWebPart, BatchPropertiesWebPartFinder>
@@ -54,20 +53,19 @@ public class BatchPropertiesWebPart extends WebPartPanel
         }
     }
 
-    public Elements elements()
+    @Override
+    protected Elements newElementCache()
     {
-        if (_elements == null)
-            _elements = new Elements();
-        return _elements;
+        return new Elements();
     }
 
-    public class Elements extends WebPartPanel.ElementCache
+    public class Elements extends WebPartPanel<?>.ElementCache
     {
         protected final WebElement sampleInfoRadioButton = Locators.sampleInfoRadio.findWhenNeeded(this);
 
     }
 
-    public static class Locators extends org.labkey.test.Locators
+    public static class Locators
     {
         protected static final Locator sampleInfoRadio = Locator.radioButtonByNameAndValue("participantVisitResolver", "SampleInfo");
     }

--- a/luminex/test/src/org/labkey/test/components/luminex/importwizard/DefineWellRoleWebPart.java
+++ b/luminex/test/src/org/labkey/test/components/luminex/importwizard/DefineWellRoleWebPart.java
@@ -86,9 +86,9 @@ public class DefineWellRoleWebPart extends WebPartPanel
 
     }
 
-    public static class Locators extends org.labkey.test.Locators
+    public static class Locators
     {
-        protected static final Locator titrationRole(String controlType, String name)
+        protected static Locator titrationRole(String controlType, String name)
         {
             return Locator.tagWithName("input", "_titrationRole_" + controlType + "_" + name);
         }

--- a/luminex/test/src/org/labkey/test/components/luminex/importwizard/RunPropertiesWebPart.java
+++ b/luminex/test/src/org/labkey/test/components/luminex/importwizard/RunPropertiesWebPart.java
@@ -27,7 +27,6 @@ public class RunPropertiesWebPart extends WebPartPanel
     private static final String TITLE = "Run Properties";
     public static final String ASSAY_ID_FIELD  = "name";
     public static final String ASSAY_DATA_FILE_LOCATION_MULTIPLE_FIELD = "__primaryFile__";
-    private Elements _elements;
 
     protected RunPropertiesWebPart(WebElement componentElement, WebDriver driver)
     {
@@ -85,19 +84,7 @@ public class RunPropertiesWebPart extends WebPartPanel
         }
     }
 
-    public Elements elements()
-    {
-        if (_elements == null)
-            _elements = new Elements();
-        return _elements;
-    }
-
-    public class Elements extends WebPartPanel.ElementCache
-    {
-
-    }
-
-    public static class Locators extends org.labkey.test.Locators
+    public static class Locators
     {
         protected static final Locator plusButton = Locator.xpath("//a[contains(@class, 'labkey-file-add-icon-enabled')]");
         protected static Locator minusButton(String fileName)

--- a/luminex/test/src/org/labkey/test/pages/luminex/ExclusionReportPage.java
+++ b/luminex/test/src/org/labkey/test/pages/luminex/ExclusionReportPage.java
@@ -26,11 +26,10 @@ import static org.labkey.test.components.luminex.exclusionreport.ExcludedSinglep
 /**
  * Created by iansigmon on 12/29/16.
  */
-public class ExclusionReportPage extends LabKeyPage
+public class ExclusionReportPage extends LabKeyPage<ExclusionReportPage.Elements>
 {
     private static final String SinglePoint_TITLE = "Excluded Singlepoint Unknowns";
 
-    Elements _elements;
     private ExclusionReportPage(WebDriver driver)
     {
         super(driver);
@@ -46,29 +45,24 @@ public class ExclusionReportPage extends LabKeyPage
 
     public void assertSinglepointUnknownExclusion(String runName, String description, String dilution, String...analytes)
     {
-        elements().singlepointUnknownsWebpart.assertExclusionPresent(runName, description, dilution, analytes);
+        elementCache().singlepointUnknownsWebpart.assertExclusionPresent(runName, description, dilution, analytes);
     }
 
     public void assertSinglepointUnknownExclusionNotPresent(String runName, String description, String dilution, String...analytes)
     {
-        elements().singlepointUnknownsWebpart.assertExclusionNotPresent(runName, description, dilution, analytes);
+        elementCache().singlepointUnknownsWebpart.assertExclusionNotPresent(runName, description, dilution, analytes);
     }
 
-    public Elements elements()
+    @Override
+    protected Elements newElementCache()
     {
-        if (_elements == null)
-            _elements = new Elements();
-        return _elements;
+        return new Elements();
     }
 
-    public class Elements extends LabKeyPage.ElementCache
+    public class Elements extends LabKeyPage<?>.ElementCache
     {
         final ExcludedSinglepointUnknownsWebpart singlepointUnknownsWebpart = ExcludedSinglepointUnknownsWebpart(getDriver()).findWhenNeeded();
 
     }
 
-    public static class Locators extends org.labkey.test.Locators
-    {
-
-    }
 }

--- a/luminex/test/src/org/labkey/test/pages/luminex/LuminexImportWizard.java
+++ b/luminex/test/src/org/labkey/test/pages/luminex/LuminexImportWizard.java
@@ -139,7 +139,7 @@ public class LuminexImportWizard extends LabKeyPage<LuminexImportWizard.Elements
         clickButton("Save and Finish", longWaitForPage);
     }
 
-    public class Elements extends LabKeyPage.ElementCache
+    public class Elements extends LabKeyPage<?>.ElementCache
     {
         //Page 1 WebParts
         final BatchPropertiesWebPart batchproperties = BatchPropertiesWebPart(getDriver()).findWhenNeeded();
@@ -152,7 +152,4 @@ public class LuminexImportWizard extends LabKeyPage<LuminexImportWizard.Elements
         final AnalytePropertiesWebPart analyteProperties = AnalytePropertiesWebPart(getDriver()).findWhenNeeded();
     }
 
-    public static class Locators extends org.labkey.test.Locators
-    {
-    }
 }


### PR DESCRIPTION
#### Rationale
`org.labkey.test.Locators` is just a static container class, no reason to extend it.

#### Related Pull Requests
- N/A

#### Changes
- Don't extend Locators class
- Remove some empty/unused element cache classes.
