### PR TITLE
Issue 51147: make exported folder archive available in file root

### DIFF
--- a/flow/src/org/labkey/flow/view/exportAnalysis.jsp
+++ b/flow/src/org/labkey/flow/view/exportAnalysis.jsp
@@ -39,8 +39,8 @@
 
     Map<ExportAnalysisForm.SendTo, String> sendToOptions = new EnumMap<>(ExportAnalysisForm.SendTo.class);
     sendToOptions.put(ExportAnalysisForm.SendTo.Browser, "Browser");
-    sendToOptions.put(ExportAnalysisForm.SendTo.PipelineZip, "Pipeline root as zip");
-    sendToOptions.put(ExportAnalysisForm.SendTo.PipelineFiles, "Pipeline root as files");
+    sendToOptions.put(ExportAnalysisForm.SendTo.PipelineZip, "File root as zip");
+    sendToOptions.put(ExportAnalysisForm.SendTo.PipelineFiles, "File root as files");
 
     FlowModule module = ModuleLoader.getInstance().getModule(FlowModule.class);
     if (module.getExportToScriptCommandLine(getContainer()) != null)


### PR DESCRIPTION
#### Rationale
Servers almost exclusively use file roots.

#### Changes
- Update folder export options to refer to file root instead of pipeline root
