### PR TITLE
Remove extra `z`

### DIFF
--- a/protein/src/org/labkey/protein/view/protAnnots.jsp
+++ b/protein/src/org/labkey/protein/view/protAnnots.jsp
@@ -1,4 +1,4 @@
-z<%
+<%
 /*
  * Copyright (c) 2005-2018 Fred Hutchinson Cancer Research Center
  *


### PR DESCRIPTION
#### Rationale
z is a great letter, but we don't need it floating above the protein detail pane

#### Changes
* Remove extraneous character