### PR TITLE
don't throw error for empty histogram

### DIFF
--- a/flow/enginesrc/org/labkey/flow/analysis/chart/PlotFactory.java
+++ b/flow/enginesrc/org/labkey/flow/analysis/chart/PlotFactory.java
@@ -280,7 +280,7 @@ public class PlotFactory
         ValueAxis xAxis = getValueAxis(getLabel(subset, axis), fn);
 
         ValueAxis yAxis = new NumberAxis("Count");
-        double yMax = 0;
+        double yMax = 10;
         for (int i = 1; i < dataset.getItemCount(0) - 1; i ++)
         {
             yMax = Math.max(dataset.getY(0, i), yMax);


### PR DESCRIPTION
#### Rationale
range [0.0,0.0] is not allowed

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
