### PR TITLE
POST a multipart form only when the page may upload a file

### DIFF
--- a/flow/src/org/labkey/flow/controllers/executescript/importAnalysis.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/importAnalysis.jsp
@@ -44,6 +44,10 @@
     ImportAnalysisForm form = (ImportAnalysisForm)getModelBean();
     Container container = getContainer();
     ActionURL cancelUrl = urlProvider(ProjectUrls.class).getStartURL(container);
+    // we are only posting files for the first step of the wizard
+    String enctype = form.getStep() > AnalysisScriptController.ImportAnalysisStep.SELECT_ANALYSIS.getNumber()
+            ? "application/x-www-form-urlencoded"
+            : "multipart/form-data";
 %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
     function endsWith(a,b)
@@ -85,7 +89,7 @@
 
 <labkey:errors/>
 
-<labkey:form name="<%=ImportAnalysisForm.NAME%>" action="<%=new ActionURL(AnalysisScriptController.ImportAnalysisAction.class, container)%>" method="POST" enctype="multipart/form-data">
+<labkey:form name="<%=ImportAnalysisForm.NAME%>" action="<%=new ActionURL(AnalysisScriptController.ImportAnalysisAction.class, container)%>" method="POST" enctype="<%=enctype%>">
     <input type="hidden" name="step" value="<%=form.getStep()%>">
     <%
         for (Map.Entry<String, String> entry : form.getWorkspace().getHiddenFields(getViewContext()).entrySet())


### PR DESCRIPTION
#### Rationale
This fixes some failures caused by the limits on multipart form elements caused by the recent upgrade to Tomcat `10.1.42`. 

The action which implemented the wizard for importing a FlowJo workspace only needed to post files for one of the steps. This change conditionalizes the form encoding based on the current wizard step.

#### Related Pull Requests
https://github.com/LabKey/server/pull/1104
