### PR TITLE
Assay: resolve a single provider/protocol before creating protocol schema

### DIFF
--- a/flow/src/org/labkey/flow/data/FlowAssayProvider.java
+++ b/flow/src/org/labkey/flow/data/FlowAssayProvider.java
@@ -340,7 +340,13 @@ public class FlowAssayProvider extends AbstractAssayProvider
     }
 
     @Override
-    public List<Pair<Domain, Map<DomainProperty, Object>>> getDomains(ExpProtocol protocol)
+    public @NotNull List<Domain> getDomains(ExpProtocol protocol)
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public @NotNull List<Pair<Domain, Map<DomainProperty, Object>>> getDomainsAndDefaultValues(ExpProtocol protocol)
     {
         return Collections.emptyList();
     }


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/platform/pull/6057 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1645
- https://github.com/LabKey/labkey-ui-premium/pull/599
- https://github.com/LabKey/platform/pull/6057
- https://github.com/LabKey/limsModules/pull/919
- https://github.com/LabKey/commonAssays/pull/822

#### Changes
- Update `FlowAssayProvider` to match interface changes.
