### PR TITLE
Fix flow NPE: No need to use the ExpData to look itself up

### DIFF
--- a/flow/src/org/labkey/flow/persist/AttributeSetHelper.java
+++ b/flow/src/org/labkey/flow/persist/AttributeSetHelper.java
@@ -153,7 +153,7 @@ public class AttributeSetHelper
                 List<List<?>> paramsList = new ArrayList<>();
                 for (Map.Entry<String, String> entry : keywords.entrySet())
                 {
-                    AttributeCache.Entry a = AttributeCache.KEYWORDS.byAttribute(c, entry.getKey());
+                    AttributeCache.Entry<?, ?> a = AttributeCache.KEYWORDS.byAttribute(c, entry.getKey());
                     assert a != null : "parepareForSave should have created an entry";
                     int preferredId = a.getAliasedId() == null ? a.getRowId() : a.getAliasedId();
                     int originalId = a.getRowId();
@@ -174,7 +174,7 @@ public class AttributeSetHelper
                 List<List<?>> paramsList = new ArrayList<>();
                 for (Map.Entry<StatisticSpec, Double> entry : statistics.entrySet())
                 {
-                    AttributeCache.Entry a = AttributeCache.STATS.byAttribute(c, entry.getKey());
+                    AttributeCache.Entry<?, ?> a = AttributeCache.STATS.byAttribute(c, entry.getKey());
                     assert a != null : "parepareForSave should have created an entry";
                     int preferredId = a.getAliasedId() == null ? a.getRowId() : a.getAliasedId();
                     int originalId = a.getRowId();
@@ -213,7 +213,7 @@ public class AttributeSetHelper
                 List<List<?>> paramsList = new ArrayList<>();
                 for (Map.Entry<GraphSpec, byte[]> entry : graphs.entrySet())
                 {
-                    AttributeCache.Entry a = AttributeCache.GRAPHS.byAttribute(c, entry.getKey());
+                    AttributeCache.Entry<?, ?> a = AttributeCache.GRAPHS.byAttribute(c, entry.getKey());
                     assert a != null : "parepareForSave should have created an entry";
                     int preferredId = a.getAliasedId() == null ? a.getRowId() : a.getAliasedId();
                     int originalId = a.getRowId();

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -1029,9 +1029,9 @@ public class FlowManager
     }
 
     
-    public AttrObject createAttrObject(ExpData data, ObjectType type, URI uri)
+    public AttrObject createAttrObject(@NotNull ExpData data, ObjectType type, URI uri)
     {
-        if (FlowDataHandler.instance.getPriority(ExperimentService.get().getExpData(data.getRowId())) != Handler.Priority.HIGH)
+        if (FlowDataHandler.instance.getPriority(data) != Handler.Priority.HIGH)
         {
             // Need to make sure the right ExperimentDataHandler is associated with this data file, otherwise, you
             // won't be able to delete it because of the foreign key constraint from the flow.object table.


### PR DESCRIPTION
#### Rationale
NPE during the crawler:

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyCSqlserver2014/3595782?buildTab=tests&status=failed&name=flow.FlowAnalysisResolverTest&expandedTest=build%3A%28id%3A3595782%29%2Cid%3A2000000139&logFilter=debug&logView=flowAware

#### Changes
* Use the `ExpData` we already have instead of looking up another one (may get a constraint violation when inserting, but at least a small optimization)
* Improve generics slightly