### PR TITLE
Issue 51084: Luminex titration exclusion displays separate rows for the same titration when the dilutions are split across files in the same run

### DIFF
--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexExcludedTitrationTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexExcludedTitrationTest.java
@@ -35,8 +35,6 @@ import static org.junit.Assert.assertTrue;
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
 public final class LuminexExcludedTitrationTest extends LuminexTest
 {
-    int pipelineJobCount = 1;
-
     /**
      * test of titration exclusion- the ability to exclude certain titrations and add a comment as to why
      * preconditions: LUMINEX project and assay list exist.  Having the Multiple Curve data will speed up execution
@@ -46,6 +44,8 @@ public final class LuminexExcludedTitrationTest extends LuminexTest
     @Test
     public void testTitrationExclusion()
     {
+        int jobCount = executeSelectRowCommand("pipeline", "Job").getRows().size();
+
         ensureMultipleCurveDataPresent(TEST_ASSAY_LUM);
 
         clickAndWait(Locator.linkContainingText(MULTIPLE_CURVE_ASSAY_RUN_NAME));
@@ -55,19 +55,21 @@ public final class LuminexExcludedTitrationTest extends LuminexTest
 
         String titration = "Sample 1";
         String exclusionMessage =  "excluding all analytes for titration " + titration;
-        excludeTitration(titration, exclusionMessage, MULTIPLE_CURVE_ASSAY_RUN_NAME, ++pipelineJobCount, 1, 1);
+        excludeTitration(titration, exclusionMessage, MULTIPLE_CURVE_ASSAY_RUN_NAME, ++jobCount, 1, 1);
         verifyTitrationExclusion(titration, exclusionMessage, 70);
 
         titration = "Sample 2";
         String analyte = "ENV6";
         exclusionMessage =  "excluding " + analyte + " analyte for titration " + titration;
-        excludeTitration(titration, exclusionMessage, MULTIPLE_CURVE_ASSAY_RUN_NAME, ++pipelineJobCount, 1, 1, analyte);
+        excludeTitration(titration, exclusionMessage, MULTIPLE_CURVE_ASSAY_RUN_NAME, ++jobCount, 1, 1, analyte);
         verifyTitrationAnalyteExclusion(titration, analyte, exclusionMessage, 12);
     }
 
     @Test
     public void testCrossPlateTitration()
     {
+        int jobCount = executeSelectRowCommand("pipeline", "Job").getRows().size();
+
         List<File> files = new ArrayList<>();
         files.add(TEST_ASSAY_LUM_FILE5);
         files.add(TEST_ASSAY_LUM_FILE6);
@@ -98,7 +100,7 @@ public final class LuminexExcludedTitrationTest extends LuminexTest
         // Issue 51084: verify exclusions for a cross plate titration (exclusions applied to all DataIds for the titration)
         clickAndWait(Locator.linkContainingText(runName));
         String exclusionMessage =  "excluding all analytes for titration " + titration;
-        excludeTitration(titration, exclusionMessage, runName, ++pipelineJobCount, 2, 1);
+        excludeTitration(titration, exclusionMessage, runName, ++jobCount, 2, 1);
 
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.addColumn("ExclusionComment");
@@ -107,7 +109,7 @@ public final class LuminexExcludedTitrationTest extends LuminexTest
 
         titration = "Standard1";
         exclusionMessage =  "excluding one analyte for titration " + titration;
-        excludeTitration(titration, exclusionMessage, runName, ++pipelineJobCount, 5, 2, "GS Analyte B");
+        excludeTitration(titration, exclusionMessage, runName, ++jobCount, 5, 2, "GS Analyte B");
         verifyTitrationAnalyteExclusion(titration, "GS Analyte B", exclusionMessage, 50);
 
         clickAndWait(Locator.linkWithText("view excluded data"));

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexExcludedTitrationTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexExcludedTitrationTest.java
@@ -28,12 +28,15 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category({Daily.class, Assays.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
 public final class LuminexExcludedTitrationTest extends LuminexTest
 {
+    int pipelineJobCount = 1;
+
     /**
      * test of titration exclusion- the ability to exclude certain titrations and add a comment as to why
      * preconditions: LUMINEX project and assay list exist.  Having the Multiple Curve data will speed up execution
@@ -52,14 +55,14 @@ public final class LuminexExcludedTitrationTest extends LuminexTest
 
         String titration = "Sample 1";
         String exclusionMessage =  "excluding all analytes for titration " + titration;
-        excludeTitration(titration, exclusionMessage, MULTIPLE_CURVE_ASSAY_RUN_NAME, 2);
-        verifyTitrationExclusion(titration, exclusionMessage);
+        excludeTitration(titration, exclusionMessage, MULTIPLE_CURVE_ASSAY_RUN_NAME, ++pipelineJobCount, 1, 1);
+        verifyTitrationExclusion(titration, exclusionMessage, 70);
 
         titration = "Sample 2";
         String analyte = "ENV6";
         exclusionMessage =  "excluding " + analyte + " analyte for titration " + titration;
-        excludeTitration(titration, exclusionMessage, MULTIPLE_CURVE_ASSAY_RUN_NAME, 3, analyte);
-        verifyTitrationAnalyteExclusion(titration, analyte, exclusionMessage);
+        excludeTitration(titration, exclusionMessage, MULTIPLE_CURVE_ASSAY_RUN_NAME, ++pipelineJobCount, 1, 1, analyte);
+        verifyTitrationAnalyteExclusion(titration, analyte, exclusionMessage, 12);
     }
 
     @Test
@@ -81,14 +84,47 @@ public final class LuminexExcludedTitrationTest extends LuminexTest
         table.clickHeaderButton("Import Data");
         clickButton("Next");
 
+        String runName = "Cross Plate titration";
         waitForElement(Locators.panelWebpartTitle.withText("Run Properties"));
-        setFormElement(Locator.name("name"), "Cross Plate titration");
+        setFormElement(Locator.name("name"), runName);
 
         uploadAssayFiles(files);
         clickButton("Next");
 
-        assertTextPresent("Standard1-CrossplateTitration");
+        String titration = "Standard1-CrossplateTitration";
+        assertTextPresent(titration);
+        clickButton("Save and Finish");
 
+        // Issue 51084: verify exclusions for a cross plate titration (exclusions applied to all DataIds for the titration)
+        clickAndWait(Locator.linkContainingText(runName));
+        String exclusionMessage =  "excluding all analytes for titration " + titration;
+        excludeTitration(titration, exclusionMessage, runName, ++pipelineJobCount, 2, 1);
+
+        _customizeViewsHelper.openCustomizeViewPanel();
+        _customizeViewsHelper.addColumn("ExclusionComment");
+        _customizeViewsHelper.applyCustomView();
+        verifyTitrationExclusion(titration, exclusionMessage, 12);
+
+        titration = "Standard1";
+        exclusionMessage =  "excluding one analyte for titration " + titration;
+        excludeTitration(titration, exclusionMessage, runName, ++pipelineJobCount, 5, 2, "GS Analyte B");
+        verifyTitrationAnalyteExclusion(titration, "GS Analyte B", exclusionMessage, 50);
+
+        clickAndWait(Locator.linkWithText("view excluded data"));
+        DataRegionTable region = new DataRegionTable("TitrationExclusion", this);
+        region.setFilter("Description", "Equals", "Standard1-CrossplateTitration");
+        assertEquals("Expected 2 rows for titration", 2, region.getDataRowCount());
+        region.setFilter("Analytes", "Contains", "GS Analyte A");
+        assertEquals("Expected 2 rows for analyte A", 2, region.getDataRowCount());
+        region.setFilter("Analytes", "Contains", "GS Analyte B");
+        assertEquals("Expected 2 rows for analyte B", 2, region.getDataRowCount());
+        region.clearFilter("Analytes");
+        region.setFilter("Description", "Equals", "Standard1");
+        assertEquals("Expected 5 rows for titration", 5, region.getDataRowCount());
+        region.setFilter("Analytes", "Contains", "GS Analyte A");
+        assertEquals("Expected 0 rows for analyte B", 0, region.getDataRowCount());
+        region.setFilter("Analytes", "Contains", "GS Analyte B");
+        assertEquals("Expected 5 rows for analyte B", 5, region.getDataRowCount());
     }
 
     private void uploadAssayFiles(List<File> guavaFiles)
@@ -96,13 +132,13 @@ public final class LuminexExcludedTitrationTest extends LuminexTest
         setInput(Locator.name("__primaryFile__"), guavaFiles);
     }
 
-    private void verifyTitrationAnalyteExclusion(String excludedTitration, String excludedAnalyte, String exclusionMessage)
+    private void verifyTitrationAnalyteExclusion(String excludedTitration, String excludedAnalyte, String exclusionMessage, int rowCount)
     {
         DataRegionTable region = new DataRegionTable("Data", this);
 
         region.setFilter("Description", "Equals", excludedTitration);
         region.setFilter("Analyte", "Contains", excludedAnalyte);
-        waitForElement(Locator.paginationText(1, 12, 12));
+        waitForElement(Locator.paginationText(1, rowCount, rowCount));
         List<List<String>> vals = region.getFullColumnValues("Well", "Description", "Type", "Exclusion Comment", "Analyte");
         List<String> wells = vals.get(0);
         List<String> descriptions = vals.get(1);
@@ -127,7 +163,7 @@ public final class LuminexExcludedTitrationTest extends LuminexTest
             comment = comments.get(i);
             log("Comment: "+ comment);
             analyte= analytesPresent.get(i);
-            analyte = analyte.substring(0, 4);
+            analyte = analyte.contains("(") ? analyte.substring(0, 4) : analyte;
             log("Analyte: " + analyte);
 
             if (analyte.contains(excludedAnalyte) && description.equals(excludedTitration))
@@ -150,12 +186,12 @@ public final class LuminexExcludedTitrationTest extends LuminexTest
         region.clearFilter("Description");
     }
 
-    private void verifyTitrationExclusion(String excludedTitration, String exclusionMessage)
+    private void verifyTitrationExclusion(String excludedTitration, String exclusionMessage, int rowCount)
     {
         DataRegionTable region = new DataRegionTable("Data", this);
 
         region.setFilter("Description", "Equals", excludedTitration);
-        waitForElement(Locator.paginationText(1, 70, 70));
+        waitForElement(Locator.paginationText(1, rowCount, rowCount));
         List<List<String>> vals = region.getFullColumnValues("Well", "Description", "Type", "Exclusion Comment", "Analyte");
         List<String> wells = vals.get(0);
         List<String> descriptions = vals.get(1);

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexExclusionRetentionTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexExclusionRetentionTest.java
@@ -161,7 +161,7 @@ public final class LuminexExclusionRetentionTest extends LuminexTest
 
         //Add titration exclusion that matches
         String titrationMatchComment = "titration match";
-        excludeTitration("Standard1", titrationMatchComment, RUN_NAME, 1, matchingAnalyte);
+        excludeTitration("Standard1", titrationMatchComment, RUN_NAME, 1, 1, 1, matchingAnalyte);
 
         //Re-import
         reimportAndReplaceRunFile(BASE_RUN_FILE, BASE_RUN_FILE, "Standard1", null);

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -320,7 +320,7 @@ public abstract class LuminexTest extends BaseWebDriverTest
         clickButton(SAVE_CHANGES_BUTTON, 0);
     }
 
-    protected void excludeTitration(String titration, String exclusionMessage, String runName, int pipelineJobCount, String...analytes)
+    protected void excludeTitration(String titration, String exclusionMessage, String runName, int pipelineJobCount, int numCommands, int numMatchingJobs, String...analytes)
     {
         DataRegionTable table = new DataRegionTable("Data", getDriver());
         table.clickHeaderMenu("Exclusions", false, "Exclude Titrations");
@@ -343,7 +343,9 @@ public abstract class LuminexTest extends BaseWebDriverTest
         clickButton("Save", 0);
         _extHelper.waitForExtDialog("Confirm Exclusions", WAIT_FOR_JAVASCRIPT);
         clickButtonContainingText("Yes", 0);
-        verifyExclusionPipelineJobComplete(pipelineJobCount, "INSERT titration exclusion (Description: " + titration + ")", runName, exclusionMessage);
+
+        String expectedInfo = numCommands > 1 ? "MULTIPLE titration exclusions" : "INSERT titration exclusion (Description: " + titration + ")";
+        verifyExclusionPipelineJobComplete(pipelineJobCount, expectedInfo, runName, exclusionMessage, numCommands, numMatchingJobs);
     }
 
     /**
@@ -516,6 +518,7 @@ public abstract class LuminexTest extends BaseWebDriverTest
         for (File additionalFile : additionalFiles)
         {
             sleep(500);
+            scrollIntoView(Locator.lkButton("Next"));
             click(Locator.xpath("//a[contains(@class, 'labkey-file-add-icon-enabled')]"));
 
             String fieldName = ASSAY_DATA_FILE_LOCATION_MULTIPLE_FIELD + (index++);

--- a/luminex/webapp/luminex/exclusion/AnalyteExclusionPanel.js
+++ b/luminex/webapp/luminex/exclusion/AnalyteExclusionPanel.js
@@ -18,8 +18,8 @@ function openExclusionsAnalyteWindow(assayId, runId)
             {
                 var win = new LABKEY.Exclusions.BaseWindow({
                     title: 'Exclude Analytes from Analysis',
-                    width: Ext.getBody().getViewSize().width < 500 ? Ext.getBody().getViewSize().width * .9 : 450,
-                    height: Ext.getBody().getViewSize().height > 500 ? 460 : Ext.getBody().getViewSize().height * .75,
+                    width: Math.max(600, Ext.getBody().getViewSize().width * .5),
+                    height: Math.max(600, Ext.getBody().getViewSize().height * .5),
                     items: new LABKEY.Exclusions.AnalytePanel({
                         protocolSchemaName: assay[0].protocolSchemaName,
                         assayId: assayId,

--- a/luminex/webapp/luminex/exclusion/SinglepointUnknownExclusionPanel.js
+++ b/luminex/webapp/luminex/exclusion/SinglepointUnknownExclusionPanel.js
@@ -65,7 +65,6 @@ LABKEY.Exclusions.SinglepointUnknownPanel = Ext.extend(LABKEY.Exclusions.BasePan
     {
         this.excluded = [];
         this.comments = [];
-        this.excludedDataIds = [];
         this.present = [];
         this.preExcludedIds = [];
         this.preAnalyteRowIds = [];
@@ -277,7 +276,6 @@ LABKEY.Exclusions.SinglepointUnknownPanel = Ext.extend(LABKEY.Exclusions.BasePan
                         this.comments[rowId] = Ext.getCmp('comment').getValue();
                         this.present[rowId] = this.getGridCheckboxSelModel().getSelections().length;
                         record.set('Present', this.present[rowId]);
-                        this.excludedDataIds[rowId] = record.get('DataId');
                     },
                     rowselect : function(tsl, rowId, record)
                     {
@@ -446,7 +444,7 @@ LABKEY.Exclusions.SinglepointUnknownPanel = Ext.extend(LABKEY.Exclusions.BasePan
         var commands = [];
         for (var index = 0; index < this.excluded.length; index++)
         {
-            var dataId = this.excludedDataIds[index];
+            var record = this.getAvailableItemsGrid().getStore().getAt(index);
             var analytesForExclusion = this.excluded[index];
             if (analytesForExclusion == undefined)
                 continue;
@@ -475,7 +473,7 @@ LABKEY.Exclusions.SinglepointUnknownPanel = Ext.extend(LABKEY.Exclusions.BasePan
             var commandConfig = {
                 command: command,
                 key: this.preExcludedIds[index], // this will be undefined for the insert case
-                dataId: dataId,
+                dataId: record.get('DataId'),
                 description: analytesForExclusion['Name'],
                 analyteRowIds: (analyteRowIds != "" ? analyteRowIds : null),
                 analyteNames: (analyteNames != "" ? analyteNames : null), // for logging purposes only

--- a/luminex/webapp/luminex/exclusion/SinglepointUnknownExclusionPanel.js
+++ b/luminex/webapp/luminex/exclusion/SinglepointUnknownExclusionPanel.js
@@ -18,8 +18,8 @@ function openExclusionsSinglepointUnknownWindow(assayId, runId)
             {
                 var win = new LABKEY.Exclusions.BaseWindow({
                     title: 'Exclude Singlepoint Unknowns from Analysis',
-                    width: Ext.getBody().getViewSize().width < 550 ? Ext.getBody().getViewSize().width * .9 : 500,
-                    height: Ext.getBody().getViewSize().height > 700 ? 600 : Ext.getBody().getViewSize().height * .75,
+                    width: Math.max(600, Ext.getBody().getViewSize().width * .6),
+                    height: Math.max(600, Ext.getBody().getViewSize().height * .6),
                     items: new LABKEY.Exclusions.SinglepointUnknownPanel({
                         protocolSchemaName: assay[0].protocolSchemaName,
                         assayId: assayId,

--- a/luminex/webapp/luminex/exclusion/TitrationExclusionPanel.js
+++ b/luminex/webapp/luminex/exclusion/TitrationExclusionPanel.js
@@ -18,8 +18,8 @@ function openExclusionsTitrationWindow(assayId, runId)
             {
                 var win = new LABKEY.Exclusions.BaseWindow({
                     title: 'Exclude Titrations from Analysis',
-                    width: Ext.getBody().getViewSize().width < 500 ? Ext.getBody().getViewSize().width * .9 : 450,
-                    height: Ext.getBody().getViewSize().height > 700 ? 600 : Ext.getBody().getViewSize().height * .75,
+                    width: Math.max(600, Ext.getBody().getViewSize().width * .6),
+                    height: Math.max(600, Ext.getBody().getViewSize().height * .6),
                     items: new LABKEY.Exclusions.TitrationPanel({
                         protocolSchemaName: assay[0].protocolSchemaName,
                         assayId: assayId,


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51084

#### Related Pull Requests
- n/a

#### Changes
- only show one exclusion row per titration but track each by dataId
- update all dataId rows per titration on analyte exclusions selection change
- add selenium test case
