### PR TITLE
Issue 51532: Null check for comments string in NAb exclusions

### DIFF
--- a/nab/src/org/labkey/nab/NabAssayController.java
+++ b/nab/src/org/labkey/nab/NabAssayController.java
@@ -1261,8 +1261,8 @@ public class NabAssayController extends SpringActionController
                     _exclusions.add(new WellExclusion(excluded.getInt("plate"),
                         excluded.getInt("row"),
                         excluded.getInt("col"),
-                        excluded.getString("comment"),
-                        excluded.getString("specimen")));
+                        excluded.optString("comment"), // issue 51532
+                        excluded.optString("specimen")));
                 }
             }
         }


### PR DESCRIPTION
#### Rationale
Issue [51532](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51532): JSONException from org.labkey.nab.NabAssayController$QCControlInfo.bindJson()

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5985

#### Changes
- Null check for comments string in NAb exclusions
