### PR TITLE
Fix data region column name references

### DIFF
--- a/ms2/test/src/org/labkey/test/tests/ms2/LibraTest.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/LibraTest.java
@@ -142,7 +142,7 @@ public class LibraTest extends MS2TestBase
         clickAndWait(Locator.linkWithText("Spectra Count Options"));
         click(Locator.linkWithText("Create or Edit View"));
         findButton("Save");
-        _customizeViewsHelper.addFilter("Hyper", "Hyper", "Is Greater Than", "250");
+        _customizeViewsHelper.addFilter("Hyper", "Is Greater Than", "250");
         assertRadioButtonSelected(Locator.radioButtonByNameAndValue("spectraConfig", "SpectraCountPeptide"));
         _customizeViewsHelper.saveCustomView("HyperFilter");
         click(Locator.radioButtonById("SpectraCountPeptideCharge"));
@@ -219,7 +219,7 @@ public class LibraTest extends MS2TestBase
     {
         for (int i = 1; i <= normalizationCount; i++)
         {
-            customizeView.addColumn("iTRAQQuantitation/Normalized" + i, "Normalized " + i);
+            customizeView.addColumn("iTRAQQuantitation/Normalized" + i);
         }
     }
 
@@ -231,7 +231,7 @@ public class LibraTest extends MS2TestBase
 
         for (int i = 1; i <= normalizationCount; i++)
         {
-            customizeView.addColumn("ProteinProphetData/ProteinGroupId/iTRAQQuantitation/Ratio" + i, "Ratio " + i);
+            customizeView.addColumn("ProteinProphetData/ProteinGroupId/iTRAQQuantitation/Ratio" + i);
         }
         addNormalizationCount(customizeView);
         customizeView.saveCustomView(proteinProphetView);

--- a/ms2/test/src/org/labkey/test/tests/ms2/LibraTest.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/LibraTest.java
@@ -26,6 +26,7 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.MS2;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.ms2.MS2TestBase;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.TextSearcher;
@@ -127,9 +128,9 @@ public class LibraTest extends MS2TestBase
         // Customize view to pull in other columns
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.addColumn("TrimmedPeptide");
-        _customizeViewsHelper.addColumn(new String[] {"Protein", "ProtSequence"});
-        _customizeViewsHelper.addColumn(new String[] {"Protein", "BestName"});
-        _customizeViewsHelper.addColumn(new String[] {"Protein", "Mass"});
+        _customizeViewsHelper.addColumn(FieldKey.fromParts("Protein", "ProtSequence"));
+        _customizeViewsHelper.addColumn(FieldKey.fromParts("Protein", "BestName"));
+        _customizeViewsHelper.addColumn(FieldKey.fromParts("Protein", "Mass"));
         _customizeViewsHelper.saveDefaultView();
         assertTextPresent("84731", "MPEETQAQDQPMEEEEVETFAFQAEIAQLM");
 

--- a/ms2/test/src/org/labkey/test/tests/ms2/MS2Test.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/MS2Test.java
@@ -24,10 +24,10 @@ import org.labkey.test.SortDirection;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.MS2;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.util.AbstractDataRegionExportOrSignHelper.ColumnHeaderType;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.TextSearcher;
 import org.openqa.selenium.WebElement;
@@ -397,21 +397,22 @@ public class MS2Test extends AbstractMS2ImportTest
         log("Check that saved view is working");
         assertTextNotPresent("K.KTEENYTLVFIVDVK.A");
 
+        DataRegionTable innerTable = DataRegionTable.DataRegion(getDriver()).withName(REGION_NAME_PEPTIDES).find(peptidesTable);
         log("Test adding a sort and a filter");
-        peptidesTable.setFilter("Hyper", "Is Greater Than", "10.6");
+        innerTable.setFilter("Hyper", "Is Greater Than", "10.6");
         assertTextNotPresent("K.RFSGTVKLK.Y");
-        peptidesTable.setSort("Next", SortDirection.ASC);
+        innerTable.setSort("Next", SortDirection.ASC);
         // Explicitly clear out the sorts, since we want to be just dealing with the ones set in Customize View
-        peptidesTable.clearSort("Next");
-        peptidesTable.clearSort("Scan");
+        innerTable.clearSort("Next");
+        innerTable.clearSort("Scan");
 
         log("Test customize view");
         peptidesTable.clearAllFilters();
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addSort("Charge", "Z", SortDirection.DESC);
-        _customizeViewsHelper.addSort("Mass", "CalcMH+", SortDirection.DESC);
-        _customizeViewsHelper.addFilter("DeltaMass", "dMass", "Is Less Than", "0");
-        _customizeViewsHelper.addColumn("NextAA", "Next AA");
+        _customizeViewsHelper.addSort("Charge", SortDirection.DESC);
+        _customizeViewsHelper.addSort("Mass", SortDirection.DESC);
+        _customizeViewsHelper.addFilter("DeltaMass", "Is Less Than", "0");
+        _customizeViewsHelper.addColumn("NextAA");
         _customizeViewsHelper.removeColumn("Expect");
         _customizeViewsHelper.removeColumn("ProteinHits");
         _customizeViewsHelper.saveCustomView(VIEW4);
@@ -515,8 +516,8 @@ public class MS2Test extends AbstractMS2ImportTest
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.clearFilters();
         _customizeViewsHelper.clearSorts();
-        _customizeViewsHelper.addSort("DeltaMass", "dMass", SortDirection.ASC);
-        _customizeViewsHelper.addFilter("Mass", "CalcMH+", "Is Greater Than", "1000");
+        _customizeViewsHelper.addSort("DeltaMass", SortDirection.ASC);
+        _customizeViewsHelper.addFilter("Mass", "Is Greater Than", "1000");
         _customizeViewsHelper.addColumn("Fraction");
         _customizeViewsHelper.removeColumn("IonPercent");
         _customizeViewsHelper.saveDefaultView();
@@ -551,14 +552,14 @@ public class MS2Test extends AbstractMS2ImportTest
 
         log("Test Protein Prophet view in Query - Peptides grouping");
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn("ProteinProphetData/ProteinGroupId/Group", "Group");
-        _customizeViewsHelper.addColumn("ProteinProphetData/ProteinGroupId/TotalNumberPeptides", "Peptides");
-        _customizeViewsHelper.addColumn("ProteinProphetData/ProteinGroupId/GroupProbability", "Prob");
-        _customizeViewsHelper.addColumn("ProteinProphetData/ProteinGroupId/BestName", "Best Name");
+        _customizeViewsHelper.addColumn("ProteinProphetData/ProteinGroupId/Group");
+        _customizeViewsHelper.addColumn("ProteinProphetData/ProteinGroupId/TotalNumberPeptides");
+        _customizeViewsHelper.addColumn("ProteinProphetData/ProteinGroupId/GroupProbability");
+        _customizeViewsHelper.addColumn("ProteinProphetData/ProteinGroupId/BestName");
         _customizeViewsHelper.removeColumn("Mass");
-        _customizeViewsHelper.addFilter("DeltaMass", "dMass", "Is Greater Than", "0");
-        _customizeViewsHelper.addFilter("ProteinProphetData/ProteinGroupId/GroupProbability", "Prob", "Is Greater Than", "0.7");
-        _customizeViewsHelper.addSort("ProteinProphetData/ProteinGroupId/GroupProbability", "Prob", SortDirection.ASC);
+        _customizeViewsHelper.addFilter("DeltaMass", "Is Greater Than", "0");
+        _customizeViewsHelper.addFilter("ProteinProphetData/ProteinGroupId/GroupProbability", "Is Greater Than", "0.7");
+        _customizeViewsHelper.addSort("ProteinProphetData/ProteinGroupId/GroupProbability", SortDirection.ASC);
         _customizeViewsHelper.saveCustomView(VIEW4);
 
         log("Test that Protein Prophet view is displayed and that it sorts and filters correctly");
@@ -621,9 +622,9 @@ public class MS2Test extends AbstractMS2ImportTest
         log("Test customize view");
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.removeColumn("UniquePeptidesCount");
-        _customizeViewsHelper.addColumn("Proteins/Protein/ProtSequence", "Protein Sequence");
-        _customizeViewsHelper.addFilter("GroupProbability", "Prob", "Is Greater Than", "0.7");
-        _customizeViewsHelper.addSort("ErrorRate", "Error", SortDirection.DESC);
+        _customizeViewsHelper.addColumn("Proteins/Protein/ProtSequence");
+        _customizeViewsHelper.addFilter("GroupProbability", "Is Greater Than", "0.7");
+        _customizeViewsHelper.addSort("ErrorRate", SortDirection.DESC);
         _customizeViewsHelper.saveCustomView(VIEW4);
 
         log("Test that sorting, filtering, and columns are correct");
@@ -833,13 +834,14 @@ public class MS2Test extends AbstractMS2ImportTest
         setFormElement(Locator.name("name"), RUN_GROUP1_NAME2);
         clickButton("Submit");
 
+        FieldKey runGroupFK = FieldKey.fromParts("RunGroupToggle");
         log("Test customizing view to include the run groups");
         navigateToFolder(FOLDER_NAME);
         clickAndWait(Locator.linkWithText("MS2 Runs"));
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn(new String[] { "RunGroupToggle", EscapeUtil.fieldKeyEncodePart(RUN_GROUP1_NAME2) }, RUN_GROUP1_NAME2);
-        _customizeViewsHelper.addColumn(new String[]{"RunGroupToggle", RUN_GROUP2_NAME}, "Run Groups " + RUN_GROUP2_NAME);
-        _customizeViewsHelper.addColumn(new String[]{"RunGroupToggle", "Default Experiment"}, "Run Groups Default Experiment");
+        _customizeViewsHelper.addColumn(runGroupFK.child(RUN_GROUP1_NAME2));
+        _customizeViewsHelper.addColumn(runGroupFK.child(RUN_GROUP2_NAME));
+        _customizeViewsHelper.addColumn(runGroupFK.child("Default Experiment"));
         _customizeViewsHelper.applyCustomView();
 
         assertTextPresent(new TextSearcher(this).setSearchTransformer(TextSearcher.TextTransformers.FIELD_LABEL),
@@ -876,8 +878,8 @@ public class MS2Test extends AbstractMS2ImportTest
 
         log("Test Customize View");
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn("SeqId/Mass", "Protein Mass");
-        _customizeViewsHelper.addFilter("SeqId/Mass", "Protein Mass", "Is Less Than", "30000");
+        _customizeViewsHelper.addColumn("SeqId/Mass");
+        _customizeViewsHelper.addFilter("SeqId/Mass", "Is Less Than", "30000");
         _customizeViewsHelper.saveCustomView(VIEW5);
 
         DataRegionTable peptidesTable = new DataRegionTable("query", this);
@@ -1110,7 +1112,7 @@ public class MS2Test extends AbstractMS2ImportTest
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.addColumn("CTAGG_AVG_XCorr");
         _customizeViewsHelper.removeColumn("InstanceCount");
-        _customizeViewsHelper.addFilter("CTAGG_AVG_XCorr", "Avg XCorr", "Is Greater Than", "10");
+        _customizeViewsHelper.addFilter("CTAGG_AVG_XCorr", "Is Greater Than", "10");
         _customizeViewsHelper.saveCustomView();
 
         log("Check filtering and columns were added correctly");

--- a/ms2/test/src/org/labkey/test/tests/ms2/MS2Test.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/MS2Test.java
@@ -1248,17 +1248,18 @@ public class MS2Test extends AbstractMS2ImportTest
         DataRegionTable dataTable = viewQueryData("ms2", "XTandemPeptides");
         dataTable.setContainerFilter(DataRegionTable.ContainerFilterType.CURRENT_AND_SUBFOLDERS);
 
+        FieldKey runGroupsFk = FieldKey.fromParts("Fraction", "Run", "ExperimentRunLSID", "RunGroups");
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn(FieldKey.fromParts("Fraction", "Run", "ExperimentRunLSID", "RunGroups"));
+        _customizeViewsHelper.addColumn(runGroupsFk);
         _customizeViewsHelper.applyCustomView();
         assertNotEquals("All rows should have a value for the run group", 0, dataTable.getDataRowCount());
 
         // validate a single run group with the expected label
-        Set<String> runGroups = new HashSet<>(dataTable.getColumnDataAsText("RunGroups"));
+        Set<String> runGroups = new HashSet<>(dataTable.getColumnDataAsText(runGroupsFk));
         assertEquals("Incorrect number of run groups", 1, runGroups.size());
         assertEquals("Invalid run group label", RUN_GROUP3_NAME, runGroups.iterator().next());
 
-        dataTable.setFilter("Fraction/Run/ExperimentRunLSID/RunGroups", "Is Blank");
+        dataTable.setFilter(runGroupsFk, "Is Blank");
         assertEquals("All rows should have a value for the run group", 0, dataTable.getDataRowCount());
     }
 }

--- a/ms2/test/src/org/labkey/test/tests/ms2/MS2Test.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/MS2Test.java
@@ -1249,7 +1249,7 @@ public class MS2Test extends AbstractMS2ImportTest
         dataTable.setContainerFilter(DataRegionTable.ContainerFilterType.CURRENT_AND_SUBFOLDERS);
 
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn(new String[]{"Fraction", "Run", "ExperimentRunLSID", "RunGroups"});
+        _customizeViewsHelper.addColumn(FieldKey.fromParts("Fraction", "Run", "ExperimentRunLSID", "RunGroups"));
         _customizeViewsHelper.applyCustomView();
         assertNotEquals("All rows should have a value for the run group", 0, dataTable.getDataRowCount());
 

--- a/ms2/test/src/org/labkey/test/tests/ms2/SequestImportTest.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/SequestImportTest.java
@@ -24,6 +24,7 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.MS2;
 import org.labkey.test.components.CustomizeView;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.FileBrowserHelper;
 import org.labkey.test.util.LogMethod;
@@ -38,8 +39,8 @@ public class SequestImportTest extends BaseWebDriverTest
 {
     private static final String PROJECT_NAME = "SequestImport" + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
 
-    private static final String[] TOTAL_PEPTIDES_FIELD_KEY = {"PeptideCounts", "TotalPeptides"};
-    private static final String[] UNIQUE_PEPTIDES_FIELD_KEY = {"PeptideCounts", "DistinctPeptides"};
+    private static final FieldKey TOTAL_PEPTIDES_FIELD_KEY = FieldKey.fromParts("PeptideCounts", "TotalPeptides");
+    private static final FieldKey UNIQUE_PEPTIDES_FIELD_KEY = FieldKey.fromParts("PeptideCounts", "DistinctPeptides");
 
     @Override
     protected String getProjectName()

--- a/ms2/test/src/org/labkey/test/tests/ms2/SequestImportTest.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/SequestImportTest.java
@@ -69,8 +69,8 @@ public class SequestImportTest extends BaseWebDriverTest
         viewsHelper.addColumn(UNIQUE_PEPTIDES_FIELD_KEY);
 
         // Add a filter so that we can check the values were calculated and shown correctly
-        viewsHelper.addFilter(TOTAL_PEPTIDES_FIELD_KEY, "Total Peptides", "Equals", "2");
-        viewsHelper.addFilter(UNIQUE_PEPTIDES_FIELD_KEY, "Distinct Peptides", "Equals", "1");
+        viewsHelper.addFilter(TOTAL_PEPTIDES_FIELD_KEY, "Equals", "2");
+        viewsHelper.addFilter(UNIQUE_PEPTIDES_FIELD_KEY, "Equals", "1");
         viewsHelper.saveDefaultView();
 
         // Make sure that our run is still showing


### PR DESCRIPTION
#### Rationale
My previous DataRegionTable refactor attempted to recreate the previous behavior that would remove spaces when matching field labels. I covered the case where the test passed in an unnecessary space but not when they omitted a space. Rather that duplicating that particular behavior, this updates the handful of tests that are passing incorrect field labels.

I've also updated the `CustomizeView` helper to accept `FieldKey` objects instead of String arrays.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2526

#### Changes
- Remove unnecessary logging parameters from the CustomizeView helper
- Update CustomizeViewHelper to use FieldKey
- Fix problematic data region column name references