### PR TITLE
Migrate remaining renderInputHtml() overrides

### DIFF
--- a/luminex/src/org/labkey/luminex/LuminexUploadWizardAction.java
+++ b/luminex/src/org/labkey/luminex/LuminexUploadWizardAction.java
@@ -91,6 +91,7 @@ import java.util.TreeSet;
 import static org.labkey.api.util.DOM.Attribute.style;
 import static org.labkey.api.util.DOM.TD;
 import static org.labkey.api.util.DOM.at;
+import static org.labkey.api.util.DOM.cl;
 
 /**
  * Adds Analyte Properties as third wizard step, handles analyte and titration definition input view UI and post, saves
@@ -435,10 +436,9 @@ public class LuminexUploadWizardAction extends UploadWizardAction<LuminexRunUplo
                     String id = groupName + "CheckBox";
 
                     TD(
-                            at(style, "display:" + (hideCell ? "none" : "table-cell")).
-                            name(titrationCellName),
-                            new Input.InputBuilder<>().type("checkbox").name(id).id(id)
-
+                        at(style, "display:" + (hideCell ? "none" : "table-cell")).
+                        name(titrationCellName),
+                        new Input.InputBuilder<>().type("checkbox").name(id).id(id)
                     ).appendTo(out);
 
                     StringBuilder onchange = new StringBuilder("b = this.checked;");
@@ -579,22 +579,13 @@ public class LuminexUploadWizardAction extends UploadWizardAction<LuminexRunUplo
             @Override
             public void renderDetailsCaptionCell(RenderContext ctx, HtmlWriter out, @Nullable String cls)
             {
-                Writer oldWriter = out.unwrap();
+                String sb = "Type: " + getBoundColumn().getFriendlyTypeName() + "\n";
 
-                try
-                {
-                    oldWriter.write("<td class=\"control-header-label\">");
-
-                    oldWriter.write(getTitle(ctx).toString());
-                    String sb = "Type: " + getBoundColumn().getFriendlyTypeName() + "\n";
-                    PageFlowUtil.popupHelp(HtmlString.of(sb), displayName).appendTo(oldWriter);
-
-                    oldWriter.write("</td>");
-                }
-                catch (IOException e)
-                {
-                    throw new RuntimeException(e);
-                }
+                TD(
+                    cl("control-header-label"),
+                    getTitle(ctx),
+                    PageFlowUtil.popupHelp(HtmlString.of(sb), displayName)
+                ).appendTo(out);
             }
         };
     }

--- a/luminex/src/org/labkey/luminex/query/AnalytePropStandardsDisplayColumn.java
+++ b/luminex/src/org/labkey/luminex/query/AnalytePropStandardsDisplayColumn.java
@@ -37,7 +37,9 @@ import java.util.Set;
 
 import static org.labkey.api.util.DOM.Attribute.name;
 import static org.labkey.api.util.DOM.Attribute.style;
+import static org.labkey.api.util.DOM.TD;
 import static org.labkey.api.util.DOM.at;
+import static org.labkey.api.util.DOM.cl;
 
 public class AnalytePropStandardsDisplayColumn extends SimpleDisplayColumn
 {
@@ -129,19 +131,12 @@ public class AnalytePropStandardsDisplayColumn extends SimpleDisplayColumn
     @Override
     public void renderDetailsCaptionCell(RenderContext ctx, HtmlWriter out, @Nullable String cls)
     {
-        String titrationCellName = PageFlowUtil.filter(LuminexUploadWizardAction.getTitrationColumnCellName(_titration.getName()));
-        Writer oldWriter = out.unwrap();
-        try
-        {
-            oldWriter.write("<td name=\"" + titrationCellName + "\"" + " class=\"" + PageFlowUtil.filter(cls)+ "\""
-                    + " style=\"display:" + (_hideCell ? "none" : "table-cell") + ";\">");
-            oldWriter.write(getTitle(ctx).toString());
-            oldWriter.write("</td>");
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException(e);
-        }
+        String titrationCellName = LuminexUploadWizardAction.getTitrationColumnCellName(_titration.getName());
+
+        TD(
+            cl(cls).at(style, "display:" + (_hideCell ? "none" : "table-cell") + ";").name(titrationCellName),
+            getTitle(ctx)
+        ).appendTo(out);
     }
 
     @Override

--- a/luminex/src/org/labkey/luminex/query/NegativeBeadDisplayColumnFactory.java
+++ b/luminex/src/org/labkey/luminex/query/NegativeBeadDisplayColumnFactory.java
@@ -95,27 +95,6 @@ public class NegativeBeadDisplayColumnFactory implements DisplayColumnFactory
                     PageFlowUtil.popupHelp(builder, _displayName)
 
                 ).appendTo(out);
-
-//                Writer oldWriter = out.unwrap();
-//                try
-//                {
-//                    oldWriter.write("<td class=\"control-header-label\">");
-//
-//                    oldWriter.write(getTitle(ctx).toString());
-//                    StringBuilder sb = new StringBuilder();
-//                    sb.append("""
-//                            The analyte to use in the FI-Bkgd-Neg transform script calculation. Available options are \
-//                            those selected as Negative Control analytes.
-//                            """);
-//                    sb.append("Type: ").append(getBoundColumn().getFriendlyTypeName()).append("\n");
-//                    PageFlowUtil.popupHelp(HtmlString.of(sb), _displayName).appendTo(oldWriter);
-//
-//                    oldWriter.write("</td>");
-//                }
-//                catch (IOException e)
-//                {
-//                    throw new RuntimeException(e);
-//                }
             }
 
             @Override
@@ -130,13 +109,6 @@ public class NegativeBeadDisplayColumnFactory implements DisplayColumnFactory
                     .addStyle("width:200px;" + (hidden ? "display:none;" : "display:inline-block;"))
                     .addDataAttribute("analytename", _analyteName); // used by NegativeBeadPopulation.js
 
-
-////                oldWriter.write("<select name=\"" + PageFlowUtil.filter(_inputName) + "\" " +
-////                        "class=\"form-control negative-bead-input\" " + // used by NegativeBeadPopulation.js
-//                        "analytename=\"" + PageFlowUtil.filter(_analyteName) + "\" " + // used by NegativeBeadPopulation.js
-////                        "width=\"200\" style=\"width:200px;" +
-////                        (hidden ? "display:none;" : "display:inline-block;") + "\">");
-
                 if (!hidden)
                     builder
                         .addOption("")
@@ -144,7 +116,6 @@ public class NegativeBeadDisplayColumnFactory implements DisplayColumnFactory
                         .selected(strValue);
 
                 builder.appendTo(out);
-//                oldWriter.write("</select>");
             }
         };
     }

--- a/luminex/src/org/labkey/luminex/query/NegativeBeadDisplayColumnFactory.java
+++ b/luminex/src/org/labkey/luminex/query/NegativeBeadDisplayColumnFactory.java
@@ -28,14 +28,15 @@ import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.JavaScriptFragment;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.element.Select.SelectBuilder;
 import org.labkey.api.writer.HtmlWriter;
 import org.labkey.luminex.LuminexDataHandler;
 
-import java.io.IOException;
-import java.io.Writer;
 import java.util.Set;
 
 import static org.labkey.api.util.DOM.SCRIPT;
+import static org.labkey.api.util.DOM.TD;
+import static org.labkey.api.util.DOM.cl;
 
 public class NegativeBeadDisplayColumnFactory implements DisplayColumnFactory
 {
@@ -80,54 +81,70 @@ public class NegativeBeadDisplayColumnFactory implements DisplayColumnFactory
             @Override
             public void renderDetailsCaptionCell(RenderContext ctx, HtmlWriter out, @Nullable String cls)
             {
-                Writer oldWriter = out.unwrap();
-                try
-                {
-                    oldWriter.write("<td class=\"control-header-label\">");
+                HtmlStringBuilder builder = HtmlStringBuilder.of("""
+                    The analyte to use in the FI-Bkgd-Neg transform script calculation. Available options are \
+                    those selected as Negative Control analytes.
+                    """)
+                    .append("Type: ")
+                    .append(getBoundColumn().getFriendlyTypeName())
+                    .append("\n");
 
-                    oldWriter.write(getTitle(ctx).toString());
-                    StringBuilder sb = new StringBuilder();
-                    sb.append("The analyte to use in the FI-Bkgd-Neg transform script calculation. Available options are " +
-                            "those selected as Negative Control analytes.\n\n");
-                    sb.append("Type: ").append(getBoundColumn().getFriendlyTypeName()).append("\n");
-                    PageFlowUtil.popupHelp(HtmlString.of(sb), _displayName).appendTo(oldWriter);
+                TD(
+                    cl("control-header-label"),
+                    getTitle(ctx),
+                    PageFlowUtil.popupHelp(builder, _displayName)
 
-                    oldWriter.write("</td>");
-                }
-                catch (IOException e)
-                {
-                    throw new RuntimeException(e);
-                }
+                ).appendTo(out);
+
+//                Writer oldWriter = out.unwrap();
+//                try
+//                {
+//                    oldWriter.write("<td class=\"control-header-label\">");
+//
+//                    oldWriter.write(getTitle(ctx).toString());
+//                    StringBuilder sb = new StringBuilder();
+//                    sb.append("""
+//                            The analyte to use in the FI-Bkgd-Neg transform script calculation. Available options are \
+//                            those selected as Negative Control analytes.
+//                            """);
+//                    sb.append("Type: ").append(getBoundColumn().getFriendlyTypeName()).append("\n");
+//                    PageFlowUtil.popupHelp(HtmlString.of(sb), _displayName).appendTo(oldWriter);
+//
+//                    oldWriter.write("</td>");
+//                }
+//                catch (IOException e)
+//                {
+//                    throw new RuntimeException(e);
+//                }
             }
 
             @Override
-            public void renderInputHtml(RenderContext ctx, Writer oldWriter, HtmlWriter out, Object value) throws IOException
+            public void renderInputHtml(RenderContext ctx, HtmlWriter out, Object value)
             {
                 String strValue = ConvertUtils.convert(value);
                 boolean hidden = _initNegativeControlAnalytes.contains(_analyteName);
 
-                oldWriter.write("<select name=\"" + PageFlowUtil.filter(_inputName) + "\" " +
-                        "class=\"form-control negative-bead-input\" " + // used by NegativeBeadPopulation.js
-                        "analytename=\"" + PageFlowUtil.filter(_analyteName) + "\" " + // used by NegativeBeadPopulation.js
-                        "width=\"200\" style=\"width:200px;" +
-                        (hidden ? "display:none;" : "display:inline-block;") + "\">");
+                SelectBuilder builder = new SelectBuilder()
+                    .name(_inputName)
+                    .className("form-control negative-bead-input") // used by NegativeBeadPopulation.js
+                    .addStyle("width:200px;" + (hidden ? "display:none;" : "display:inline-block;"))
+                    .addDataAttribute("analytename", _analyteName); // used by NegativeBeadPopulation.js
+
+
+////                oldWriter.write("<select name=\"" + PageFlowUtil.filter(_inputName) + "\" " +
+////                        "class=\"form-control negative-bead-input\" " + // used by NegativeBeadPopulation.js
+//                        "analytename=\"" + PageFlowUtil.filter(_analyteName) + "\" " + // used by NegativeBeadPopulation.js
+////                        "width=\"200\" style=\"width:200px;" +
+////                        (hidden ? "display:none;" : "display:inline-block;") + "\">");
 
                 if (!hidden)
-                {
-                    oldWriter.write("<option value=\"\"></option>");
-                    for (String negControlAnalyte : _initNegativeControlAnalytes)
-                    {
-                        oldWriter.write("<option value=\"" + PageFlowUtil.filter(negControlAnalyte) + "\"");
-                        if (strValue != null && strValue.equals(negControlAnalyte))
-                        {
-                            oldWriter.write(" SELECTED");
-                        }
-                        oldWriter.write(">");
-                        oldWriter.write(PageFlowUtil.filter(negControlAnalyte));
-                        oldWriter.write("</option>");
-                    }
-                }
-                oldWriter.write("</select>");
+                    builder
+                        .addOption("")
+                        .addOptions(_initNegativeControlAnalytes)
+                        .selected(strValue);
+
+                builder.appendTo(out);
+//                oldWriter.write("</select>");
             }
         };
     }

--- a/luminex/webapp/luminex/NegativeBeadPopulation.js
+++ b/luminex/webapp/luminex/NegativeBeadPopulation.js
@@ -27,7 +27,7 @@ function getAnalyteSelectedNegativeControls()
     {
         var negControlEl = getAnalyteNegativeControlEl(negBeadEls[i].name);
         if (negControlEl != null && negControlEl.checked)
-            negControlAnalytes.push(negBeadEls[i].getAttribute("analytename"));
+            negControlAnalytes.push(negBeadEls[i].getAttribute("data-analytename"));
     }
     return negControlAnalytes.sort();
 }
@@ -69,7 +69,7 @@ function updateAnalyteNegativeBeadInputs()
     {
         var negBeadEl = negBeadEls[i];
         var prevValue = negBeadEl.value;
-        var analyteName = negBeadEl.getAttribute("analytename");
+        var analyteName = negBeadEl.getAttribute("data-analytename");
         var hidden = negControlAnalytes.indexOf(analyteName) > -1;
 
         negBeadEl.value = null;

--- a/viability/src/org/labkey/viability/data/MultiValueInputColumn.java
+++ b/viability/src/org/labkey/viability/data/MultiValueInputColumn.java
@@ -19,21 +19,19 @@ package org.labkey.viability.data;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.RenderContext;
+import org.labkey.api.util.JavaScriptFragment;
 import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.view.HttpView;
 import org.labkey.api.writer.HtmlWriter;
 
-import java.io.Writer;
-import java.io.IOException;
 import java.util.List;
 
-/**
- * User: kevink
- * Date: Sep 19, 2009
- */
+import static org.labkey.api.util.DOM.DIV;
+import static org.labkey.api.util.DOM.SCRIPT;
+import static org.labkey.api.util.DOM.id;
+
 public class MultiValueInputColumn extends DataColumn
 {
-    private List<String> _values;
+    private final List<String> _values;
 
     public MultiValueInputColumn(ColumnInfo col, List<String> values)
     {
@@ -42,34 +40,36 @@ public class MultiValueInputColumn extends DataColumn
     }
 
     @Override
-    public void renderInputHtml(RenderContext ctx, Writer oldWriter, HtmlWriter out, Object value) throws IOException
+    public void renderInputHtml(RenderContext ctx, HtmlWriter out, Object value)
     {
-        String id = ctx.getForm().getFormFieldName(getColumnInfo());
+        String colId = ctx.getForm().getFormFieldName(getColumnInfo());
 
-        oldWriter.write("<div id=\"" + PageFlowUtil.filter(id) + "\" class=\"extContainer\"></div>");
-        oldWriter.write("<script text=\"text/javascript\" nonce=\"" + HttpView.currentPageConfig().getScriptNonce() + "\">\n");
-        oldWriter.write("LABKEY.requiresScript('viability/MultiValueInput', function(){\n");
-        oldWriter.write("new MultiValueInput('");
-        oldWriter.write(PageFlowUtil.filter(id));
-        oldWriter.write("'");
+        DIV(
+            id(colId).cl("extContainer")
+        ).appendTo(out);
+
+        StringBuilder script = new StringBuilder("LABKEY.requiresScript('viability/MultiValueInput', function(){");
+        script.append("new MultiValueInput(");
+        script.append(PageFlowUtil.jsString(colId));
 
         // XXX: hack. ignore the value in the render context. take the value as passed in during view creation.
         if (_values != null && !_values.isEmpty())
         {
-            oldWriter.write(", [");
+            script.append(", [");
             for (int i = 0; i < _values.size(); i++)
             {
-                oldWriter.write("'");
-                oldWriter.write(PageFlowUtil.filter(_values.get(i)));
-                oldWriter.write("'");
+                script.append(PageFlowUtil.jsString(_values.get(i)));
                 if (i < _values.size() - 1)
-                    oldWriter.write(", ");
+                    script.append(", ");
             }
-            oldWriter.write("]");
+            script.append("]");
         }
 
-        oldWriter.write(");\n});\n");
-        oldWriter.write("</script>\n");
+        script.append(");\n});\n");
+
+        SCRIPT(
+            JavaScriptFragment.unsafe(script.toString())
+        ).appendTo(out);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Migrate remaining `renderInputHtml()` overrides to use HtmlWriter, DOM, and builders. Eliminate the deprecated renderInputHtml() variant.

Also migrate some code paths using `HtmlWriter.unwrap()`.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6467