### PR TITLE
Eliminate sketchy htmlHelpText boolean in favor of HtmlString

### DIFF
--- a/ms2/src/org/labkey/ms2/compare/comparePeptideQueryOptions.jsp
+++ b/ms2/src/org/labkey/ms2/compare/comparePeptideQueryOptions.jsp
@@ -16,22 +16,23 @@
  */
 %>
 <%@ page import="org.labkey.api.protein.search.ProphetFilterType" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.ms2.MS2Controller" %>
 <%@ page import="org.labkey.ms2.MS2Controller.PeptideFilteringFormElements" %>
+<%@ page import="org.labkey.ms2.query.FilterView" %>
 <%@ page import="static org.labkey.api.protein.search.ProphetFilterType.customView" %>
 <%@ page import="static org.labkey.api.protein.search.ProphetFilterType.probability" %>
 <%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.peptideFilterType" %>
 <%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.peptideProphetProbability" %>
 <%@ page import="static org.labkey.ms2.MS2Controller.PeptideFilteringFormElements.targetProtein" %>
-<%@ page import="org.labkey.ms2.query.FilterView" %>
 <%@ page extends="org.labkey.api.jsp.JspBase"%>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
-JspView<MS2Controller.CompareOptionsBean> view = (JspView<MS2Controller.CompareOptionsBean>) HttpView.currentView();
+JspView<MS2Controller.CompareOptionsBean> view = HttpView.currentView();
 MS2Controller.CompareOptionsBean bean = view.getModelBean();
 MS2Controller.PeptideFilteringComparisonForm form = bean.getForm();
 String peptideViewName = form.getPeptideCustomViewName(getViewContext());
@@ -57,7 +58,7 @@ String peptideViewName = form.getPeptideCustomViewName(getViewContext());
     <hr/>
     <p>
         Optionally require that peptides have a sequence match in protein: <input type="text" size="30" name="<%= targetProtein %>" value="<%= h(form.getTargetProtein()==null ? "" : form.getTargetProtein()) %>" />
-        <%=helpPopup("Protein Filter", "<p>Show only peptides whose sequences match against a specified protein. It need not be the protein mapped to the peptide by the search engine or ProteinProphet.</p><p>If no protein matches the name specified, or if multiple proteins match, this page will be redisplayed to correct the search.</p>", true)%>
+        <%=helpPopup("Protein Filter", HtmlString.unsafe("<p>Show only peptides whose sequences match against a specified protein. It need not be the protein mapped to the peptide by the search engine or ProteinProphet.</p><p>If no protein matches the name specified, or if multiple proteins match, this page will be redisplayed to correct the search.</p>"))%>
     </p>
 
     <p><labkey:button text="Compare"/></p>

--- a/ms2/src/org/labkey/ms2/compare/spectraCountOptions.jsp
+++ b/ms2/src/org/labkey/ms2/compare/spectraCountOptions.jsp
@@ -115,7 +115,7 @@
     </div>
         <p>
         Optionally require that peptides have a sequence match in protein: <input type="text" size="30" name="<%= targetProtein %>" value="<%= h(form.getTargetProtein()==null ? "" : form.getTargetProtein()) %>" />
-        <%=helpPopup("Protein Filter", "<p>Show only peptides whose sequences match against a specified protein. It need not be the protein mapped to the peptide by the search engine or ProteinProphet.</p><p>If no protein matches the name specified, or if multiple proteins match, this page will be redisplayed to correct the search.</p>", true)%>
+        <%=helpPopup("Protein Filter", HtmlString.unsafe("<p>Show only peptides whose sequences match against a specified protein. It need not be the protein mapped to the peptide by the search engine or ProteinProphet.</p><p>If no protein matches the name specified, or if multiple proteins match, this page will be redisplayed to correct the search.</p>"))%>
     </p>
     <p><labkey:button text="Compare"/></p>
 </labkey:form>

--- a/ms2/src/org/labkey/ms2/protein.jsp
+++ b/ms2/src/org/labkey/ms2/protein.jsp
@@ -23,6 +23,7 @@
 <%@ page import="org.labkey.ms2.PeptideManager" %>
 <%@ page import="org.labkey.ms2.protein.ProteinViewBean" %>
 <%@ page import="java.text.Format" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
@@ -46,7 +47,7 @@
         ActionURL urlProteinDetailsPage = getViewContext().cloneActionURL();
         urlProteinDetailsPage.deleteParameter(ProteinViewBean.ALL_PEPTIDES_URL_PARAM); %>
         <tr>
-            <td class="labkey-form-label">Peptides<%=helpPopup("Peptides", "<p><strong>Show only peptides assigned by search engine</strong><br/>The page displays only the set of peptides that the search engine has chosen as matching the subject protein, based on engine-specific scoring.</p><p><strong>Show all peptides with sequence matches</strong><br/>The coverage map and peptide grid show all the filtered trimmed peptides from the run that match a sequence within the subject protein, regardless of whether the protein was chosen by the search engine as matching that specific peptide.</p>", true)%></td>
+            <td class="labkey-form-label">Peptides<%=helpPopup("Peptides", HtmlString.unsafe("<p><strong>Show only peptides assigned by search engine</strong><br/>The page displays only the set of peptides that the search engine has chosen as matching the subject protein, based on engine-specific scoring.</p><p><strong>Show all peptides with sequence matches</strong><br/>The coverage map and peptide grid show all the filtered trimmed peptides from the run that match a sequence within the subject protein, regardless of whether the protein was chosen by the search engine as matching that specific peptide.</p>"))%></td>
             <td>
                 <labkey:form action="<%= urlProteinDetailsPage %>" method="GET">
                     <% for (Pair<String, String> param : urlProteinDetailsPage.getParameters()) { %>


### PR DESCRIPTION
#### Rationale
HtmlString is our preferred approach for denoting HTML-containing strings

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6478