### PR TITLE
Fix issue where importing from the pipeline root doesn't properly process flow files

### DIFF
--- a/flow/src/org/labkey/flow/controllers/executescript/AnalysisScriptController.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/AnalysisScriptController.java
@@ -961,7 +961,7 @@ public class AnalysisScriptController extends BaseFlowController
                         if (relPath != null)
                         {
                             String[] parts = StringUtils.split(relPath, File.separatorChar);
-                            String keywordPath = StringUtils.join(parts, "/");
+                            String keywordPath = "./" + StringUtils.join(parts, "/");
                             form.setKeywordDir(new String[] { keywordPath });
                         }
                         form.setSelectFCSFilesOption(SelectFCSFileOption.Browse);

--- a/flow/src/org/labkey/flow/script/KeywordsTask.java
+++ b/flow/src/org/labkey/flow/script/KeywordsTask.java
@@ -69,7 +69,7 @@ public class KeywordsTask extends PipelineJob.Task<KeywordsTask.Factory>
         PipeRoot pr = PipelineService.get().findPipelineRoot(job.getContainer());
 
         KeywordsJob keywordsJob = new KeywordsJob(job.getInfo(), protocol, paths, targetStudyContainer, pr);
-        keywordsJob.setLogFile(job.getLogFile());
+        keywordsJob.setLogFile(job.getLogFilePath());
         keywordsJob.setLogLevel(job.getLogLevel());
         keywordsJob.setSubmitted();
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51706
Importing Flow files directly from the root aren't processed as expected

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6074

#### Changes
- Added a relative string for keywordPath, which is blank when importing from the root and causes issues downstream
- Switch to the non-deprecated version
