### PR TITLE
Add restrictions on names of domains

### DIFF
--- a/luminex/test/sampledata/luminex/views/LuminexGuideSet.html
+++ b/luminex/test/sampledata/luminex/views/LuminexGuideSet.html
@@ -8,7 +8,7 @@
 
 <!-- Used as HTML wiki source, so nonce is NOT required -->
 <script type="text/javascript">
-    var tablePrefix = "TestAssayLuminex+- _:&()/☃Åä";
+    var tablePrefix = "TestAssayLuminex+- _:&()/";
     var loadedQWPsOnce = false;
     var logHtml = "";
     var validDataId = null;

--- a/luminex/test/sampledata/luminex/views/LuminexGuideSet.html
+++ b/luminex/test/sampledata/luminex/views/LuminexGuideSet.html
@@ -8,7 +8,7 @@
 
 <!-- Used as HTML wiki source, so nonce is NOT required -->
 <script type="text/javascript">
-    var tablePrefix = "TestAssayLuminex +-_:&()/☃Åä";
+    var tablePrefix = "TestAssayLuminex+- _:&()/☃Åä";
     var loadedQWPsOnce = false;
     var logHtml = "";
     var validDataId = null;

--- a/luminex/test/sampledata/luminex/views/LuminexGuideSet.html
+++ b/luminex/test/sampledata/luminex/views/LuminexGuideSet.html
@@ -8,7 +8,7 @@
 
 <!-- Used as HTML wiki source, so nonce is NOT required -->
 <script type="text/javascript">
-    var tablePrefix = "&TestAssayLuminex></% 1";
+    var tablePrefix = "TestAssayLuminex +-_:&()/☃Åä";
     var loadedQWPsOnce = false;
     var logHtml = "";
     var validDataId = null;

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -70,7 +70,10 @@ public abstract class LuminexTest extends BaseWebDriverTest
     protected final static String TEST_ASSAY_PRJ_LUMINEX = "LuminexTest Project";            //project for luminex test
 
     // public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_TRICKY_CHARACTERS.replaceAll("\\.", ""); // Issue 51845: Luminex assay not working well when assay name contains dot (.)
-    public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_SPECIAL_STRING.replaceAll("\\.", "").replaceAll("/", ""); // Issue 51845: Luminex assay not working well when assay name contains dot (.)
+    public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_SPECIAL_STRING
+            .replaceAll(":", "")
+            .replaceAll("\\.", "")
+            .replaceAll("/", ""); // Issue 51845: Luminex assay not working well when assay name contains dot (.)
     protected static final String TEST_ASSAY_LUM_DESC = "Description for Luminex assay";
 
     protected static final String TEST_ASSAY_XAR_NAME = "TestLuminexAssay";

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -60,13 +60,14 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.params.FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
 
 @BaseWebDriverTest.ClassTimeout(minutes = 40)
 public abstract class LuminexTest extends BaseWebDriverTest
 {
     protected final static String TEST_ASSAY_PRJ_LUMINEX = "LuminexTest Project";            //project for luminex test
 
-    public static final String TEST_ASSAY_LUM =  "&TestAssayLuminex></% 1";// put back TRICKY_CHARACTERS_NO_QUOTES when issue 20061 is resolved
+    public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_TRICKY_CHARACTERS;
     protected static final String TEST_ASSAY_LUM_DESC = "Description for Luminex assay";
 
     protected static final String TEST_ASSAY_XAR_NAME = "TestLuminexAssay";

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -69,11 +69,10 @@ public abstract class LuminexTest extends BaseWebDriverTest
 {
     protected final static String TEST_ASSAY_PRJ_LUMINEX = "LuminexTest Project";            //project for luminex test
 
-    // public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_TRICKY_CHARACTERS.replaceAll("\\.", ""); // Issue 51845: Luminex assay not working well when assay name contains dot (.)
-    public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_SPECIAL_STRING
-            .replaceAll(":", "")
-            .replaceAll("\\.", "")
-            .replaceAll("/", ""); // Issue 51845: Luminex assay not working well when assay name contains dot (.)
+    // Issue 51845:
+    //  - Luminex assay not working well when assay name contains dot (.)
+    //  - use DOMAIN_SPECIAL_STRING instead of DOMAIN_TRICKY_CHARACTERS since sql server is not working with unicode characters
+    public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_SPECIAL_STRING.replaceAll("\\.", "");
     protected static final String TEST_ASSAY_LUM_DESC = "Description for Luminex assay";
 
     protected static final String TEST_ASSAY_XAR_NAME = "TestLuminexAssay";

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -62,13 +62,15 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.params.FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
+import static org.labkey.test.util.TestDataGenerator.DOMAIN_SPECIAL_STRING;
 
 @BaseWebDriverTest.ClassTimeout(minutes = 40)
 public abstract class LuminexTest extends BaseWebDriverTest
 {
     protected final static String TEST_ASSAY_PRJ_LUMINEX = "LuminexTest Project";            //project for luminex test
 
-    public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_TRICKY_CHARACTERS.replaceAll("\\.", ""); // Issue 51845: Luminex assay not working well when assay name contains dot (.)
+    // public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_TRICKY_CHARACTERS.replaceAll("\\.", ""); // Issue 51845: Luminex assay not working well when assay name contains dot (.)
+    public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_SPECIAL_STRING.replaceAll("\\.", ""); // Issue 51845: Luminex assay not working well when assay name contains dot (.)
     protected static final String TEST_ASSAY_LUM_DESC = "Description for Luminex assay";
 
     protected static final String TEST_ASSAY_XAR_NAME = "TestLuminexAssay";

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -18,6 +18,7 @@ package org.labkey.test.tests.luminex;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.BeforeClass;
+import org.labkey.api.query.QueryKey;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.assay.GetProtocolCommand;
@@ -67,7 +68,7 @@ public abstract class LuminexTest extends BaseWebDriverTest
 {
     protected final static String TEST_ASSAY_PRJ_LUMINEX = "LuminexTest Project";            //project for luminex test
 
-    public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_TRICKY_CHARACTERS;
+    public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_TRICKY_CHARACTERS.replaceAll("\\.", ""); // Issue 51845: Luminex assay not working well when assay name contains dot (.)
     protected static final String TEST_ASSAY_LUM_DESC = "Description for Luminex assay";
 
     protected static final String TEST_ASSAY_XAR_NAME = "TestLuminexAssay";
@@ -433,7 +434,7 @@ public abstract class LuminexTest extends BaseWebDriverTest
     @LogMethod(quiet = true)
     protected void assertAnalytesHaveCorrectStandards(String assayName, int runId, Map<String, Set<String>> expectedAnalyteStandards)
     {
-        SelectRowsCommand command = new SelectRowsCommand("assay.Luminex." + assayName, "Data");
+        SelectRowsCommand command = new SelectRowsCommand("assay.Luminex." + QueryKey.encodePart(assayName), "Data");
         command.setRequiredVersion(9.1); // Needed in order to get display values of lookup columns
         command.addFilter(new Filter("Run/RowId", runId, Filter.Operator.EQUAL));
         Connection connection = createDefaultConnection(true);

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -70,7 +70,7 @@ public abstract class LuminexTest extends BaseWebDriverTest
     protected final static String TEST_ASSAY_PRJ_LUMINEX = "LuminexTest Project";            //project for luminex test
 
     // public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_TRICKY_CHARACTERS.replaceAll("\\.", ""); // Issue 51845: Luminex assay not working well when assay name contains dot (.)
-    public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_SPECIAL_STRING.replaceAll("\\.", ""); // Issue 51845: Luminex assay not working well when assay name contains dot (.)
+    public static final String TEST_ASSAY_LUM =  "TestAssayLuminex" + DOMAIN_SPECIAL_STRING.replaceAll("\\.", "").replaceAll("/", ""); // Issue 51845: Luminex assay not working well when assay name contains dot (.)
     protected static final String TEST_ASSAY_LUM_DESC = "Description for Luminex assay";
 
     protected static final String TEST_ASSAY_XAR_NAME = "TestLuminexAssay";

--- a/luminex/test/src/org/labkey/test/util/luminex/LuminexGuideSetHelper.java
+++ b/luminex/test/src/org/labkey/test/util/luminex/LuminexGuideSetHelper.java
@@ -79,7 +79,8 @@ public class LuminexGuideSetHelper
     public void verifyGuideSetsNotApplied(String assayName)
     {
         _test.goToSchemaBrowser();
-        _test.selectQuery("assay.Luminex." + assayName, "AnalyteTitration");
+        String[] schemaPart = {"assay", "Luminex", assayName};
+        _test.selectQuery(schemaPart, "AnalyteTitration");
         _test.waitForText("view data");
         _test.clickAndWait(Locator.linkContainingText("view data"));
         DataRegionTable table = new DataRegionTable("query", _test.getDriver());
@@ -297,7 +298,8 @@ public class LuminexGuideSetHelper
     {
         // see if the 3 uploaded runs got the correct 'current' guide set applied
         _test.goToSchemaBrowser();
-        _test.selectQuery("assay.Luminex." + assayName, "AnalyteTitration");
+        String[] schemaPart = {"assay", "Luminex", assayName};
+        _test.selectQuery(schemaPart, "AnalyteTitration");
         _test.waitForText("view data");
         _test.clickAndWait(Locator.linkContainingText("view data"));
         _test._customizeViewsHelper.openCustomizeViewPanel();
@@ -318,7 +320,8 @@ public class LuminexGuideSetHelper
     public Map<String, Integer> getGuideSetIdMap(String assayName)
     {
         _test.goToSchemaBrowser();
-        _test.selectQuery("assay.Luminex." + assayName, "GuideSet");
+        String[] schemaPart = {"assay", "Luminex", assayName};
+        _test.selectQuery(schemaPart, "GuideSet");
         _test.waitForText("view data");
         _test.clickAndWait(Locator.linkContainingText("view data"));
         Map<String, Integer> guideSetIds = new HashMap<>();


### PR DESCRIPTION
#### Rationale
This set of PRs implement a set of rules what characters / patterns can be used as domain (sample, data class, list, etc) names for new domains as well as existing domains when they are re-named.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1662
- https://github.com/LabKey/labkey-ui-premium/pull/616
- https://github.com/LabKey/limsModules/pull/984
- https://github.com/LabKey/platform/pull/6140
- https://github.com/LabKey/testAutomation/pull/2189
- https://github.com/LabKey/commonAssays/pull/826

#### Changes
* update Luminex test to use accepted special character as assay name
