### PR TITLE
Update SignalDataRawTest to provide the correct file path for assay data

### DIFF
--- a/signalData/resources/views/mockSignalDataWatch.html
+++ b/signalData/resources/views/mockSignalDataWatch.html
@@ -6,6 +6,7 @@
     (function() {
 
         var RUN_FOLDER = "TestRun001";
+        var SIGNAL_DATA_FILE_ROOT = "SignalDataAssayData/" + RUN_FOLDER + "/";
 
         function getEl(selector) {
             return Ext4.get(Ext4.DomQuery.select(selector)[0]);
@@ -66,7 +67,7 @@
             Ext4.each(fileSet, function(file) {
                 dataRows.push({
                     Name: file.text,
-                    DataFile: file.text,
+                    DataFile: SIGNAL_DATA_FILE_ROOT + file.text,
                     TestType: 'SMP'
                 });
                 dataInputs.push({


### PR DESCRIPTION
#### Rationale
With the recent change, a file path for file field must already exist at import time. The file path can either be relative to the container's file/pipleine root, or it needs to be absolute webdav url or file path.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1833
- https://github.com/LabKey/platform/pull/6847
- https://github.com/LabKey/limsModules/pull/1524
- https://github.com/LabKey/testAutomation/pull/2582
- https://github.com/LabKey/commonAssays/pull/910

#### Changes
* Change mockSignalDataWatch saveBatch to provide correct relative file path for data files.
