### PR TITLE
Mark modules as PostgreSQL-only

### DIFF
--- a/microarray/module.properties
+++ b/microarray/module.properties
@@ -6,3 +6,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: pgsql

--- a/viability/module.properties
+++ b/viability/module.properties
@@ -6,3 +6,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: pgsql


### PR DESCRIPTION
#### Rationale
They don't need to support SQL Server