### PR TITLE
Complete migration from srcURL and returnURL to returnUrl

### DIFF
--- a/flow/src/org/labkey/flow/controllers/ReportsController.java
+++ b/flow/src/org/labkey/flow/controllers/ReportsController.java
@@ -303,7 +303,7 @@ public class ReportsController extends BaseFlowController
         {
             ActionURL url = new ActionURL(UpdateAction.class, getContainer()).addParameter("reportId", r.getReportId().toString());
             if (idForm.getReturnActionURL() != null)
-                url.addReturnURL(idForm.getReturnActionURL());
+                url.addReturnUrl(idForm.getReturnActionURL());
             return url;
         }
 
@@ -346,7 +346,7 @@ public class ReportsController extends BaseFlowController
         @Override
         public URLHelper getCancelUrl()
         {
-            return _form.getReturnURLHelper(new ActionURL(BeginAction.class, getContainer()));
+            return _form.getReturnUrlHelper(new ActionURL(BeginAction.class, getContainer()));
         }
 
         @Override

--- a/flow/src/org/labkey/flow/controllers/attribute/createAlias.jsp
+++ b/flow/src/org/labkey/flow/controllers/attribute/createAlias.jsp
@@ -26,7 +26,7 @@
     AttributeCache.Entry entry = form.getEntry(getContainer());
 
     ActionURL editURL = getActionURL();
-    ActionURL returnURL = form.getReturnActionURL(new ActionURL(ProtocolController.BeginAction.class, getContainer()));
+    ActionURL returnUrl = form.getReturnActionURL(new ActionURL(ProtocolController.BeginAction.class, getContainer()));
 %>
 
 Create alias for <%=h(entry.getType().name())%>: <%=h(entry.getName())%>
@@ -49,7 +49,7 @@ Create alias for <%=h(entry.getType().name())%>: <%=h(entry.getName())%>
             <td>&nbsp;</td>
             <td>
                 <%= button("Submit").submit(true) %>
-                <%= button("Cancel").href(returnURL) %>
+                <%= button("Cancel").href(returnUrl) %>
             </td>
         </tr>
     </table>

--- a/flow/src/org/labkey/flow/controllers/attribute/edit.jsp
+++ b/flow/src/org/labkey/flow/controllers/attribute/edit.jsp
@@ -29,15 +29,15 @@
     if (StringUtils.isEmpty(name))
         name = entry.getName();
 
-    ActionURL editURL = getActionURL();
-    ActionURL returnURL = form.getReturnActionURL(new ActionURL(ProtocolController.BeginAction.class, getContainer()));
+    ActionURL editUrl = getActionURL();
+    ActionURL returnUrl = form.getReturnActionURL(new ActionURL(ProtocolController.BeginAction.class, getContainer()));
 %>
 
 Change the name of the <%=h(entry.getType().name())%> or clear the name to delete it.
 <br>
 
 <labkey:errors/>
-<labkey:form action="<%=editURL%>" method="post">
+<labkey:form action="<%=editUrl%>" method="post">
     <table>
         <tr>
             <td>
@@ -51,7 +51,7 @@ Change the name of the <%=h(entry.getType().name())%> or clear the name to delet
             <td>&nbsp;</td>
             <td>
                 <%= button("Submit").submit(true) %>
-                <%= button("Cancel").href(returnURL) %>
+                <%= button("Cancel").href(returnUrl) %>
             </td>
         </tr>
     </table>

--- a/flow/src/org/labkey/flow/controllers/attribute/summary.jsp
+++ b/flow/src/org/labkey/flow/controllers/attribute/summary.jsp
@@ -31,9 +31,9 @@
     Map<FlowEntry, Collection<FlowEntry>> aliasMap = FlowManager.get().getAliases(getContainer(), type);
     ActionURL summaryURL = getActionURL();
 
-    ActionURL editURL = new ActionURL(AttributeController.EditAction.class, getContainer()).addParameter(AttributeController.Param.type, type.name()).addReturnURL(summaryURL);
-    ActionURL detailsURL = new ActionURL(AttributeController.DetailsAction.class, getContainer()).addParameter(AttributeController.Param.type, type.name()).addReturnURL(summaryURL);
-    ActionURL aliasURL = new ActionURL(AttributeController.CreateAliasAction.class, getContainer()).addParameter(AttributeController.Param.type, type.name()).addReturnURL(summaryURL);
+    ActionURL editURL = new ActionURL(AttributeController.EditAction.class, getContainer()).addParameter(AttributeController.Param.type, type.name()).addReturnUrl(summaryURL);
+    ActionURL detailsURL = new ActionURL(AttributeController.DetailsAction.class, getContainer()).addParameter(AttributeController.Param.type, type.name()).addReturnUrl(summaryURL);
+    ActionURL aliasURL = new ActionURL(AttributeController.CreateAliasAction.class, getContainer()).addParameter(AttributeController.Param.type, type.name()).addReturnUrl(summaryURL);
 %>
 
 <table>

--- a/flow/src/org/labkey/flow/controllers/copyReport.jsp
+++ b/flow/src/org/labkey/flow/controllers/copyReport.jsp
@@ -32,7 +32,7 @@
 
     ActionURL copyURL = new ActionURL(ReportsController.CopyAction.class, c).addParameter("reportId", report.getReportId().toString());
     if (form.getReturnUrl() != null)
-        copyURL.addReturnURL(form.getReturnActionURL());
+        copyURL.addReturnUrl(form.getReturnActionURL());
 %>
 <labkey:errors/>
 

--- a/flow/src/org/labkey/flow/controllers/executescript/AnalysisScriptController.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/AnalysisScriptController.java
@@ -377,7 +377,7 @@ public class AnalysisScriptController extends BaseFlowController
         {
             if (!form.isConfirm())
             {
-                URLHelper url = form.getReturnURLHelper();
+                URLHelper url = form.getReturnUrlHelper();
                 if (url == null)
                     url = new ActionURL(BeginAction.class, getContainer());
                 return HttpView.redirect(url);

--- a/flow/src/org/labkey/flow/controllers/executescript/confirmRunsToImport.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/confirmRunsToImport.jsp
@@ -95,12 +95,12 @@
 
         <br />
         <%=button("Import Selected Runs").submit(true)%>
-        <labkey:button text="Cancel" href="<%=form.getReturnURLHelper()%>"/>
+        <labkey:button text="Cancel" href="<%=form.getReturnUrlHelper()%>"/>
         </labkey:form><%
     }
     else
     {
-        %><labkey:button text="Browse for more runs" href="<%=form.getReturnURLHelper()%>"/><%
+        %><labkey:button text="Browse for more runs" href="<%=form.getReturnUrlHelper()%>"/><%
     }
 
 %>

--- a/flow/src/org/labkey/flow/controllers/protocol/editICSMetadata.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/editICSMetadata.jsp
@@ -58,7 +58,7 @@
 
     ActionURL submitURL = form.getProtocol().urlFor(ProtocolController.EditICSMetadataAction.class);
     if (form.getReturnActionURL() != null)
-        submitURL.addReturnURL(form.getReturnActionURL());
+        submitURL.addReturnUrl(form.getReturnActionURL());
 %>
 <labkey:errors />
 <labkey:form action="<%=submitURL%>" method="POST">

--- a/flow/src/org/labkey/flow/controllers/protocol/showProtocol.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/showProtocol.jsp
@@ -63,8 +63,8 @@
 </p>
 <p><b>Manage Names and Aliases</b><br>
     Create and remove names and aliases for Keywords, Statistics, and Graphs.<br>
-    <%=link("Case sensitivity").href(protocol.urlFor(AttributeController.CaseSensitivityAction.class).addReturnURL(getActionURL()))%><br/>
-    <%=link("Delete Unused").href(protocol.urlFor(AttributeController.DeleteUnusedAction.class).addReturnURL(getActionURL()))%><br/>
+    <%=link("Case sensitivity").href(protocol.urlFor(AttributeController.CaseSensitivityAction.class).addReturnUrl(getActionURL()))%><br/>
+    <%=link("Delete Unused").href(protocol.urlFor(AttributeController.DeleteUnusedAction.class).addReturnUrl(getActionURL()))%><br/>
     <%=link("Manage Keywords").href(protocol.urlFor(AttributeController.SummaryAction.class).addParameter(AttributeController.Param.type, AttributeType.keyword.name()))%><br/>
     <%=link("Manage Statistics").href(protocol.urlFor(AttributeController.SummaryAction.class).addParameter(AttributeController.Param.type, AttributeType.statistic.name()))%><br/>
     <%=link("Manage Graphs").href(protocol.urlFor(AttributeController.SummaryAction.class).addParameter(AttributeController.Param.type, AttributeType.graph.name()))%><br/>

--- a/flow/src/org/labkey/flow/controllers/reports.jsp
+++ b/flow/src/org/labkey/flow/controllers/reports.jsp
@@ -42,8 +42,8 @@
     boolean canEdit = c.hasPermission(user, UpdatePermission.class);
 
     ActionURL currentURL = getActionURL();
-    ActionURL copyURL = new ActionURL(ReportsController.CopyAction.class, c).addReturnURL(currentURL);
-    ActionURL deleteURL = new ActionURL(ReportsController.DeleteAction.class, c).addReturnURL(currentURL);
+    ActionURL copyURL = new ActionURL(ReportsController.CopyAction.class, c).addReturnUrl(currentURL);
+    ActionURL deleteURL = new ActionURL(ReportsController.DeleteAction.class, c).addReturnUrl(currentURL);
 
     Collection<FlowReport> reports = FlowReportManager.getFlowReports(c, user);
     Map<String, List<FlowReport>> reportsByType = new TreeMap<>();
@@ -96,7 +96,7 @@ table.reports td {
                 navtree.addChild("Edit", editURL);
                 navtree.addChild("Copy", copyURL);
                 navtree.addChild("Delete", deleteURL);
-                navtree.addChild("Execute", r.getRunReportURL(context).addParameter("confirm", true).addReturnURL(currentURL));
+                navtree.addChild("Execute", r.getRunReportURL(context).addParameter("confirm", true).addReturnUrl(currentURL));
                 PopupMenu menu = new PopupMenu(navtree, PopupMenu.Align.LEFT, PopupMenu.ButtonStyle.TEXT);
             %><td><% menu.render(out); %></td>
             <%}%>

--- a/flow/src/org/labkey/flow/reports/ControlsQCReport.java
+++ b/flow/src/org/labkey/flow/reports/ControlsQCReport.java
@@ -41,11 +41,11 @@ public class ControlsQCReport extends FilterFlowReport
     public static String DESC = "Flow Controls Statistics over Time";
     public static final String STATISTIC_PROP = "statistic";
 
-    public static ActionURL createURL(Container c, @Nullable ActionURL returnURL, @Nullable ActionURL cancelURL)
+    public static ActionURL createURL(Container c, @Nullable ActionURL returnUrl, @Nullable ActionURL cancelURL)
     {
         ActionURL url = new ActionURL(ReportsController.CreateAction.class, c).addParameter(ReportDescriptor.Prop.reportType, TYPE);
-        if (returnURL != null)
-            url.addReturnURL(returnURL);
+        if (returnUrl != null)
+            url.addReturnUrl(returnUrl);
         if (cancelURL != null)
             url.addCancelURL(cancelURL);
         return url;
@@ -70,9 +70,9 @@ public class ControlsQCReport extends FilterFlowReport
     }
 
     @Override
-    public HttpView getConfigureForm(ViewContext context, ActionURL returnURL, ActionURL cancelURL)
+    public HttpView<?> getConfigureForm(ViewContext context, ActionURL returnUrl, ActionURL cancelUrl)
     {
-        return new JspView<>("/org/labkey/flow/reports/editQCReport.jsp", Tuple3.of(this, returnURL, cancelURL));
+        return new JspView<>("/org/labkey/flow/reports/editQCReport.jsp", Tuple3.of(this, returnUrl, cancelUrl));
     }
 
     @Override

--- a/flow/src/org/labkey/flow/reports/FlowReport.java
+++ b/flow/src/org/labkey/flow/reports/FlowReport.java
@@ -153,7 +153,7 @@ abstract public class FlowReport extends AbstractReport
         }
     }
 
-    public abstract HttpView getConfigureForm(ViewContext context, ActionURL returnURL, ActionURL cancelURL);
+    public abstract HttpView<?> getConfigureForm(ViewContext context, ActionURL returnUrl, ActionURL cancelUrl);
 
     /** override=true means only set parameters overrideable via the URL on execute */
     public abstract boolean updateProperties(ContainerUser cu, PropertyValues pvs, BindException errors, boolean override);

--- a/flow/src/org/labkey/flow/reports/PositivityFlowReport.java
+++ b/flow/src/org/labkey/flow/reports/PositivityFlowReport.java
@@ -59,13 +59,13 @@ public class PositivityFlowReport extends FilterFlowReport
     public static final String DESC = "Flow Positivity Call";
     public static final String SUBSET_PROP = "subset";
 
-    public static ActionURL createURL(Container c, @Nullable ActionURL returnURL, @Nullable ActionURL cancelURL)
+    public static ActionURL createURL(Container c, @Nullable ActionURL returnUrl, @Nullable ActionURL cancelUrl)
     {
         ActionURL url = new ActionURL(ReportsController.CreateAction.class, c).addParameter(ReportDescriptor.Prop.reportType, TYPE);
-        if (returnURL != null)
-            url.addReturnURL(returnURL);
-        if (cancelURL != null)
-            url.addCancelURL(cancelURL);
+        if (returnUrl != null)
+            url.addReturnUrl(returnUrl);
+        if (cancelUrl != null)
+            url.addCancelURL(cancelUrl);
         return url;
     }
 
@@ -91,9 +91,9 @@ public class PositivityFlowReport extends FilterFlowReport
     }
 
     @Override
-    public HttpView getConfigureForm(ViewContext context, ActionURL returnURL, ActionURL cancelURL)
+    public HttpView<?> getConfigureForm(ViewContext context, ActionURL returnUrl, ActionURL cancelUrl)
     {
-        return new JspView<>("/org/labkey/flow/reports/editPositivityReport.jsp", Tuple3.of(this, returnURL, cancelURL));
+        return new JspView<>("/org/labkey/flow/reports/editPositivityReport.jsp", Tuple3.of(this, returnUrl, cancelUrl));
     }
 
     SubsetSpec getSubset()
@@ -174,7 +174,7 @@ public class PositivityFlowReport extends FilterFlowReport
             FlowProtocol protocol = FlowProtocol.getForContainer(context.getContainer());
             ActionURL currentURL = context.getActionURL();
             ActionURL editICSMetadataURL = protocol.urlFor(ProtocolController.EditICSMetadataAction.class);
-            editICSMetadataURL.addReturnURL(currentURL);
+            editICSMetadataURL.addReturnUrl(currentURL);
 
             return HtmlView.unsafe(
                     "<p class='labkey-error'>Positivity report requires configuring flow experiment metadata for study and background information before running.</p>" +

--- a/flow/src/org/labkey/flow/reports/editPositivityReport.jsp
+++ b/flow/src/org/labkey/flow/reports/editPositivityReport.jsp
@@ -45,13 +45,13 @@
 
     Tuple3<PositivityFlowReport, ActionURL, ActionURL> bean = (Tuple3<PositivityFlowReport, ActionURL, ActionURL>) HttpView.currentModel();
     PositivityFlowReport report = bean.first;
-    ActionURL returnURL = bean.second;
-    ActionURL cancelURL = bean.third;
+    ActionURL returnUrl = bean.second;
+    ActionURL cancelUrl = bean.third;
     ReportDescriptor d = report.getDescriptor();
     String reportId = d.getReportId() == null ? null : d.getReportId().toString();
 
-    ActionURL retURL = returnURL == null ? urlFor(BeginAction.class) : returnURL;
-    ActionURL canURL = cancelURL == null ? retURL : cancelURL;
+    ActionURL retURL = returnUrl == null ? urlFor(BeginAction.class) : returnUrl;
+    ActionURL canURL = cancelUrl == null ? retURL : cancelUrl;
 
     FlowProtocol protocol = FlowProtocol.getForContainer(c);
     ICSMetadata metadata = protocol == null ? null : protocol.getICSMetadata();
@@ -61,7 +61,7 @@
     if (protocol != null)
     {
         editICSMetadataURL = protocol.urlFor(EditICSMetadataAction.class);
-        editICSMetadataURL.addReturnURL(currentURL);
+        editICSMetadataURL.addReturnUrl(currentURL);
     }
 %>
 
@@ -142,12 +142,12 @@ function Form_onDelete()
    if (d.getReportId() != null)
    {
        url = urlFor(DeleteAction.class).addParameter("reportId", report.getReportId().toString());
-       if (returnURL != null)
-           url.addReturnURL(returnURL);
+       if (returnUrl != null)
+           url.addReturnUrl(returnUrl);
    }
-   else if (returnURL != null)
+   else if (returnUrl != null)
    {
-       url = returnURL;
+       url = returnUrl;
    }
    else
    {

--- a/flow/src/org/labkey/flow/reports/editQCReport.jsp
+++ b/flow/src/org/labkey/flow/reports/editQCReport.jsp
@@ -37,13 +37,13 @@
 <%
     Tuple3<FilterFlowReport, ActionURL, ActionURL> bean = (Tuple3<FilterFlowReport, ActionURL, ActionURL>) HttpView.currentModel();
     FilterFlowReport report = bean.first;
-    ActionURL returnURL = bean.second;
-    ActionURL cancelURL = bean.third;
+    ActionURL returnUrl = bean.second;
+    ActionURL cancelUrl = bean.third;
     ReportDescriptor d = report.getDescriptor();
     String reportId = d.getReportId() == null ? null : d.getReportId().toString();
 
-    ActionURL retURL = returnURL == null ? urlFor(BeginAction.class) : returnURL;
-    ActionURL canURL = cancelURL == null ? retURL : cancelURL;
+    ActionURL retURL = returnUrl == null ? urlFor(BeginAction.class) : returnUrl;
+    ActionURL canURL = cancelUrl == null ? retURL : cancelUrl;
 %>
 <style type="text/css">
     .x-form-item {
@@ -113,12 +113,12 @@ function Form_onDelete()
    if (d.getReportId() != null)
    {
        url = urlFor(DeleteAction.class).addParameter("reportId", report.getReportId().toString());
-       if (returnURL != null)
-           url.addReturnURL(returnURL);
+       if (returnUrl != null)
+           url.addReturnUrl(returnUrl);
    }
-   else if (returnURL != null)
+   else if (returnUrl != null)
    {
-       url = returnURL;
+       url = returnUrl;
    }
    else
    {

--- a/flow/src/org/labkey/flow/script/FlowPipelineProvider.java
+++ b/flow/src/org/labkey/flow/script/FlowPipelineProvider.java
@@ -103,7 +103,7 @@ public class FlowPipelineProvider extends PipelineProvider
 
         String path = directory.getPathParameter();
         ActionURL returnUrl = PageFlowUtil.urlProvider(PipelineUrls.class).urlBrowse(context.getContainer(), null, path.toString());
-        importRunsURL.addReturnURL(returnUrl);
+        importRunsURL.addReturnUrl(returnUrl);
         importRunsURL.replaceParameter("path", path);
         String baseId = this.getClass().getName();
 

--- a/flow/src/org/labkey/flow/view/FlowQueryView.java
+++ b/flow/src/org/labkey/flow/view/FlowQueryView.java
@@ -155,7 +155,7 @@ public class FlowQueryView extends QueryView
 
                 if (showGraphs == FlowQuerySettings.ShowGraphs.Inline)
                 {
-                    JspView view = new SetGraphSizeView();
+                    SetGraphSizeView view = new SetGraphSizeView();
                     view.setFrame(FrameType.NONE);
                     HttpView.currentView().include(view, out);
                 }
@@ -334,7 +334,7 @@ public class FlowQueryView extends QueryView
                 form.setIncludeStatistics(true);
                 form.setIncludeFCSFiles(false);
                 form.setSelectionType("runs");
-                HttpView analysisExportView = new JspView<>("/org/labkey/flow/view/exportAnalysis.jsp", form);
+                JspView<?> analysisExportView = new JspView<>("/org/labkey/flow/view/exportAnalysis.jsp", form);
                 panelButton.addSubPanel("Analysis", analysisExportView);
             }
             else if (queryName.equals(FlowTableType.FCSFiles.toString()) || queryName.equals(FlowTableType.FCSAnalyses.toString()) || queryName.equals(FlowTableType.CompensationControls.toString()))
@@ -346,7 +346,7 @@ public class FlowQueryView extends QueryView
                 form.setIncludeStatistics(false);
                 form.setIncludeFCSFiles(true);
                 form.setSelectionType("wells");
-                HttpView analysisExportView = new JspView<>("/org/labkey/flow/view/exportAnalysis.jsp", form);
+                JspView<?> analysisExportView = new JspView<>("/org/labkey/flow/view/exportAnalysis.jsp", form);
                 panelButton.addSubPanel("Analysis", analysisExportView);
             }
         }

--- a/flow/src/org/labkey/flow/view/FlowQueryView.java
+++ b/flow/src/org/labkey/flow/view/FlowQueryView.java
@@ -302,7 +302,7 @@ public class FlowQueryView extends QueryView
             ActionURL editWellsURL = new ActionURL(WellController.EditWellAction.class, getContainer());
             URLHelper returnUrl = getReturnUrl();
             editWellsURL.addReturnUrl(returnUrl);
-            editWellsURL.addParameter("editWellReturnUrl", getReturnUrl().toString());
+            editWellsURL.addParameter("editWellReturnUrl", returnUrl.toString());
             editWellsURL.addParameter("ff_isBulkEdit", true);
             editWellsURL.addParameter("isUpdate", false);
 

--- a/flow/src/org/labkey/flow/view/FlowQueryView.java
+++ b/flow/src/org/labkey/flow/view/FlowQueryView.java
@@ -236,7 +236,7 @@ public class FlowQueryView extends QueryView
     {
         // The Analysis "folder" table needs to use the getDeleteProtocolURL, the FCSRuns and FCSAnalysis 'views' need the getDeleteSelectedExpRunsURL
         if (useExpRunsURL)
-            setDeleteURL(ExperimentUrls.get().getDeleteSelectedExpRunsURL(getContainer(), getReturnURL()).toContainerRelativeURL());
+            setDeleteURL(ExperimentUrls.get().getDeleteSelectedExpRunsURL(getContainer(), getReturnUrl()).toContainerRelativeURL());
         return super.createDeleteButton(showConfirmation);
     }
 
@@ -300,9 +300,9 @@ public class FlowQueryView extends QueryView
         if (queryName.equals(FlowTableType.FCSFiles.toString()))
         {
             ActionURL editWellsURL = new ActionURL(WellController.EditWellAction.class, getContainer());
-            URLHelper returnURL = getReturnURL();
-            editWellsURL.addReturnURL(returnURL);
-            editWellsURL.addParameter("editWellReturnUrl", getReturnURL().toString());
+            URLHelper returnUrl = getReturnUrl();
+            editWellsURL.addReturnUrl(returnUrl);
+            editWellsURL.addParameter("editWellReturnUrl", getReturnUrl().toString());
             editWellsURL.addParameter("ff_isBulkEdit", true);
             editWellsURL.addParameter("isUpdate", false);
 

--- a/flow/src/org/labkey/flow/webparts/AnalysesWebPart.java
+++ b/flow/src/org/labkey/flow/webparts/AnalysesWebPart.java
@@ -49,7 +49,7 @@ public class AnalysesWebPart extends FlowQueryView
         setShowDeleteButtonConfirmationText(false);
         setShowExportButtons(false);
         setShowPagination(false);
-        // Workaround for "Issue 18903: can't change query on showRuns.view" -- for now, just don't display the [details] link which includes the returnURL parameter.
+        // Workaround for "Issue 18903: can't change query on showRuns.view" -- for now, just don't display the [details] link which includes the returnUrl parameter.
         setShowDetailsColumn(false);
         setButtonBarPosition(DataRegion.ButtonBarPosition.TOP);
     }
@@ -77,7 +77,7 @@ public class AnalysesWebPart extends FlowQueryView
                 bar.add(btnAnalyze);
             }
 
-            ActionURL createRunGroupURL = PageFlowUtil.urlProvider(ExperimentUrls.class).getCreateRunGroupURL(getContainer(), getReturnURL(), false);
+            ActionURL createRunGroupURL = PageFlowUtil.urlProvider(ExperimentUrls.class).getCreateRunGroupURL(getContainer(), getReturnUrl(), false);
             ActionButton createExperiment = new ActionButton(createRunGroupURL, "Create Analysis Folder", ActionButton.Action.POST);
             createExperiment.setActionType(ActionButton.Action.LINK);
             createExperiment.setDisplayPermission(InsertPermission.class);

--- a/luminex/src/org/labkey/luminex/LuminexAssayProvider.java
+++ b/luminex/src/org/labkey/luminex/LuminexAssayProvider.java
@@ -349,7 +349,7 @@ public class LuminexAssayProvider extends AbstractAssayProvider
                 {
                     ActionURL analytePropsUrl = new ActionURL(LuminexController.SetAnalyteDefaultValuesAction.class, viewContext.getContainer());
                     analytePropsUrl.addParameter("rowId", protocol.getRowId());
-                    analytePropsUrl.addReturnURL(viewContext.getActionURL());
+                    analytePropsUrl.addReturnUrl(viewContext.getActionURL());
                     analytePropsTree.setHref(analytePropsUrl.toString());
                 }
             }

--- a/luminex/src/org/labkey/luminex/LuminexController.java
+++ b/luminex/src/org/labkey/luminex/LuminexController.java
@@ -400,7 +400,7 @@ public class LuminexController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(DefaultValuesForm form)
         {
-            return form.getReturnURLHelper();
+            return form.getReturnUrlHelper();
         }
 
         @Override
@@ -919,7 +919,7 @@ public class LuminexController extends SpringActionController
                 public ActionButton createDeleteButton()
                 {
                     ActionURL urlDelete = new ActionURL(LuminexController.DeleteGuideSetAction.class, getContainer());
-                    urlDelete.addReturnURL(getReturnURL());
+                    urlDelete.addReturnUrl(getReturnUrl());
                     urlDelete.addParameter("rowId", protocolId);
                     ActionButton btnDelete = new ActionButton(urlDelete, "Delete");
                     btnDelete.setIconCls("trash");

--- a/luminex/src/org/labkey/luminex/view/defaultValues.jsp
+++ b/luminex/src/org/labkey/luminex/view/defaultValues.jsp
@@ -59,11 +59,11 @@
         <tr>
             <td colspan="2">
                 <%= button("Add Row").onClick("addRow();")%>
-                <%= button("Import Data").href(new ActionURL(LuminexController.ImportDefaultValuesAction.class, getContainer()).addParameter("rowId", bean.getProtocol().getRowId()).addReturnURL(getViewContext().getActionURL()))%>
+                <%= button("Import Data").href(new ActionURL(LuminexController.ImportDefaultValuesAction.class, getContainer()).addParameter("rowId", bean.getProtocol().getRowId()).addReturnUrl(getViewContext().getActionURL()))%>
                 <%= button("Export TSV").href(new ActionURL(LuminexController.ExportDefaultValuesAction.class, getContainer()).addParameter("rowId", bean.getProtocol().getRowId()))%>
             </td>
             <td align="right">
-                <%= button("Cancel").href(bean.getReturnURLHelper()) %>
+                <%= button("Cancel").href(bean.getReturnUrlHelper()) %>
                 <%= button("Save Defaults").submit(true) %>
             </td>
             <td>&nbsp;</td>

--- a/microarray/src/org/labkey/microarray/controllers/FeatureAnnotationSetController.java
+++ b/microarray/src/org/labkey/microarray/controllers/FeatureAnnotationSetController.java
@@ -301,7 +301,7 @@ public class FeatureAnnotationSetController extends SpringActionController
             ButtonBar bb = new ButtonBar();
             ActionURL editURL = QueryService.get().urlDefault(getContainer(), QueryAction.updateQueryRow, schema.getSchemaPath().toString(), featureAnnotationSetTable.getName());
             editURL.addParameter("RowId", form.getRowId());
-            editURL.addReturnURL(getViewContext().getActionURL());
+            editURL.addReturnUrl(getViewContext().getActionURL());
 
             ActionButton edit = new ActionButton(editURL, "Edit");
             edit.setActionType(ActionButton.Action.LINK);

--- a/microarray/src/org/labkey/microarray/view/FeatureAnnotationSetQueryView.java
+++ b/microarray/src/org/labkey/microarray/view/FeatureAnnotationSetQueryView.java
@@ -70,7 +70,7 @@ public class FeatureAnnotationSetQueryView extends QueryView
         ActionButton deleteButton = new ActionButton(FeatureAnnotationSetController.DeleteAction.class, "Delete", ActionButton.Action.GET);
         deleteButton.setDisplayPermission(DeletePermission.class);
         ActionURL deleteURL = new ActionURL(FeatureAnnotationSetController.DeleteAction.class, getContainer());
-        deleteURL.addReturnURL(getViewContext().getActionURL());
+        deleteURL.addReturnUrl(getViewContext().getActionURL());
         deleteButton.setURL(deleteURL);
         deleteButton.setActionType(ActionButton.Action.POST);
         deleteButton.setRequiresSelection(true);
@@ -78,7 +78,7 @@ public class FeatureAnnotationSetQueryView extends QueryView
 
         ActionButton uploadButton = new ActionButton(FeatureAnnotationSetController.UploadAction.class, "Import Feature Annotation Set", ActionButton.Action.LINK);
         ActionURL uploadURL = new ActionURL(FeatureAnnotationSetController.UploadAction.class, getContainer());
-        uploadURL.addReturnURL(getViewContext().getActionURL());
+        uploadURL.addReturnUrl(getViewContext().getActionURL());
         uploadButton.setURL(uploadURL);
         uploadButton.setDisplayPermission(UpdatePermission.class);
         bar.add(uploadButton);

--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -685,11 +685,11 @@ public class MS2Controller extends SpringActionController
         }
     }
 
-    public static ActionURL getRenameRunURL(Container c, MS2Run run, ActionURL returnURL)
+    public static ActionURL getRenameRunURL(Container c, MS2Run run, ActionURL returnUrl)
     {
         ActionURL url = new ActionURL(RenameRunAction.class, c);
         url.addParameter("run", run.getRun());
-        url.addReturnURL(returnURL);
+        url.addReturnUrl(returnUrl);
         return url;
     }
 
@@ -697,7 +697,7 @@ public class MS2Controller extends SpringActionController
     public class RenameRunAction extends FormViewAction<RenameForm>
     {
         private MS2Run _run;
-        private URLHelper _returnURL;
+        private URLHelper _returnUrl;
 
         @Override
         public void validateCommand(RenameForm target, Errors errors)
@@ -708,16 +708,16 @@ public class MS2Controller extends SpringActionController
         public ModelAndView getView(RenameForm form, boolean reshow, BindException errors)
         {
             _run = form.validateRun();
-            _returnURL = form.getReturnURLHelper(getShowRunURL(getUser(), getContainer(), form.getRun()));
+            _returnUrl = form.getReturnUrlHelper(getShowRunURL(getUser(), getContainer(), form.getRun()));
 
             String description = form.getDescription();
-            if (description == null || description.length() == 0)
+            if (description == null || description.isEmpty())
                 description = _run.getDescription();
 
             RenameBean bean = new RenameBean();
             bean.run = _run;
             bean.description = description;
-            bean.returnURL = _returnURL;
+            bean.returnUrl = _returnUrl;
 
             getPageConfig().setFocusId("description");
 
@@ -739,13 +739,13 @@ public class MS2Controller extends SpringActionController
         @Override
         public URLHelper getSuccessURL(RenameForm form)
         {
-            return form.getReturnURLHelper();
+            return form.getReturnUrlHelper();
         }
 
         @Override
         public void addNavTrail(NavTree root)
         {
-            addRunNavTrail(root, _run, _returnURL, "Rename Run", getPageConfig(), null);
+            addRunNavTrail(root, _run, _returnUrl, "Rename Run", getPageConfig(), null);
         }
     }
 
@@ -754,7 +754,7 @@ public class MS2Controller extends SpringActionController
     {
         public MS2Run run;
         public String description;
-        public URLHelper returnURL;
+        public URLHelper returnUrl;
     }
 
     @RequiresPermission(ReadPermission.class)
@@ -1004,7 +1004,7 @@ public class MS2Controller extends SpringActionController
     {
         ActionURL url = new ActionURL(ManageViewsAction.class, getContainer());
         url.addParameter("run", run.getRun());
-        url.addReturnURL(runURL);
+        url.addReturnUrl(runURL);
         return url;
     }
 
@@ -1053,7 +1053,7 @@ public class MS2Controller extends SpringActionController
     public class ManageViewsAction extends FormViewAction<ManageViewsForm>
     {
         private MS2Run _run;
-        private ActionURL _returnURL;
+        private ActionURL _returnUrl;
 
         @Override
         public void validateCommand(ManageViewsForm form, Errors errors)
@@ -1065,7 +1065,7 @@ public class MS2Controller extends SpringActionController
         {
             _run = form.validateRun();
 
-            _returnURL = form.getReturnActionURL();
+            _returnUrl = form.getReturnActionURL();
 
             DefaultViewType defaultViewType;
             Map<String, String> props = PropertyManager.getProperties(getUser(), ContainerManager.getRoot(), MS2_DEFAULT_VIEW_CATEGORY);
@@ -1086,7 +1086,7 @@ public class MS2Controller extends SpringActionController
             }
 
 
-            ManageViewsBean bean = new ManageViewsBean(_returnURL, defaultViewType, viewMap, viewName);
+            ManageViewsBean bean = new ManageViewsBean(_returnUrl, defaultViewType, viewMap, viewName);
             JspView<ManageViewsBean> view = new JspView<>("/org/labkey/ms2/manageViews.jsp", bean);
             view.setFrame(WebPartView.FrameType.PORTAL);
             view.setTitle("Manage Views");
@@ -1096,7 +1096,7 @@ public class MS2Controller extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            addRunNavTrail(root, _run, _returnURL, "Customize Views", getPageConfig(), "viewRun");
+            addRunNavTrail(root, _run, _returnUrl, "Customize Views", getPageConfig(), "viewRun");
         }
 
         @Override
@@ -1178,22 +1178,22 @@ public class MS2Controller extends SpringActionController
 
     public static class ManageViewsBean
     {
-        private final ActionURL _returnURL;
+        private final ActionURL _returnUrl;
         private final DefaultViewType _defaultViewType;
         private final Map<String, String> _views;
         private final String _viewName;
 
-        public ManageViewsBean(ActionURL returnURL, DefaultViewType defaultViewType, Map<String, String> views, String viewName)
+        public ManageViewsBean(ActionURL returnUrl, DefaultViewType defaultViewType, Map<String, String> views, String viewName)
         {
-            _returnURL = returnURL;
+            _returnUrl = returnUrl;
             _defaultViewType = defaultViewType;
             _views = views;
             _viewName = viewName;
         }
 
-        public ActionURL getReturnURL()
+        public ActionURL getReturnUrl()
         {
-            return _returnURL;
+            return _returnUrl;
         }
 
         public DefaultViewType getDefaultViewType()
@@ -1216,7 +1216,7 @@ public class MS2Controller extends SpringActionController
     {
         public ActionURL nextURL;
         public SelectBuilder select;
-        public HttpView extraOptionsView;
+        public HttpView<?> extraOptionsView;
         public String viewInstructions;
         public int runList;
         public String buttonText;
@@ -1296,7 +1296,7 @@ public class MS2Controller extends SpringActionController
         {
             CompareOptionsBean<PeptideFilteringComparisonForm> bean = new CompareOptionsBean<>(new ActionURL(CompareProteinProphetQueryAction.class, getContainer()), runListId, form);
 
-            return new JspView<CompareOptionsBean>("/org/labkey/ms2/compare/compareProteinProphetQueryOptions.jsp", bean);
+            return new JspView<>("/org/labkey/ms2/compare/compareProteinProphetQueryOptions.jsp", bean);
         }
 
         @Override
@@ -3038,7 +3038,7 @@ public class MS2Controller extends SpringActionController
     public class SaveViewAction extends FormViewAction<MS2ViewForm>
     {
         private MS2Run _run;
-        private ActionURL _returnURL;
+        private ActionURL _returnUrl;
 
         @Override
         public void validateCommand(MS2ViewForm target, Errors errors)
@@ -3050,13 +3050,13 @@ public class MS2Controller extends SpringActionController
         {
             _run = form.validateRun();
 
-            _returnURL = getViewContext().cloneActionURL().setAction(ShowRunAction.class);
+            _returnUrl = getViewContext().cloneActionURL().setAction(ShowRunAction.class);
             JspView<SaveViewBean> saveView = new JspView<>("/org/labkey/ms2/saveView.jsp", new SaveViewBean());
             SaveViewBean bean = saveView.getModelBean();
-            bean.returnURL = _returnURL;
+            bean.returnUrl = _returnUrl;
             bean.canShare = getContainer().hasPermission(getUser(), InsertPermission.class);
 
-            ActionURL newURL = bean.returnURL.clone().deleteParameter("run");
+            ActionURL newURL = bean.returnUrl.clone().deleteParameter("run");
             bean.viewParams = newURL.getRawQuery();
 
             getPageConfig().setFocusId("name");
@@ -3085,20 +3085,20 @@ public class MS2Controller extends SpringActionController
         @Override
         public URLHelper getSuccessURL(MS2ViewForm form)
         {
-            return form.getReturnURLHelper();
+            return form.getReturnUrlHelper();
         }
 
         @Override
         public void addNavTrail(NavTree root)
         {
-            addRunNavTrail(root, _run, _returnURL, "Save View", getPageConfig(), "viewRun");
+            addRunNavTrail(root, _run, _returnUrl, "Save View", getPageConfig(), "viewRun");
         }
     }
 
 
     public static class SaveViewBean
     {
-        public ActionURL returnURL;
+        public ActionURL returnUrl;
         public boolean canShare;
         public String viewParams;
     }

--- a/ms2/src/org/labkey/ms2/manageViews.jsp
+++ b/ms2/src/org/labkey/ms2/manageViews.jsp
@@ -26,7 +26,7 @@
 %>
 <labkey:form method="post" name="manageViewsForm" action="">
     <p>
-        <input type=hidden value="<%=h(bean.getReturnURL())%>">
+        <input type=hidden value="<%=h(bean.getReturnUrl())%>">
         <%
             getPageConfig().addHandlerForQuerySelector("INPUT.labkey-defaultViewType", "change", "updateForm();");
             for (MS2Controller.DefaultViewType defaultViewType : MS2Controller.DefaultViewType.values())
@@ -71,7 +71,7 @@
         }
         %>
     </table><br/>
-    <%= button("OK").submit(true) %> <%= button("Cancel").href(bean.getReturnURL()) %>
+    <%= button("OK").submit(true) %> <%= button("Cancel").href(bean.getReturnUrl()) %>
 </labkey:form>
 
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">

--- a/ms2/src/org/labkey/ms2/renameRun.jsp
+++ b/ms2/src/org/labkey/ms2/renameRun.jsp
@@ -25,7 +25,7 @@
     RenameBean bean = ((JspView<RenameBean>) HttpView.currentView()).getModelBean();
 %>
 <labkey:form action="<%=urlFor(RenameRunAction.class)%>" method="post">
-<%=generateReturnUrlFormField(bean.returnURL)%>
+<%=generateReturnUrlFormField(bean.returnUrl)%>
 <input type="hidden" name="run" value="<%=bean.run.getRun()%>"/>
 <table class="lk-fields-table">
     <tr>
@@ -35,7 +35,7 @@
     <tr>
         <td colspan="2" style="padding-top: 10px;">
             <%= button("Rename").submit(true) %>
-            <%= button("Cancel").href(bean.returnURL) %>
+            <%= button("Cancel").href(bean.returnUrl) %>
         </td>
     </tr>
 </table>

--- a/ms2/src/org/labkey/ms2/saveView.jsp
+++ b/ms2/src/org/labkey/ms2/saveView.jsp
@@ -31,7 +31,7 @@
             <td>
                 <input name="name" id="name" style="width:200px;">
                 <input type=hidden value="<%=h(bean.viewParams)%>" name="viewParams">
-                <%=generateReturnUrlFormField(bean.returnURL)%>
+                <%=generateReturnUrlFormField(bean.returnUrl)%>
             </td>
         </tr><%
 if (bean.canShare)
@@ -43,7 +43,7 @@ if (bean.canShare)
         <tr>
             <td colspan=2>
                 <%= button("Save View").submit(true) %>
-                <%= button("Cancel").href(bean.returnURL) %>
+                <%= button("Cancel").href(bean.returnUrl) %>
             </td>
         </tr>
     </table>

--- a/viability/src/org/labkey/viability/ViabilityAssayProvider.java
+++ b/viability/src/org/labkey/viability/ViabilityAssayProvider.java
@@ -435,7 +435,7 @@ public class ViabilityAssayProvider extends AbstractAssayProvider
             {
                 ActionURL url = new ActionURL(ViabilityController.RecalculateSpecimenAggregatesAction.class, c);
                 url.addParameter("rowId", protocol.getRowId());
-                url.addReturnURL(getViewContext().getActionURL());
+                url.addReturnUrl(getViewContext().getActionURL());
 
                 links.add(new NavTree("recalc specimen aggregates", url));
             }


### PR DESCRIPTION
#### Rationale
In 2021 we made a major push to use `returnUrl` consistently instead of `srcURL` or `returnURL`. We can finish the job.

Issue 7580: inconsistent use of returnUrl parameter

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6407

#### Changes
- Change everything to `returnUrl` and get rid of code checking for old versions of the parameters