### PR TITLE
Issue 50861: Pass around properly encoded WebDav URLs

### DIFF
--- a/flow/src/org/labkey/flow/controllers/executescript/importAnalysisSelectFCSFiles.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/importAnalysisSelectFCSFiles.jsp
@@ -42,7 +42,7 @@
 
     IWorkspace workspace = form.getWorkspace().getWorkspaceObject();
     List<String> warnings = workspace.getWarnings();
-    if (warnings.size() > 0)
+    if (!warnings.isEmpty())
     {
         %>
         <p class="labkey-warning-messages" style="display:inline-block">
@@ -166,7 +166,7 @@
                 Ext4.QuickTips.init();
 
                 fileSystem = Ext4.create('File.system.Webdav', {
-                    rootPath : <%=q(pipeRoot.getWebdavURL())%>,
+                    rootPath : <%=q(pipeRoot.getWebdavURL().toString())%>,
                     rootName : <%=q(AppProps.getInstance().getServerName())%>
                     //rootOffset : <%=q(keywordDir)%>
                 });

--- a/nab/src/org/labkey/nab/NabAssayProvider.java
+++ b/nab/src/org/labkey/nab/NabAssayProvider.java
@@ -348,9 +348,9 @@ public class NabAssayProvider extends AbstractDilutionAssayProvider<NabRunUpload
         try
         {
             AssayProvider provider = context.getProvider();
-            if (supportsMultiVirusPlate() && provider instanceof NabAssayProvider)
+            if (supportsMultiVirusPlate() && provider instanceof NabAssayProvider nabProvider && template != null)
             {
-                Domain domain = ((NabAssayProvider)provider).getVirusWellGroupDomain(context.getProtocol());
+                Domain domain = nabProvider.getVirusWellGroupDomain(context.getProtocol());
 
                 if (domain != null)
                 {


### PR DESCRIPTION
#### Rationale
We are inconsistently encoding URIs in Strings and passing them around. Many codepaths end up double-encoding and then selectively decoding specific characters.

We can do better by using `URI` on the server and properly encoding throughout.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5961

#### Changes
- Switch to `URI` to make it clear what's being passed around
- Return encoded values in JSON and other responses
