### PR TITLE
Stream ExpRuns from DB to prevent error for large containers

### DIFF
--- a/flow/src/org/labkey/flow/data/FlowRun.java
+++ b/flow/src/org/labkey/flow/data/FlowRun.java
@@ -419,11 +419,10 @@ public class FlowRun extends FlowObject<ExpRun>
             }
             childProtocol = childFlowProtocol.getProtocol();
         }
-        for (ExpRun run : ExperimentService.get().getExpRuns(container, null, childProtocol))
-        {
-            if (runFilePathRoot == null || (run.getFilePathRoot() != null && runFilePathRoot.equals(run.getFilePathRoot())))
-                ret.add(new FlowRun(run));
-        }
+
+        ExperimentService.get().getExpRuns(container, null, childProtocol, run -> 
+                runFilePathRoot == null || (run.getFilePathRoot() != null && runFilePathRoot.equals(run.getFilePathRoot()))
+            ).forEach( run -> ret.add(new FlowRun(run)));
 
         if (comparator != null)
             ret.sort(comparator);


### PR DESCRIPTION
#### Rationale
Stream ExpRuns from DB to prevent error for large containers

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5713

#### Changes
* Adjust flow run call to use stream-ish version
