### PR TITLE
Consolidate to preferred getExcelWriter override

### DIFF
--- a/ms2/src/org/labkey/ms2/compare/SpectraCountQueryView.java
+++ b/ms2/src/org/labkey/ms2/compare/SpectraCountQueryView.java
@@ -36,6 +36,7 @@ import org.labkey.ms2.query.SpectraCountConfiguration;
 import org.springframework.validation.BindException;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * User: jeckels
@@ -70,9 +71,9 @@ public class SpectraCountQueryView extends QueryView
     }
 
     @Override
-    public ExcelWriter getExcelWriter(ExcelWriter.ExcelDocumentType docType) throws IOException
+    public ExcelWriter getExcelWriter(ExcelWriter.ExcelDocumentType docType, @Nullable Map<String, String> renameColumnMap) throws IOException
     {
-        ExcelWriter result = super.getExcelWriter(docType);
+        ExcelWriter result = super.getExcelWriter(docType, renameColumnMap);
         String header = getExportHeader();
         if (header != null)
         {


### PR DESCRIPTION
#### Rationale
Overloaded methods require the right override to get consistent behavior

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6627

#### Changes
* Switch to the preferred `getExcelWriter()` variant for subclasses to customize behavior