### PR TITLE
Issue 52614: AssertionError deleting site group from its details page

### DIFF
--- a/flow/src/org/labkey/flow/persist/FlowKeywordAuditProvider.java
+++ b/flow/src/org/labkey/flow/persist/FlowKeywordAuditProvider.java
@@ -20,6 +20,7 @@ import org.labkey.api.audit.AuditTypeEvent;
 import org.labkey.api.audit.AuditTypeProvider;
 import org.labkey.api.audit.query.AbstractAuditDomainKind;
 import org.labkey.api.audit.query.DefaultAuditTypeTable;
+import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.PropertyDescriptor;
@@ -133,7 +134,7 @@ public class FlowKeywordAuditProvider extends AbstractAuditTypeProvider implemen
             super();
         }
 
-        public FlowKeywordAuditEvent(String container, String comment)
+        public FlowKeywordAuditEvent(Container container, String comment)
         {
             super(EVENT_TYPE, container, comment);
         }

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -1232,7 +1232,7 @@ public class FlowManager
     private void addKeywordAuditEvent(Container c, User user, String keyword, String newValue, String oldValue, String fileName, String lsid)
     {
 
-        FlowKeywordAuditProvider.FlowKeywordAuditEvent event =  new FlowKeywordAuditProvider.FlowKeywordAuditEvent(c.getId(),"keyword");
+        FlowKeywordAuditProvider.FlowKeywordAuditEvent event =  new FlowKeywordAuditProvider.FlowKeywordAuditEvent(c,"keyword");
         event.setKeywordName(keyword);
         event.setOldValue(oldValue);
         event.setNewValue(newValue);


### PR DESCRIPTION
#### Rationale
Improve API for audit log events.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6469

#### Changes
* Use Container instead of String in event constructors
* Include User when making changes to groups so changes can be properly logged