### PR TITLE
Switch assay import to use DataIterator

### DIFF
--- a/elisa/src/org/labkey/elisa/ElisaDataHandler.java
+++ b/elisa/src/org/labkey/elisa/ElisaDataHandler.java
@@ -38,6 +38,8 @@ import org.labkey.api.data.statistics.DoublePoint;
 import org.labkey.api.data.statistics.FitFailedException;
 import org.labkey.api.data.statistics.MathStat;
 import org.labkey.api.data.statistics.StatsService;
+import org.labkey.api.dataiterator.AbstractMapDataIterator;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.api.DataType;
@@ -47,7 +49,6 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
-import org.labkey.api.iterator.ValidatingDataRowIterator;
 import org.labkey.api.qc.DataLoaderSettings;
 import org.labkey.api.qc.TransformDataHandler;
 import org.labkey.api.query.FieldKey;
@@ -120,7 +121,7 @@ public class ElisaDataHandler extends AbstractAssayTsvDataHandler implements Tra
     }
 
     @Override
-    public Map<DataType, Supplier<ValidatingDataRowIterator>> getValidationDataMap(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context, DataLoaderSettings settings) throws ExperimentException
+    public Map<DataType, DataIteratorBuilder> getValidationDataMap(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context, DataLoaderSettings settings) throws ExperimentException
     {
         List<Map<String, Object>> results = new ArrayList<>();
         ExpProtocol protocol = data.getRun().getProtocol();
@@ -297,8 +298,8 @@ public class ElisaDataHandler extends AbstractAssayTsvDataHandler implements Tra
                 }
             }
         }
-        Map<DataType, Supplier<ValidatingDataRowIterator>> datas = new HashMap<>();
-        datas.put(getDataType(), () -> ValidatingDataRowIterator.of(results));
+        Map<DataType, DataIteratorBuilder> datas = new HashMap<>();
+        datas.put(getDataType(), AbstractMapDataIterator.builderOf(results));
 
         return datas;
     }

--- a/elisa/src/org/labkey/elisa/ElisaDataHandler.java
+++ b/elisa/src/org/labkey/elisa/ElisaDataHandler.java
@@ -38,8 +38,8 @@ import org.labkey.api.data.statistics.DoublePoint;
 import org.labkey.api.data.statistics.FitFailedException;
 import org.labkey.api.data.statistics.MathStat;
 import org.labkey.api.data.statistics.StatsService;
-import org.labkey.api.dataiterator.AbstractMapDataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.api.DataType;
@@ -69,7 +69,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -299,7 +298,7 @@ public class ElisaDataHandler extends AbstractAssayTsvDataHandler implements Tra
             }
         }
         Map<DataType, DataIteratorBuilder> datas = new HashMap<>();
-        datas.put(getDataType(), AbstractMapDataIterator.builderOf(results));
+        datas.put(getDataType(), MapDataIterator.of(results));
 
         return datas;
     }

--- a/elispotassay/src/org/labkey/elispot/AbstractElispotDataHandler.java
+++ b/elispotassay/src/org/labkey/elispot/AbstractElispotDataHandler.java
@@ -21,7 +21,6 @@ import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ConvertHelper;
-import org.labkey.api.dataiterator.AbstractMapDataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.DataIteratorUtil;
@@ -89,7 +88,7 @@ public abstract class AbstractElispotDataHandler extends AbstractExperimentDataH
 
         ElispotDataFileParser parser = getDataFileParser(data, dataFile, info, log, context);
         List<Map<String, Object>> rows = parser.getResults();
-        importData(run, AbstractMapDataIterator.builderOf(rows));
+        importData(run, MapDataIterator.of(rows));
     }
 
     protected void importData(ExpRun run, DataIteratorBuilder dataRows) throws ExperimentException

--- a/elispotassay/src/org/labkey/elispot/AbstractElispotDataHandler.java
+++ b/elispotassay/src/org/labkey/elispot/AbstractElispotDataHandler.java
@@ -94,7 +94,7 @@ public abstract class AbstractElispotDataHandler extends AbstractExperimentDataH
 
     protected void importData(ExpRun run, DataIteratorBuilder dataRows) throws ExperimentException
     {
-        try (MapDataIterator iter = DataIteratorUtil.wrapMap(dataRows.getDataIterator(new DataIteratorContext()), true))
+        try (MapDataIterator iter = DataIteratorUtil.wrapMap(dataRows.getDataIterator(new DataIteratorContext()), false))
         {
             List<? extends ExpData> runData = run.getOutputDatas(ExperimentService.get().getDataType(ElispotDataHandler.NAMESPACE));
             assert(runData.size() == 1);

--- a/elispotassay/src/org/labkey/elispot/AbstractElispotDataHandler.java
+++ b/elispotassay/src/org/labkey/elispot/AbstractElispotDataHandler.java
@@ -21,6 +21,11 @@ import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ConvertHelper;
+import org.labkey.api.dataiterator.AbstractMapDataIterator;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.dataiterator.DataIteratorUtil;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.ObjectProperty;
@@ -31,7 +36,6 @@ import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
-import org.labkey.api.iterator.ValidatingDataRowIterator;
 import org.labkey.api.security.User;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
@@ -41,7 +45,6 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 /**
  * User: klum
@@ -86,19 +89,19 @@ public abstract class AbstractElispotDataHandler extends AbstractExperimentDataH
 
         ElispotDataFileParser parser = getDataFileParser(data, dataFile, info, log, context);
         List<Map<String, Object>> rows = parser.getResults();
-        importData(run, () -> ValidatingDataRowIterator.of(rows));
+        importData(run, AbstractMapDataIterator.builderOf(rows));
     }
 
-    protected void importData(ExpRun run, Supplier<ValidatingDataRowIterator> dataRows) throws ExperimentException
+    protected void importData(ExpRun run, DataIteratorBuilder dataRows) throws ExperimentException
     {
-        try (ValidatingDataRowIterator iter = dataRows.get())
+        try (MapDataIterator iter = DataIteratorUtil.wrapMap(dataRows.getDataIterator(new DataIteratorContext()), true))
         {
             List<? extends ExpData> runData = run.getOutputDatas(ExperimentService.get().getDataType(ElispotDataHandler.NAMESPACE));
             assert(runData.size() == 1);
 
-            while (iter.hasNext())
+            while (iter.next())
             {
-                Map<String, Object> row = iter.next();
+                Map<String, Object> row = iter.getMap();
                 if (!row.containsKey(WELL_ROW_PROPERTY) || !row.containsKey(WELL_COLUMN_PROPERTY))
                     throw new ExperimentException("The row must contain values for well row and column locations : " + WELL_ROW_PROPERTY + ", " + WELL_COLUMN_PROPERTY);
 

--- a/elispotassay/src/org/labkey/elispot/ElispotDataHandler.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotDataHandler.java
@@ -25,6 +25,8 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.statistics.MathStat;
 import org.labkey.api.data.statistics.StatsService;
+import org.labkey.api.dataiterator.AbstractMapDataIterator;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.XarContext;
@@ -36,7 +38,6 @@ import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
-import org.labkey.api.iterator.ValidatingDataRowIterator;
 import org.labkey.api.qc.DataLoaderSettings;
 import org.labkey.api.qc.TransformDataHandler;
 import org.labkey.api.assay.plate.Plate;
@@ -67,7 +68,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 
 /**
  * User: Karl Lum
@@ -204,19 +204,19 @@ public class ElispotDataHandler extends AbstractElispotDataHandler implements Tr
     }
 
     @Override
-    public void importTransformDataMap(ExpData data, AssayRunUploadContext<?> context, ExpRun run, Supplier<ValidatingDataRowIterator> dataMap) throws ExperimentException
+    public void importTransformDataMap(ExpData data, AssayRunUploadContext<?> context, ExpRun run, DataIteratorBuilder dataMap) throws ExperimentException
     {
         importData(run, dataMap);
     }
 
     @Override
-    public Map<DataType, Supplier<ValidatingDataRowIterator>> getValidationDataMap(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context, DataLoaderSettings settings) throws ExperimentException
+    public Map<DataType, DataIteratorBuilder> getValidationDataMap(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context, DataLoaderSettings settings) throws ExperimentException
     {
         ElispotDataFileParser parser = getDataFileParser(data, dataFile, info, log, context);
 
-        Map<DataType, Supplier<ValidatingDataRowIterator>> datas = new HashMap<>();
+        Map<DataType, DataIteratorBuilder> datas = new HashMap<>();
         List<Map<String, Object>> rows = parser.getResults();
-        datas.put(ELISPOT_TRANSFORMED_DATA_TYPE, () -> ValidatingDataRowIterator.of(rows));
+        datas.put(ELISPOT_TRANSFORMED_DATA_TYPE, AbstractMapDataIterator.builderOf(rows));
 
         return datas;
     }

--- a/elispotassay/src/org/labkey/elispot/ElispotDataHandler.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotDataHandler.java
@@ -25,8 +25,8 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.statistics.MathStat;
 import org.labkey.api.data.statistics.StatsService;
-import org.labkey.api.dataiterator.AbstractMapDataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.XarContext;
@@ -216,7 +216,7 @@ public class ElispotDataHandler extends AbstractElispotDataHandler implements Tr
 
         Map<DataType, DataIteratorBuilder> datas = new HashMap<>();
         List<Map<String, Object>> rows = parser.getResults();
-        datas.put(ELISPOT_TRANSFORMED_DATA_TYPE, AbstractMapDataIterator.builderOf(rows));
+        datas.put(ELISPOT_TRANSFORMED_DATA_TYPE, MapDataIterator.of(rows));
 
         return datas;
     }

--- a/elispotassay/src/org/labkey/elispot/ElispotUploadWizardAction.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotUploadWizardAction.java
@@ -562,7 +562,7 @@ public class ElispotUploadWizardAction extends UploadWizardAction<ElispotRunUplo
             catch (ValidationException ve)
             {
                 for (ValidationError error : ve.getErrors())
-                    errors.reject(SpringActionController.ERROR_MSG, PageFlowUtil.filter(error.getMessage()));
+                    errors.reject(SpringActionController.ERROR_MSG, error.getMessage());
             }
             catch (ExperimentException e)
             {

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 import org.labkey.api.audit.AuditLogService;
-import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.data.Aggregate;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
@@ -41,8 +40,8 @@ import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
-import org.labkey.api.dataiterator.AbstractMapDataIterator;
 import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.Handler;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
@@ -1736,7 +1735,7 @@ public class FlowManager
                 }
             });
 
-            OntologyManager.insertTabDelimited(c, user, null, helper, descriptors, AbstractMapDataIterator.of(propMaps, new DataIteratorContext()), true);
+            OntologyManager.insertTabDelimited(c, user, null, helper, descriptors, MapDataIterator.of(propMaps).getDataIterator(new DataIteratorContext()), true, null);
 
             tx.commit();
         }

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 import org.labkey.api.audit.AuditLogService;
+import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.data.Aggregate;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
@@ -1697,6 +1698,7 @@ public class FlowManager
 
         try (DbScope.Transaction tx = getSchema().getScope().ensureTransaction())
         {
+            CaseInsensitiveMapWrapper<Object> sharedMap = new CaseInsensitiveMapWrapper<>(Collections.emptyMap());
             List<Map<String, Object>> propMaps = new ArrayList<>(1000);
 
             SqlSelector ss = new SqlSelector(getSchema(), sqlSelectDateTime);
@@ -1728,7 +1730,7 @@ public class FlowManager
                 }
                 else
                 {
-                    Map<String, Object> propMap = new HashMap<>();
+                    Map<String, Object> propMap = new CaseInsensitiveMapWrapper<>(new HashMap<>(), sharedMap);
                     propMap.put("lsid", row.get("lsid"));
                     propMap.put(fileDatePd.getPropertyURI(), d);
                     propMaps.add(propMap);

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -1698,7 +1698,6 @@ public class FlowManager
 
         try (DbScope.Transaction tx = getSchema().getScope().ensureTransaction())
         {
-            CaseInsensitiveMapWrapper<Object> sharedMap = new CaseInsensitiveMapWrapper<>(Collections.emptyMap());
             List<Map<String, Object>> propMaps = new ArrayList<>(1000);
 
             SqlSelector ss = new SqlSelector(getSchema(), sqlSelectDateTime);
@@ -1730,7 +1729,7 @@ public class FlowManager
                 }
                 else
                 {
-                    Map<String, Object> propMap = new CaseInsensitiveMapWrapper<>(new HashMap<>(), sharedMap);
+                    Map<String, Object> propMap = new HashMap<>();
                     propMap.put("lsid", row.get("lsid"));
                     propMap.put(fileDatePd.getPropertyURI(), d);
                     propMaps.add(propMap);

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -40,6 +40,8 @@ import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
+import org.labkey.api.dataiterator.AbstractMapDataIterator;
+import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.exp.Handler;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
@@ -47,12 +49,11 @@ import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.query.SamplesSchema;
-import org.labkey.api.iterator.ValidatingDataRowIterator;
 import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.FileUtil;
@@ -1734,11 +1735,11 @@ public class FlowManager
                 }
             });
 
-            OntologyManager.insertTabDelimited(c, user, null, helper, descriptors, ValidatingDataRowIterator.of(propMaps.iterator()), true);
+            OntologyManager.insertTabDelimited(c, user, null, helper, descriptors, AbstractMapDataIterator.of(propMaps, new DataIteratorContext()), true);
 
             tx.commit();
         }
-        catch (ValidationException | SQLException ex)
+        catch (BatchValidationException | SQLException ex)
         {
             throw UnexpectedException.wrap(ex);
         }

--- a/luminex/src/org/labkey/luminex/LuminexDataExchangeHandler.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataExchangeHandler.java
@@ -17,8 +17,11 @@
 package org.labkey.luminex;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.property.DomainProperty;
@@ -31,6 +34,7 @@ import org.labkey.luminex.model.Titration;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,9 +58,11 @@ public class LuminexDataExchangeHandler extends TsvDataExchangeHandler
         LuminexRunContext form = (LuminexRunContext)context;
         List<Map<String, Object>> analytes = new ArrayList<>();
 
+        CaseInsensitiveMapWrapper<Object> casingMap = new CaseInsensitiveMapWrapper<>(Collections.emptyMap());
+
         for (String analyteName : form.getAnalyteNames())
         {
-            Map<String, Object> row = new HashMap<>();
+            Map<String, Object> row = new CaseInsensitiveMapWrapper<>(new HashMap<>(), casingMap);
             row.put("Name", analyteName);
             // get the analyte domain property values
             for (Map.Entry<DomainProperty, String> entry : form.getAnalyteProperties(analyteName).entrySet())
@@ -74,10 +80,20 @@ public class LuminexDataExchangeHandler extends TsvDataExchangeHandler
         }
         addSampleProperties(ANALYTE_DATA_PROP_NAME, analytes);
 
+        List<Map<String, Object>> titrations = getTitrationMaps(form);
+        addSampleProperties(TITRATION_DATA_PROP_NAME, titrations);
+
+        return super.createTransformationRunInfo(context, run, scriptDir, runProperties, batchProperties);
+    }
+
+    private static @NotNull List<Map<String, Object>> getTitrationMaps(LuminexRunContext form) throws ExperimentException
+    {
+        CaseInsensitiveMapWrapper<Object> casingMap = new CaseInsensitiveMapWrapper<>(Collections.emptyMap());
+
         List<Map<String, Object>> titrations = new ArrayList<>();
         for (Titration titration : form.getTitrations())
         {
-            Map<String, Object> titrationRow = new HashMap<>();
+            Map<String, Object> titrationRow = new CaseInsensitiveMapWrapper<>(new HashMap<>(), casingMap);
             titrationRow.put("Name", titration.getName());
             titrationRow.put("QCControl", titration.isQcControl());
             titrationRow.put("Standard", titration.isStandard());
@@ -85,9 +101,7 @@ public class LuminexDataExchangeHandler extends TsvDataExchangeHandler
             titrationRow.put("OtherControl", titration.isOtherControl());
             titrations.add(titrationRow);
         }
-        addSampleProperties(TITRATION_DATA_PROP_NAME, titrations);
-
-        return super.createTransformationRunInfo(context, run, scriptDir, runProperties, batchProperties);
+        return titrations;
     }
 
     @Override

--- a/luminex/src/org/labkey/luminex/LuminexDataExchangeHandler.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataExchangeHandler.java
@@ -18,10 +18,10 @@ package org.labkey.luminex;
 
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.property.DomainProperty;
-import org.labkey.api.iterator.ValidatingDataRowIterator;
 import org.labkey.api.qc.TsvDataExchangeHandler;
 import org.labkey.api.qc.TsvDataSerializer;
 import org.labkey.api.assay.AssayProvider;
@@ -35,7 +35,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 
 /**
  * Adds analyte and titration info for transform scripts
@@ -100,7 +99,7 @@ public class LuminexDataExchangeHandler extends TsvDataExchangeHandler
     private static class LuminexDataSerializer extends TsvDataSerializer
     {
         @Override
-        public Supplier<ValidatingDataRowIterator> importRunData(ExpProtocol protocol, File runData) throws Exception
+        public DataIteratorBuilder importRunData(ExpProtocol protocol, File runData) throws Exception
         {
             return _importRunData(protocol, runData, false);
         }

--- a/luminex/src/org/labkey/luminex/LuminexDataExchangeHandler.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataExchangeHandler.java
@@ -18,7 +18,6 @@ package org.labkey.luminex;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.exp.ExperimentException;
@@ -34,7 +33,6 @@ import org.labkey.luminex.model.Titration;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,11 +56,9 @@ public class LuminexDataExchangeHandler extends TsvDataExchangeHandler
         LuminexRunContext form = (LuminexRunContext)context;
         List<Map<String, Object>> analytes = new ArrayList<>();
 
-        CaseInsensitiveMapWrapper<Object> casingMap = new CaseInsensitiveMapWrapper<>(Collections.emptyMap());
-
         for (String analyteName : form.getAnalyteNames())
         {
-            Map<String, Object> row = new CaseInsensitiveMapWrapper<>(new HashMap<>(), casingMap);
+            Map<String, Object> row = new HashMap<>();
             row.put("Name", analyteName);
             // get the analyte domain property values
             for (Map.Entry<DomainProperty, String> entry : form.getAnalyteProperties(analyteName).entrySet())
@@ -88,12 +84,10 @@ public class LuminexDataExchangeHandler extends TsvDataExchangeHandler
 
     private static @NotNull List<Map<String, Object>> getTitrationMaps(LuminexRunContext form) throws ExperimentException
     {
-        CaseInsensitiveMapWrapper<Object> casingMap = new CaseInsensitiveMapWrapper<>(Collections.emptyMap());
-
         List<Map<String, Object>> titrations = new ArrayList<>();
         for (Titration titration : form.getTitrations())
         {
-            Map<String, Object> titrationRow = new CaseInsensitiveMapWrapper<>(new HashMap<>(), casingMap);
+            Map<String, Object> titrationRow = new HashMap<>();
             titrationRow.put("Name", titration.getName());
             titrationRow.put("QCControl", titration.isQcControl());
             titrationRow.put("Standard", titration.isStandard());
@@ -113,7 +107,7 @@ public class LuminexDataExchangeHandler extends TsvDataExchangeHandler
     private static class LuminexDataSerializer extends TsvDataSerializer
     {
         @Override
-        public DataIteratorBuilder importRunData(ExpProtocol protocol, File runData) throws Exception
+        public DataIteratorBuilder importRunData(ExpProtocol protocol, File runData)
         {
             return _importRunData(protocol, runData, false);
         }

--- a/luminex/src/org/labkey/luminex/LuminexDataHandler.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataHandler.java
@@ -2057,12 +2057,13 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
 
         Set<String> excludedWells = LuminexManager.get().getWellExclusionKeysForRun(runId, protocol, info.getContainer(), info.getUser());
 
+        CaseInsensitiveMapWrapper<Object> casingMap = new CaseInsensitiveMapWrapper<>(Collections.emptyMap());
         for (Map.Entry<Analyte, List<LuminexDataRow>> entry : parser.getSheets().entrySet())
         {
             for (LuminexDataRow dataRow : entry.getValue())
             {
                 handleParticipantResolver(dataRow, resolver, new LinkedHashMap<>(), true);
-                Map<String, Object> dataMap = dataRow.toMap(entry.getKey());
+                Map<String, Object> dataMap = new CaseInsensitiveMapWrapper<>(dataRow.toMap(entry.getKey()), casingMap);
                 dataMap.put("titration", dataRow.getDescription() != null && titrations.contains(dataRow.getDescription()));
                 dataMap.remove("data");
 

--- a/luminex/src/org/labkey/luminex/LuminexDataHandler.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataHandler.java
@@ -22,7 +22,6 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
@@ -42,7 +41,6 @@ import org.labkey.api.data.Table;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.statistics.MathStat;
 import org.labkey.api.data.statistics.StatsService;
-import org.labkey.api.dataiterator.AbstractMapDataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.DataIteratorUtil;
@@ -79,6 +77,7 @@ import org.labkey.api.study.assay.StudyParticipantVisitResolverType;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewBackgroundInfo;
@@ -147,7 +146,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
     public static final String NEGATIVE_BEAD_DISPLAY_NAME = "Subtract Negative Bead";
     public static final Double MAX_CURVE_PARAM_VALUE = 10e37; // Issue 15200
 
-    private static final Logger LOGGER = LogManager.getLogger(LuminexDataHandler.class);
+    private static final Logger LOGGER = LogHelper.getLogger(LuminexDataHandler.class, "Parses and imports Luminex data");
 
     public static final int MINIMUM_TITRATION_SUMMARY_COUNT = 5;
     public static final int MINIMUM_TITRATION_RAW_COUNT = 10;
@@ -574,11 +573,11 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
         LuminexImportHelper helper = new LuminexImportHelper();
         if (!insertRows.isEmpty())
         {
-            OntologyManager.insertTabDelimited(tableInfo, expRun.getContainer(), user, helper, AbstractMapDataIterator.of(insertRows, new DataIteratorContext()), LogManager.getLogger(LuminexDataHandler.class));
+            OntologyManager.insertTabDelimited(tableInfo, expRun.getContainer(), user, helper, MapDataIterator.of(insertRows).getDataIterator(new DataIteratorContext()), true, LOGGER, null);
         }
         if (!updateRows.isEmpty())
         {
-            OntologyManager.updateTabDelimited(tableInfo, expRun.getContainer(), user, helper, AbstractMapDataIterator.of(updateRows, new DataIteratorContext()), LogManager.getLogger(LuminexDataHandler.class));
+            OntologyManager.updateTabDelimited(tableInfo, expRun.getContainer(), user, helper, MapDataIterator.of(updateRows).getDataIterator(new DataIteratorContext()), true, LOGGER);
         }
     }
 
@@ -1656,7 +1655,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
             public void updateStatistics(int currentRow)
             {
             }
-        }, domain, AbstractMapDataIterator.of(excelRunPropsList, new DataIteratorContext()), true, null);
+        }, domain, MapDataIterator.of(excelRunPropsList).getDataIterator(new DataIteratorContext()), true, null);
     }
 
     protected void performOOR(List<LuminexDataRow> dataRows, Analyte analyte)
@@ -2073,7 +2072,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
                 dataRows.add(dataMap);
             }
         }
-        datas.put(LUMINEX_TRANSFORMED_DATA_TYPE, AbstractMapDataIterator.builderOf(dataRows));
+        datas.put(LUMINEX_TRANSFORMED_DATA_TYPE, MapDataIterator.of(dataRows));
         return datas;
     }
 

--- a/luminex/src/org/labkey/luminex/LuminexDataHandler.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataHandler.java
@@ -43,7 +43,6 @@ import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.statistics.MathStat;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.dataiterator.AbstractMapDataIterator;
-import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.DataIteratorUtil;
@@ -552,7 +551,6 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
             existingRows.put(new DataRowKey(existingRow), existingRow);
         }
 
-        CaseInsensitiveMapWrapper<Object> sharedMap = new CaseInsensitiveMapWrapper<>(Collections.emptyMap());
         List<Map<String, Object>> insertRows = new ArrayList<>();
         List<Map<String, Object>> updateRows = new ArrayList<>();
 
@@ -562,11 +560,11 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
             LuminexDataRow existingRow = existingRows.get(entry.getKey());
             if (existingRow == null)
             {
-                insertRows.add(new CaseInsensitiveMapWrapper<>(entry.getValue(), sharedMap));
+                insertRows.add(entry.getValue());
             }
             else
             {
-                Map<String, Object> updateRow = new CaseInsensitiveMapWrapper<>(entry.getValue(), sharedMap);
+                Map<String, Object> updateRow = entry.getValue();
                 updateRow.put("RowId", existingRow.getRowId());
                 updateRow.put("LSID", existingRow.getLsid());
                 updateRows.add(updateRow);
@@ -2057,13 +2055,12 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
 
         Set<String> excludedWells = LuminexManager.get().getWellExclusionKeysForRun(runId, protocol, info.getContainer(), info.getUser());
 
-        CaseInsensitiveMapWrapper<Object> casingMap = new CaseInsensitiveMapWrapper<>(Collections.emptyMap());
         for (Map.Entry<Analyte, List<LuminexDataRow>> entry : parser.getSheets().entrySet())
         {
             for (LuminexDataRow dataRow : entry.getValue())
             {
                 handleParticipantResolver(dataRow, resolver, new LinkedHashMap<>(), true);
-                Map<String, Object> dataMap = new CaseInsensitiveMapWrapper<>(dataRow.toMap(entry.getKey()), casingMap);
+                Map<String, Object> dataMap = dataRow.toMap(entry.getKey());
                 dataMap.put("titration", dataRow.getDescription() != null && titrations.contains(dataRow.getDescription()));
                 dataMap.remove("data");
 

--- a/luminex/src/org/labkey/luminex/LuminexDataHandler.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataHandler.java
@@ -2090,7 +2090,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
 
         Map<Analyte, List<LuminexDataRow>> sheets = new LinkedHashMap<>();
         Lsid.LsidBuilder builder = new Lsid.LsidBuilder(LuminexAssayProvider.LUMINEX_DATA_ROW_LSID_PREFIX,"");
-        try (MapDataIterator iter = DataIteratorUtil.wrapMap(dataMaps.getDataIterator(new DataIteratorContext()), true))
+        try (MapDataIterator iter = DataIteratorUtil.wrapMap(dataMaps.getDataIterator(new DataIteratorContext()), false))
         {
             while (iter.next())
             {

--- a/nab/src/org/labkey/nab/NabDataHandler.java
+++ b/nab/src/org/labkey/nab/NabDataHandler.java
@@ -164,7 +164,7 @@ public abstract class NabDataHandler extends DilutionDataHandler
         for (ExpMaterial material : run.getMaterialInputs().keySet())
             inputMaterialMap.put(material.getLSID(), material);
 
-        try (MapDataIterator iter = DataIteratorUtil.wrapMap(rawData.getDataIterator(new DataIteratorContext()), true))
+        try (MapDataIterator iter = DataIteratorUtil.wrapMap(rawData.getDataIterator(new DataIteratorContext()), false))
         {
             while (iter.next())
             {

--- a/nab/src/org/labkey/nab/NabDataHandler.java
+++ b/nab/src/org/labkey/nab/NabDataHandler.java
@@ -28,8 +28,6 @@ import org.labkey.api.assay.nab.query.NAbSpecimenTable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.statistics.StatsService;
-import org.labkey.api.dataiterator.AbstractMapDataIterator;
-import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.DataIteratorUtil;
@@ -141,7 +139,7 @@ public abstract class NabDataHandler extends DilutionDataHandler
     public void recalculateDilutionStats(ExpData data, ExpRun run, ExpProtocol protocol, List<Map<String, Object>> rawData,
                                          List<Map<String, Object>> specimenRows, List<Map<String, Object>> cutoffRows) throws ExperimentException
     {
-        _populateDilutionStats(data, run, protocol, AbstractMapDataIterator.builderOf(rawData), Collections.emptyMap(), false, specimenRows, cutoffRows);
+        _populateDilutionStats(data, run, protocol, MapDataIterator.of(rawData), Collections.emptyMap(), false, specimenRows, cutoffRows);
     }
 
     /**

--- a/nab/src/org/labkey/nab/NabDataHandler.java
+++ b/nab/src/org/labkey/nab/NabDataHandler.java
@@ -28,6 +28,12 @@ import org.labkey.api.assay.nab.query.NAbSpecimenTable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.statistics.StatsService;
+import org.labkey.api.dataiterator.AbstractMapDataIterator;
+import org.labkey.api.dataiterator.DataIterator;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.dataiterator.DataIteratorUtil;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.api.DataType;
@@ -36,13 +42,13 @@ import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
-import org.labkey.api.iterator.ValidatingDataRowIterator;
-import org.labkey.api.query.ValidationException;
+import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.util.Pair;
 import org.labkey.nab.query.NabProtocolSchema;
 
 import java.io.File;
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,7 +56,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 /**
  * User: klum
@@ -112,7 +117,7 @@ public abstract class NabDataHandler extends DilutionDataHandler
     }
 
     @Override
-    protected void importRows(ExpData data, ExpRun run, ExpProtocol protocol, Supplier<ValidatingDataRowIterator> rawData, User user) throws ExperimentException
+    protected void importRows(ExpData data, ExpRun run, ExpProtocol protocol, DataIteratorBuilder rawData, User user) throws ExperimentException
     {
         Map<Integer, String> cutoffFormats = getCutoffFormats(protocol, run);
         Map<String, Pair<Integer, String>> wellGroupNameToNabSpecimen = new HashMap<>();
@@ -124,7 +129,7 @@ public abstract class NabDataHandler extends DilutionDataHandler
     /**
      * Populates cutoff and AUC information from the passed in raw data
      */
-    public void populateDilutionStats(ExpData data, ExpRun run, ExpProtocol protocol, Supplier<ValidatingDataRowIterator> rawData,
+    public void populateDilutionStats(ExpData data, ExpRun run, ExpProtocol protocol, DataIteratorBuilder rawData,
                                       Map<String, Pair<Integer, String>> wellgroupNameToNabSpecimen) throws ExperimentException
     {
         _populateDilutionStats(data, run, protocol, rawData, wellgroupNameToNabSpecimen, true, Collections.emptyList(), Collections.emptyList());
@@ -136,7 +141,7 @@ public abstract class NabDataHandler extends DilutionDataHandler
     public void recalculateDilutionStats(ExpData data, ExpRun run, ExpProtocol protocol, List<Map<String, Object>> rawData,
                                          List<Map<String, Object>> specimenRows, List<Map<String, Object>> cutoffRows) throws ExperimentException
     {
-        _populateDilutionStats(data, run, protocol, () -> ValidatingDataRowIterator.of(rawData), Collections.emptyMap(), false, specimenRows, cutoffRows);
+        _populateDilutionStats(data, run, protocol, AbstractMapDataIterator.builderOf(rawData), Collections.emptyMap(), false, specimenRows, cutoffRows);
     }
 
     /**
@@ -147,7 +152,7 @@ public abstract class NabDataHandler extends DilutionDataHandler
      * @param specimenRows if commitData is false, then specimen data will be returned in this collection
      * @param cutoffRows if commitData is false, then cutoff data will be returned in this collection
      */
-    private void _populateDilutionStats(ExpData data, ExpRun run, ExpProtocol protocol, Supplier<ValidatingDataRowIterator> rawData,
+    private void _populateDilutionStats(ExpData data, ExpRun run, ExpProtocol protocol, DataIteratorBuilder rawData,
                                         Map<String, Pair<Integer, String>> wellGroupNameToNabSpecimen, boolean commitData,
                                         List<Map<String, Object>> specimenRows, List<Map<String, Object>> cutoffRows) throws ExperimentException
     {
@@ -159,11 +164,11 @@ public abstract class NabDataHandler extends DilutionDataHandler
         for (ExpMaterial material : run.getMaterialInputs().keySet())
             inputMaterialMap.put(material.getLSID(), material);
 
-        try (ValidatingDataRowIterator iter = rawData.get())
+        try (MapDataIterator iter = DataIteratorUtil.wrapMap(rawData.getDataIterator(new DataIteratorContext()), true))
         {
-            while (iter.hasNext())
+            while (iter.next())
             {
-                Map<String, Object> group = iter.next();
+                Map<String, Object> group = iter.getMap();
                 if (!group.containsKey(WELLGROUP_NAME_PROPERTY))
                     throw new ExperimentException("The row must contain a value for the well group name : " + WELLGROUP_NAME_PROPERTY);
 
@@ -252,7 +257,7 @@ public abstract class NabDataHandler extends DilutionDataHandler
             if (commitData)
                 NabProtocolSchema.clearProtocolFromCutoffCache(protocol.getRowId());
         }
-        catch (ValidationException e)
+        catch (BatchValidationException | IOException e)
         {
             throw new ExperimentException(e);
         }

--- a/nab/src/org/labkey/nab/SinglePlateNabDataHandler.java
+++ b/nab/src/org/labkey/nab/SinglePlateNabDataHandler.java
@@ -37,6 +37,8 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.statistics.StatsService;
+import org.labkey.api.dataiterator.AbstractMapDataIterator;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.PropertyDescriptor;
@@ -47,7 +49,6 @@ import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.property.DomainProperty;
-import org.labkey.api.iterator.ValidatingDataRowIterator;
 import org.labkey.api.qc.DataLoaderSettings;
 import org.labkey.api.qc.TransformDataHandler;
 import org.labkey.api.query.FieldKey;
@@ -72,7 +73,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 
 /**
  * User: brittp
@@ -349,19 +349,19 @@ public class SinglePlateNabDataHandler extends NabDataHandler implements Transfo
     }
 
     @Override
-    public void importTransformDataMap(ExpData data, AssayRunUploadContext<?> context, ExpRun run, Supplier<ValidatingDataRowIterator> dataMap) throws ExperimentException
+    public void importTransformDataMap(ExpData data, AssayRunUploadContext<?> context, ExpRun run, DataIteratorBuilder dataMap) throws ExperimentException
     {
         importRows(data, run, context.getProtocol(), dataMap, context.getUser());
     }
 
     @Override
-    public Map<DataType, Supplier<ValidatingDataRowIterator>> getValidationDataMap(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context, DataLoaderSettings settings) throws ExperimentException
+    public Map<DataType, DataIteratorBuilder> getValidationDataMap(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context, DataLoaderSettings settings) throws ExperimentException
     {
         DilutionDataFileParser parser = getDataFileParser(data, dataFile, info);
 
-        Map<DataType, Supplier<ValidatingDataRowIterator>> datas = new HashMap<>();
+        Map<DataType, DataIteratorBuilder> datas = new HashMap<>();
         List<Map<String, Object>> rows = parser.getResults();
-        datas.put(NAB_TRANSFORMED_DATA_TYPE, () -> ValidatingDataRowIterator.of(rows));
+        datas.put(NAB_TRANSFORMED_DATA_TYPE, AbstractMapDataIterator.builderOf(rows));
 
         return datas;
     }

--- a/nab/src/org/labkey/nab/SinglePlateNabDataHandler.java
+++ b/nab/src/org/labkey/nab/SinglePlateNabDataHandler.java
@@ -37,8 +37,8 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.statistics.StatsService;
-import org.labkey.api.dataiterator.AbstractMapDataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.PropertyDescriptor;
@@ -361,7 +361,7 @@ public class SinglePlateNabDataHandler extends NabDataHandler implements Transfo
 
         Map<DataType, DataIteratorBuilder> datas = new HashMap<>();
         List<Map<String, Object>> rows = parser.getResults();
-        datas.put(NAB_TRANSFORMED_DATA_TYPE, AbstractMapDataIterator.builderOf(rows));
+        datas.put(NAB_TRANSFORMED_DATA_TYPE, MapDataIterator.of(rows));
 
         return datas;
     }

--- a/nab/src/org/labkey/nab/multiplate/HighThroughputNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/HighThroughputNabDataHandler.java
@@ -25,6 +25,8 @@ import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.WellData;
 import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.dataiterator.AbstractMapDataIterator;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.XarContext;
@@ -33,7 +35,6 @@ import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.property.DomainProperty;
-import org.labkey.api.iterator.ValidatingDataRowIterator;
 import org.labkey.api.qc.DataLoaderSettings;
 import org.labkey.api.qc.TransformDataHandler;
 import org.labkey.api.reader.ColumnDescriptor;
@@ -51,7 +52,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 /**
  * User: brittp
@@ -238,19 +238,19 @@ public abstract class HighThroughputNabDataHandler extends NabDataHandler implem
     }
 
     @Override
-    public Map<DataType, Supplier<ValidatingDataRowIterator>> getValidationDataMap(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context, DataLoaderSettings settings) throws ExperimentException
+    public Map<DataType, DataIteratorBuilder> getValidationDataMap(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context, DataLoaderSettings settings) throws ExperimentException
     {
         DilutionDataFileParser parser = getDataFileParser(data, dataFile, info);
 
-        Map<DataType, Supplier<ValidatingDataRowIterator>> datas = new HashMap<>();
+        Map<DataType, DataIteratorBuilder> datas = new HashMap<>();
         List<Map<String, Object>> rows = parser.getResults();
-        datas.put(NAB_TRANSFORMED_DATA_TYPE, () -> ValidatingDataRowIterator.of(rows));
+        datas.put(NAB_TRANSFORMED_DATA_TYPE, AbstractMapDataIterator.builderOf(rows));
 
         return datas;
     }
 
     @Override
-    public void importTransformDataMap(ExpData data, AssayRunUploadContext<?> context, ExpRun run, Supplier<ValidatingDataRowIterator> dataMap) throws ExperimentException
+    public void importTransformDataMap(ExpData data, AssayRunUploadContext<?> context, ExpRun run, DataIteratorBuilder dataMap) throws ExperimentException
     {
         importRows(data, run, context.getProtocol(), dataMap, context.getUser());
     }

--- a/nab/src/org/labkey/nab/multiplate/HighThroughputNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/HighThroughputNabDataHandler.java
@@ -25,8 +25,8 @@ import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.WellData;
 import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.dataiterator.AbstractMapDataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.XarContext;
@@ -244,7 +244,7 @@ public abstract class HighThroughputNabDataHandler extends NabDataHandler implem
 
         Map<DataType, DataIteratorBuilder> datas = new HashMap<>();
         List<Map<String, Object>> rows = parser.getResults();
-        datas.put(NAB_TRANSFORMED_DATA_TYPE, AbstractMapDataIterator.builderOf(rows));
+        datas.put(NAB_TRANSFORMED_DATA_TYPE, MapDataIterator.of(rows));
 
         return datas;
     }

--- a/protein/src/org/labkey/protein/ProteinController.java
+++ b/protein/src/org/labkey/protein/ProteinController.java
@@ -44,8 +44,8 @@ import org.labkey.api.data.Sort;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.dataiterator.AbstractMapDataIterator;
 import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.DomainDescriptor;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.OntologyManager;
@@ -608,7 +608,7 @@ public class ProteinController extends SpringActionController
                 int ownerObjectId = OntologyManager.ensureObject(getContainer(), annotationSet.getLsid());
                 OntologyManager.ImportHelper helper = new CustomAnnotationImportHelper(stmt, connection, annotationSet.getLsid(), lookupStringColumnName);
 
-                OntologyManager.insertTabDelimited(getContainer(), getUser(), ownerObjectId, helper, descriptors, AbstractMapDataIterator.of(rows, new DataIteratorContext()), false);
+                OntologyManager.insertTabDelimited(getContainer(), getUser(), ownerObjectId, helper, descriptors, MapDataIterator.of(rows).getDataIterator(new DataIteratorContext()), false, null);
 
                 stmt.executeBatch();
                 connection.commit();

--- a/viability/src/org/labkey/viability/GuavaDataHandler.java
+++ b/viability/src/org/labkey/viability/GuavaDataHandler.java
@@ -24,8 +24,8 @@ import org.labkey.api.assay.AssayDataType;
 import org.labkey.api.assay.AssayRunUploadContext;
 import org.labkey.api.assay.AssayUploadXarContext;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
-import org.labkey.api.dataiterator.AbstractMapDataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.XarContext;
@@ -409,7 +409,7 @@ public class GuavaDataHandler extends ViabilityAssayDataHandler implements Trans
             }
 
             // Use the .tsv DATA_TYPE so the results will be read back in by the ViabilityTsvDataHandler after transformation
-            result.put(ViabilityTsvDataHandler.DATA_TYPE, AbstractMapDataIterator.builderOf(rows));
+            result.put(ViabilityTsvDataHandler.DATA_TYPE, MapDataIterator.of(rows));
         }
         else
         {

--- a/viability/src/org/labkey/viability/GuavaDataHandler.java
+++ b/viability/src/org/labkey/viability/GuavaDataHandler.java
@@ -24,6 +24,8 @@ import org.labkey.api.assay.AssayDataType;
 import org.labkey.api.assay.AssayRunUploadContext;
 import org.labkey.api.assay.AssayUploadXarContext;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.dataiterator.AbstractMapDataIterator;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.XarContext;
@@ -32,7 +34,6 @@ import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
-import org.labkey.api.iterator.ValidatingDataRowIterator;
 import org.labkey.api.qc.DataLoaderSettings;
 import org.labkey.api.qc.TransformDataHandler;
 import org.labkey.api.reader.ColumnDescriptor;
@@ -49,7 +50,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 /**
  * User: kevink
@@ -73,7 +73,7 @@ public class GuavaDataHandler extends ViabilityAssayDataHandler implements Trans
         if (DATA_TYPE.matches(lsid) || OLD_DATA_TYPE.matches(lsid))
         {
             File f = data.getFile();
-            if (f != null && f.getName() != null)
+            if (f != null)
             {
                 String lowerName = f.getName().toLowerCase();
                 if (lowerName.endsWith(".csv"))
@@ -125,15 +125,15 @@ public class GuavaDataHandler extends ViabilityAssayDataHandler implements Trans
 
                     if (!foundBlankLine)
                     {
-                        if (line.length() == 0 || parts.length == 0 || parts[0].length() == 0)
+                        if (line.isEmpty() || parts.length == 0 || parts[0].isEmpty())
                         {
                             foundBlankLine = true;
                         }
                         else
                         {
-                            String firstCell = parts.length > 0 ? parts[0] : line;
+                            String firstCell = parts[0];
                             String[] runMeta = firstCell.split(" - ", 2);
-                            if (runMeta.length == 2 && runMeta[0].length() > 0 && runMeta[1].length() > 0)
+                            if (runMeta.length == 2 && !runMeta[0].isEmpty() && !runMeta[1].isEmpty())
                             {
                                 String runHeaderKey = runMeta[0].trim();
                                 String runHeaderValue = runMeta[1].trim();
@@ -157,7 +157,7 @@ public class GuavaDataHandler extends ViabilityAssayDataHandler implements Trans
                     else
                     {
                         // skip blank or entirely empty lines after the first
-                        if (line.length() == 0 || parts.length == 0 || Arrays.stream(parts).allMatch(StringUtils::isEmpty))
+                        if (line.isEmpty() || parts.length == 0 || Arrays.stream(parts).allMatch(StringUtils::isEmpty))
                             continue;
 
                         // skip line containing disclaimer
@@ -168,15 +168,11 @@ public class GuavaDataHandler extends ViabilityAssayDataHandler implements Trans
                         {
                             groupHeaders = parts;
                         }
-                        else if (headers == null)
+                        else
                         {
                             headers = parts;
                             // found both header lines.
                             break;
-                        }
-                        else
-                        {
-                            assert false : "should have stopped parsing";
                         }
                     }
 
@@ -386,9 +382,9 @@ public class GuavaDataHandler extends ViabilityAssayDataHandler implements Trans
     }
 
     @Override
-    public Map<DataType, Supplier<ValidatingDataRowIterator>> getValidationDataMap(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context, DataLoaderSettings settings) throws ExperimentException
+    public Map<DataType, DataIteratorBuilder> getValidationDataMap(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context, DataLoaderSettings settings) throws ExperimentException
     {
-        Map<DataType, Supplier<ValidatingDataRowIterator>> result = new HashMap<>();
+        Map<DataType, DataIteratorBuilder> result = new HashMap<>();
         if (context instanceof AssayUploadXarContext xarContext)
         {
             List<Map<String, Object>> rows;
@@ -412,8 +408,8 @@ public class GuavaDataHandler extends ViabilityAssayDataHandler implements Trans
                 ViabilityAssayDataHandler.validateData(rows, false);
             }
 
-            // Use the .tsv DATA_TYPE so the results will be read back in by the ViabilityTsvDataHandler after transormation
-            result.put(ViabilityTsvDataHandler.DATA_TYPE, () -> ValidatingDataRowIterator.of(rows));
+            // Use the .tsv DATA_TYPE so the results will be read back in by the ViabilityTsvDataHandler after transformation
+            result.put(ViabilityTsvDataHandler.DATA_TYPE, AbstractMapDataIterator.builderOf(rows));
         }
         else
         {

--- a/viability/src/org/labkey/viability/ViabilityAssayDataHandler.java
+++ b/viability/src/org/labkey/viability/ViabilityAssayDataHandler.java
@@ -318,7 +318,7 @@ public abstract class ViabilityAssayDataHandler extends AbstractAssayTsvDataHand
                                                       OntologyManager.RowCallback rowCallback)
             throws BatchValidationException
     {
-        MapDataIterator mapData = DataIteratorUtil.wrapMap(fileData, true);
+        MapDataIterator mapData = DataIteratorUtil.wrapMap(fileData, false);
         // Find the target study property on the batch, run, or result domains.
         // If the target study is on the batch or run domain, get the value from the ExpRun or the ExpExperiment.
         // If the target study is on the result domain, pass the DomainProperty to splitBaseFromExtra()

--- a/viability/src/org/labkey/viability/ViabilityAssayDataHandler.java
+++ b/viability/src/org/labkey/viability/ViabilityAssayDataHandler.java
@@ -23,6 +23,9 @@ import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.dataiterator.DataIterator;
+import org.labkey.api.dataiterator.DataIteratorUtil;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
@@ -33,7 +36,7 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
-import org.labkey.api.iterator.ValidatingDataRowIterator;
+import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.assay.AbstractAssayProvider;
@@ -149,12 +152,12 @@ public abstract class ViabilityAssayDataHandler extends AbstractAssayTsvDataHand
                             visit = poolID.substring(sep+1).trim();
                         }
 
-                        if (ptid != null && ptid.length() > 0)
+                        if (!ptid.isEmpty())
                         {
                             row.put(AbstractAssayProvider.PARTICIPANTID_PROPERTY_NAME, ptid);
                         }
 
-                        if (visit != null && visit.length() > 0)
+                        if (visit != null && !visit.isEmpty())
                         {
                             try
                             {
@@ -177,7 +180,7 @@ public abstract class ViabilityAssayDataHandler extends AbstractAssayTsvDataHand
         protected Object convert(DomainProperty dp, String value) throws ExperimentException
         {
             PropertyDescriptor pd = dp.getPropertyDescriptor();
-            Class type = pd.getPropertyType().getJavaType();
+            Class<?> type = pd.getPropertyType().getJavaType();
             try
             {
                 return ConvertUtils.convert(value, type);
@@ -271,21 +274,20 @@ public abstract class ViabilityAssayDataHandler extends AbstractAssayTsvDataHand
         {
             Map<String, Object> row = it.next();
             String poolID = String.valueOf(row.get(ViabilityAssayProvider.POOL_ID_PROPERTY_NAME));
-            if (poolID == null || poolID.length() == 0)
+            if (poolID == null || poolID.isEmpty())
                 throw new ExperimentException(ViabilityAssayProvider.POOL_ID_PROPERTY_NAME + " required");
 
             if (requireSpecimens)
             {
                 Object obj = row.get(ViabilityAssayProvider.SPECIMENIDS_PROPERTY_NAME);
-                if (!(obj instanceof String[]))
+                if (!(obj instanceof String[] specimenIDs))
                     throw new ExperimentException(ViabilityAssayProvider.SPECIMENIDS_PROPERTY_NAME + " required");
-                String[] specimenIDs = (String[]) obj;
                 if (specimenIDs.length == 0)
                     throw new ExperimentException(ViabilityAssayProvider.SPECIMENIDS_PROPERTY_NAME + " required");
                 for (int i = 0; i < specimenIDs.length; i++)
                 {
                     String specimenID = specimenIDs[i];
-                    if (specimenID == null || specimenID.length() == 0)
+                    if (specimenID == null || specimenID.isEmpty())
                         throw new ExperimentException(ViabilityAssayProvider.SPECIMENIDS_PROPERTY_NAME + "[" + i + "] is empty or null.");
 
                     // XXX: check all specimens come from the same study.
@@ -296,10 +298,10 @@ public abstract class ViabilityAssayDataHandler extends AbstractAssayTsvDataHand
     }
 
     @Override
-    protected ValidatingDataRowIterator convertPropertyNamesToURIs(ValidatingDataRowIterator dataMaps, Domain domain)
+    protected DataIterator convertPropertyNamesToURIs(DataIterator dataMaps, Domain domain)
     {
         // XXX: pass data thru untouched for now.
-        return ValidatingDataRowIterator.of(dataMaps);
+        return dataMaps;
     }
 
     @Override
@@ -310,12 +312,13 @@ public abstract class ViabilityAssayDataHandler extends AbstractAssayTsvDataHand
                                                       ExpProtocol protocol,
                                                       AssayProvider provider,
                                                       Domain dataDomain,
-                                                      ValidatingDataRowIterator fileData,
+                                                      DataIterator fileData,
                                                       TableInfo tableInfo,
                                                       boolean autoFillDefaultColumns,
                                                       OntologyManager.RowCallback rowCallback)
-            throws ValidationException
+            throws BatchValidationException
     {
+        MapDataIterator mapData = DataIteratorUtil.wrapMap(fileData, true);
         // Find the target study property on the batch, run, or result domains.
         // If the target study is on the batch or run domain, get the value from the ExpRun or the ExpExperiment.
         // If the target study is on the result domain, pass the DomainProperty to splitBaseFromExtra()
@@ -348,9 +351,9 @@ public abstract class ViabilityAssayDataHandler extends AbstractAssayTsvDataHand
         }
 
         int rowIndex = 0;
-        while (fileData.hasNext())
+        while (mapData.next())
         {
-            Map<String, Object> row = fileData.next();
+            Map<String, Object> row = mapData.getMap();
             Pair<Map<String, Object>, Map<PropertyDescriptor, Object>> pair = splitBaseFromExtra(row, importMap, resultLevelTargetStudyProperty);
             Map<String, Object> base = pair.first;
             Map<PropertyDescriptor, Object> extra = pair.second;
@@ -371,7 +374,14 @@ public abstract class ViabilityAssayDataHandler extends AbstractAssayTsvDataHand
             result.setContainer(container.getId());
             result.setProtocolID(protocol.getRowId());
 
-            ViabilityManager.saveResult(user, container, result, rowIndex++);
+            try
+            {
+                ViabilityManager.saveResult(user, container, result, rowIndex++);
+            }
+            catch (ValidationException e)
+            {
+                throw new BatchValidationException(e);
+            }
         }
 
         ViabilityManager.updateSpecimenAggregates(user, container, provider, protocol, run);
@@ -406,7 +416,7 @@ public abstract class ViabilityAssayDataHandler extends AbstractAssayTsvDataHand
         private File getViabilitySampleDirectory() throws IOException
         {
             File viabilityFiles = JunitUtil.getSampleData(null, "viability");
-            assertTrue("Expected to find viability test files", null != viabilityFiles && viabilityFiles.exists());
+            assertTrue("Expected to find viability test files", viabilityFiles.exists());
 
             return viabilityFiles;
         }

--- a/viability/src/org/labkey/viability/ViabilityDataExchangeHandler.java
+++ b/viability/src/org/labkey/viability/ViabilityDataExchangeHandler.java
@@ -16,8 +16,8 @@
 
 package org.labkey.viability;
 
-import org.labkey.api.dataiterator.AbstractMapDataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.ExperimentDataHandler;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -60,9 +60,9 @@ public class ViabilityDataExchangeHandler extends TsvDataExchangeHandler
                 ViabilityAssayDataHandler.Parser parser = viabilityHandler.getParser(provider.getRunDomain(protocol),
                         provider.getResultsDomain(protocol), runData);
                 List<Map<String, Object>> rows = parser.getResultData();
-                return AbstractMapDataIterator.builderOf(rows);
+                return MapDataIterator.of(rows);
             }
-            return AbstractMapDataIterator.builderOf(Collections.emptyList());
+            return MapDataIterator.of(Collections.emptyList());
         }
     }
 }

--- a/viability/src/org/labkey/viability/ViabilityDataExchangeHandler.java
+++ b/viability/src/org/labkey/viability/ViabilityDataExchangeHandler.java
@@ -16,11 +16,12 @@
 
 package org.labkey.viability;
 
+import org.labkey.api.dataiterator.AbstractMapDataIterator;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.exp.ExperimentDataHandler;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExperimentService;
-import org.labkey.api.iterator.ValidatingDataRowIterator;
 import org.labkey.api.qc.TsvDataExchangeHandler;
 import org.labkey.api.qc.TsvDataSerializer;
 import org.labkey.api.assay.AssayProvider;
@@ -30,7 +31,6 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 /**
  * User: klum
@@ -38,7 +38,7 @@ import java.util.function.Supplier;
  */
 public class ViabilityDataExchangeHandler extends TsvDataExchangeHandler
 {
-    private DataSerializer _serializer = new ViabilityDataSerializer();
+    private final DataSerializer _serializer = new ViabilityDataSerializer();
 
     @Override
     public DataSerializer getDataSerializer()
@@ -49,7 +49,7 @@ public class ViabilityDataExchangeHandler extends TsvDataExchangeHandler
     private static class ViabilityDataSerializer extends TsvDataSerializer
     {
         @Override
-        public Supplier<ValidatingDataRowIterator> importRunData(ExpProtocol protocol, File runData) throws Exception
+        public DataIteratorBuilder importRunData(ExpProtocol protocol, File runData) throws Exception
         {
             AssayProvider provider = AssayService.get().getProvider(protocol);
             ExpData data = ExperimentService.get().createData(protocol.getContainer(), ViabilityTsvDataHandler.DATA_TYPE);
@@ -60,9 +60,9 @@ public class ViabilityDataExchangeHandler extends TsvDataExchangeHandler
                 ViabilityAssayDataHandler.Parser parser = viabilityHandler.getParser(provider.getRunDomain(protocol),
                         provider.getResultsDomain(protocol), runData);
                 List<Map<String, Object>> rows = parser.getResultData();
-                return () -> ValidatingDataRowIterator.of(rows);
+                return AbstractMapDataIterator.builderOf(rows);
             }
-            return () -> ValidatingDataRowIterator.of(Collections.emptyList());
+            return AbstractMapDataIterator.builderOf(Collections.emptyList());
         }
     }
 }

--- a/viability/src/org/labkey/viability/ViabilityTsvDataHandler.java
+++ b/viability/src/org/labkey/viability/ViabilityTsvDataHandler.java
@@ -16,6 +16,8 @@
 
 package org.labkey.viability;
 
+import org.labkey.api.dataiterator.AbstractMapDataIterator;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.DataType;
 import org.labkey.api.exp.api.ExpRun;
@@ -25,7 +27,6 @@ import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
-import org.labkey.api.iterator.ValidatingDataRowIterator;
 import org.labkey.api.qc.DataLoaderSettings;
 import org.labkey.api.reader.TabLoader;
 import org.labkey.api.reader.ColumnDescriptor;
@@ -39,7 +40,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
-import java.util.function.Supplier;
 
 /**
  * User: kevink
@@ -62,7 +62,7 @@ public class ViabilityTsvDataHandler extends ViabilityAssayDataHandler
         if (DATA_TYPE.matches(lsid) || OLD_DATA_TYPE.matches(lsid))
         {
             File f = data.getFile();
-            if (f != null && f.getName() != null)
+            if (f != null)
             {
                 String lowerName = f.getName().toLowerCase();
                 if (lowerName.endsWith(".tsv") || lowerName.endsWith(".txt"))
@@ -135,13 +135,13 @@ public class ViabilityTsvDataHandler extends ViabilityAssayDataHandler
     }
 
     @Override
-    public Map<DataType, Supplier<ValidatingDataRowIterator>> getValidationDataMap(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context, DataLoaderSettings settings) throws ExperimentException
+    public Map<DataType, DataIteratorBuilder> getValidationDataMap(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context, DataLoaderSettings settings) throws ExperimentException
     {
         assert dataFile.getName().endsWith(".tsv") || dataFile.getName().endsWith(".TSV");
         
         // Uck.  The TsvDataExchangeHandler writes out GuavaDataHandler.getValidationDataMap() bfore running the transform script.
         // After the transform has run, this method is called to read that output back in.
-        Map<DataType, Supplier<ValidatingDataRowIterator>> result = new HashMap<>();
+        Map<DataType, DataIteratorBuilder> result = new HashMap<>();
         ExpRun run = data.getRun();
         ExpProtocol protocol = run.getProtocol();
         AssayProvider provider = AssayService.get().getProvider(protocol);
@@ -150,7 +150,7 @@ public class ViabilityTsvDataHandler extends ViabilityAssayDataHandler
 
         Parser parser = getParser(runDomain, resultsDomain, dataFile);
         List<Map<String, Object>> dataMap = parser.getResultData();
-        result.put(ViabilityTsvDataHandler.DATA_TYPE, () -> ValidatingDataRowIterator.of(dataMap));
+        result.put(ViabilityTsvDataHandler.DATA_TYPE, AbstractMapDataIterator.builderOf(dataMap));
 
         return result;
     }

--- a/viability/src/org/labkey/viability/ViabilityTsvDataHandler.java
+++ b/viability/src/org/labkey/viability/ViabilityTsvDataHandler.java
@@ -16,8 +16,8 @@
 
 package org.labkey.viability;
 
-import org.labkey.api.dataiterator.AbstractMapDataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.DataType;
 import org.labkey.api.exp.api.ExpRun;
@@ -150,7 +150,7 @@ public class ViabilityTsvDataHandler extends ViabilityAssayDataHandler
 
         Parser parser = getParser(runDomain, resultsDomain, dataFile);
         List<Map<String, Object>> dataMap = parser.getResultData();
-        result.put(ViabilityTsvDataHandler.DATA_TYPE, AbstractMapDataIterator.builderOf(dataMap));
+        result.put(ViabilityTsvDataHandler.DATA_TYPE, MapDataIterator.of(dataMap));
 
         return result;
     }


### PR DESCRIPTION
#### Rationale
Building on earlier work to make assay import stream data to handle large files, using `DataIterator` for the streaming aligns this code with other streaming approaches.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5703

#### Changes
- New helpers for Map-oriented DataIterating
- Switch from the temporary `ValidatingDataRowIterator` to `DataIterator`
- Stronger enforcement of `DataIterator` assumptions