### PR TITLE
Fix field key casing for CustomizeView.addColumn

### DIFF
--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexUploadAndLinkTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexUploadAndLinkTest.java
@@ -246,8 +246,8 @@ public final class LuminexUploadAndLinkTest extends LuminexTest
         _customizeViewsHelper.addColumn("StdDev");
         _customizeViewsHelper.addColumn("CV");
         _customizeViewsHelper.addColumn("Summary");
-        _customizeViewsHelper.addColumn("ANALYTE/ANALYTEWITHBEAD");
-        _customizeViewsHelper.addColumn("ANALYTE/BEADNUMBER");
+        _customizeViewsHelper.addColumn("Analyte/AnalyteWithBead");
+        _customizeViewsHelper.addColumn("Analyte/BeadNumber");
         _customizeViewsHelper.applyCustomView();
 
         // show all rows (> 100 in full data file)


### PR DESCRIPTION
#### Rationale
Using the correct casing for column names allows `CustomizeView.addItem` to validate that the new column appears in the list of selected columns.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/2043

#### Changes
* Fix field key casing for CustomizeView.addColumn
