### PR TITLE
Issue 52461: Luminex Levey-Jennings report 4PL curve fit comparison report not working for assay run selected from another folder

### DIFF
--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
@@ -384,6 +384,10 @@ public final class LuminexGuideSetTest extends LuminexTest
     @LogMethod
     private void verifyLeveyJenningsPlots()
     {
+        // Issue 52461: view the LJ report and curve fit comparison plots from subfolder
+        goToProjectFolder(getProjectName(), TEST_ASSAY_SUBFOLDER);
+        clickAndWait(Locator.linkWithText(TEST_ASSAY_LUM));
+
         _guideSetHelper.goToLeveyJenningsGraphPage(TEST_ASSAY_LUM, "Standard1");
         _guideSetHelper.setUpLeveyJenningsGraphParams("GS Analyte B");
 
@@ -434,6 +438,8 @@ public final class LuminexGuideSetTest extends LuminexTest
         selectCurveComparisonPlotOption("curvecomparison-legend-combo", "Notebook No.");
         Locator.extButton("Close").findElement(curveComparisonWindow).click();
         _extHelper.waitForExt3MaskToDisappear(WAIT_FOR_JAVASCRIPT);
+
+        goToProjectHome();
     }
 
     private void selectCurveComparisonPlotOption(String comboName, String value)

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -64,7 +64,8 @@ import static org.junit.Assert.assertTrue;
 @BaseWebDriverTest.ClassTimeout(minutes = 40)
 public abstract class LuminexTest extends BaseWebDriverTest
 {
-    protected final static String TEST_ASSAY_PRJ_LUMINEX = "LuminexTest Project";            //project for luminex test
+    protected final static String TEST_ASSAY_PRJ_LUMINEX = "LuminexTest Project";
+    protected final static String TEST_ASSAY_SUBFOLDER = "Subfolder";//project for luminex test
 
     public static final String TEST_ASSAY_LUM =  "&TestAssayLuminex></% 1";// put back TRICKY_CHARACTERS_NO_QUOTES when issue 20061 is resolved
     protected static final String TEST_ASSAY_LUM_DESC = "Description for Luminex assay";
@@ -180,6 +181,10 @@ public abstract class LuminexTest extends BaseWebDriverTest
             createDefaultStudy();
             goToProjectHome();
         }
+
+        // create a subfolder to the project
+        _containerHelper.createSubfolder(getProjectName(), TEST_ASSAY_SUBFOLDER, "Assay");
+        goToProjectHome();
 
         PortalHelper portalHelper = new PortalHelper(this);
         //add the Assay List web part so we can create a new luminex assay
@@ -575,7 +580,7 @@ public abstract class LuminexTest extends BaseWebDriverTest
     //helper function to go to test assay home from anywhere the project link is visible
     public void goToTestAssayHome(String assayName)
     {
-        if (!isTextPresent(assayName + " Runs"))
+        if (!getDriver().getTitle().startsWith(assayName + " Runs"))
         {
             goToProjectHome();
             clickAndWait(Locator.linkWithText(assayName));

--- a/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
@@ -257,6 +257,7 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.Component, {
                     queryName: this.controlType === 'SinglePoint' ? 'AnalyteSinglePointControl' : 'AnalyteTitration',
                     columns: 'Analyte/Data/Run/RowId',
                     filterArray: [LABKEY.Filter.create('Analyte', analyteIds, LABKEY.Filter.Types.IN)],
+                    containerFilter: LABKEY.Query.containerFilter.allFolders,
                     success: function(data) {
                         var runIds = [];
                         for (var i = 0; i < data.rows.length; i++) {
@@ -457,11 +458,11 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.Component, {
                     if (Ext.getDom(divId)) {
                         var html = Ext.getDom(divId).innerHTML;
                         html = html.replace(/&amp;/g, "&");
-                        var pdfHref = html.substring(html.indexOf('href="') + 6, html.indexOf('&attachment=true'));
+                        var pdfHref = html.substring(html.indexOf('href="') + 6, html.indexOf('Curve Comparison Plot.pdf') - 2);
                         if (pdfHref.indexOf("deleteFile") == -1) {
                             pdfHref = pdfHref + "&deleteFile=false";
                         }
-                        window.location = pdfHref + "&attachment=true";
+                        window.location = pdfHref;
                     }
                 }
             },


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52461
We are correctly using the allFolders container filter to get the data for the Levey-Jennings report and plot, but we were not using that containerFilter to looking RunId values for the selected rows when clicking "View 4PL Curves".

#### Changes
- add LABKEY.Query.containerFilter.allFolders to selectRows request in viewCurvesClicked()
