### PR TITLE
Mark modules that support both databases

### DIFF
--- a/elisa/module.properties
+++ b/elisa/module.properties
@@ -6,3 +6,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/elispotassay/module.properties
+++ b/elispotassay/module.properties
@@ -13,3 +13,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/flow/module.properties
+++ b/flow/module.properties
@@ -9,3 +9,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/luminex/module.properties
+++ b/luminex/module.properties
@@ -10,3 +10,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/ms2/module.properties
+++ b/ms2/module.properties
@@ -10,3 +10,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/nab/module.properties
+++ b/nab/module.properties
@@ -7,3 +7,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/protein/module.properties
+++ b/protein/module.properties
@@ -4,4 +4,4 @@ Description: Provides proteomics-related protein services and actions, and manag
 Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
-LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+LicenseURL: http://www.apache.org/licenses/LICENSE-2.0SupportedDatabases: mssql, pgsql

--- a/protein/module.properties
+++ b/protein/module.properties
@@ -4,4 +4,5 @@ Description: Provides proteomics-related protein services and actions, and manag
 Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
-LicenseURL: http://www.apache.org/licenses/LICENSE-2.0SupportedDatabases: mssql, pgsql
+LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql


### PR DESCRIPTION
#### Rationale
Need to explicitly declare support for SQL Server since we're about to change the default to PostgreSQL-only