### PR TITLE
Try to avoid intermittent LuminexTest query timeouts by forcing db stats update

### DIFF
--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexUploadAndLinkTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexUploadAndLinkTest.java
@@ -240,6 +240,14 @@ public final class LuminexUploadAndLinkTest extends LuminexTest
         clickButton("Next", 60000);
         clickButton("Save and Finish");
 
+        // try forcing an immediate stats update to prompt a better query plan selection - hopefully avoids test timeouts
+        startSystemMaintenance("Database");
+        waitForSystemMaintenanceCompletion();
+
+        // return to the assay runs page
+        goToProjectHome(TEST_ASSAY_PRJ_LUMINEX);
+        clickAndWait(Locator.linkWithText(TEST_ASSAY_LUM));
+
         clickAndWait(Locator.linkWithText("raw and summary"), longWaitForPage);
         // make sure the Summary, StdDev, and DV columns are visible
         _customizeViewsHelper.openCustomizeViewPanel();


### PR DESCRIPTION
#### Rationale
Recently, [LuminexUploadAndLinkTest.testUploadAndLink](https://teamcity.labkey.org/viewLog.html?buildId=3478858&buildTypeId=LabKey_253Release_Community_DailySqlServer&fromSakuraUI=true#testNameId-5450029526957051702) has been failing intermittently (mostly on SQL) in ways that look like the query took just a moment longer than the 30-second timeout for it.  (that is, the after-failure screenshot shows the test in the expected state).  

The theory of this change is that SQL isn't choosing an appropriate query plan for this longer-running query; the change itself forces a stats update in hopes of poking it into choosing a better query plan

#### Related Pull Requests
n/a

#### Changes
update stats and then return to the page it was on
