### PR TITLE
Support BIGINT Primary Keys

### DIFF
--- a/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
+++ b/elisa/src/org/labkey/elisa/ElisaAssayProvider.java
@@ -434,7 +434,7 @@ public class ElisaAssayProvider extends AbstractPlateBasedAssayProvider
     protected void moveAssayResults(List<ExpRun> runs, ExpProtocol protocol, Container sourceContainer, Container targetContainer, User user, AssayMoveData assayMoveData) throws ExperimentException
     {
         super.moveAssayResults(runs, protocol, sourceContainer, targetContainer, user, assayMoveData); // assay results
-        List<Integer> runRowIds = runs.stream().map(ExpRun::getRowId).toList();
+        List<Long> runRowIds = runs.stream().map(ExpRun::getRowId).toList();
 
         // move specimen
         String tableName = AssayProtocolSchema.DATA_TABLE_NAME;

--- a/elisa/src/org/labkey/elisa/ElisaController.java
+++ b/elisa/src/org/labkey/elisa/ElisaController.java
@@ -55,17 +55,17 @@ public class ElisaController extends SpringActionController
 
     public static class RunDetailsForm
     {
-        private int _protocolId;
-        private int _runId;
+        private long _protocolId;
+        private long _runId;
         private String _runName;
         private String _schemaName;
 
-        public int getRunId()
+        public long getRunId()
         {
             return _runId;
         }
 
-        public void setRunId(int runId)
+        public void setRunId(long runId)
         {
             _runId = runId;
         }
@@ -90,12 +90,12 @@ public class ElisaController extends SpringActionController
             _schemaName = schemaName;
         }
 
-        public int getProtocolId()
+        public long getProtocolId()
         {
             return _protocolId;
         }
 
-        public void setProtocolId(int protocolId)
+        public void setProtocolId(long protocolId)
         {
             _protocolId = protocolId;
         }

--- a/elisa/src/org/labkey/elisa/ElisaDataHandler.java
+++ b/elisa/src/org/labkey/elisa/ElisaDataHandler.java
@@ -431,7 +431,7 @@ public class ElisaDataHandler extends AbstractAssayTsvDataHandler implements Tra
         {
             super.beforeDeleteData(datas, user);
 
-            Set<Integer> runIds = new HashSet<>();
+            Set<Long> runIds = new HashSet<>();
             for (ExpData data : datas)
             {
                 if (null != data.getRunId())

--- a/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
+++ b/elisa/src/org/labkey/elisa/HighThroughputImportHelper.java
@@ -10,6 +10,7 @@ import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.PositionImpl;
 import org.labkey.api.assay.plate.Well;
 import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.statistics.CurveFit;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpMaterial;
@@ -139,7 +140,7 @@ public class HighThroughputImportHelper extends AbstractElisaImportHelper
     @Override
     public Map<Integer, Plate> getAnalyteToPlate(String plateName) throws ExperimentException
     {
-        Map<Integer, Plate> analyteToPlate = new HashMap<>();
+        Map<Integer, Plate> analyteToPlate = new IntHashMap<>();
         for (Map.Entry<Integer, double[][]> entry : _plateMap.get(plateName).getDataMap().entrySet())
         {
             Plate plate = PlateService.get().createPlate(_plateTemplate, entry.getValue(), null);
@@ -171,8 +172,8 @@ public class HighThroughputImportHelper extends AbstractElisaImportHelper
 
     private static class AnalytePlate
     {
-        private final Map<Integer, Map<String, Double>> _stdConcentrations = new HashMap<>();
-        private final Map<Integer, double[][]> _dataMap = new HashMap<>();
+        private final Map<Integer, Map<String, Double>> _stdConcentrations = new IntHashMap<>();
+        private final Map<Integer, double[][]> _dataMap = new IntHashMap<>();
         private final String _plateName;
         private final Plate _plateTemplate;
         // contains the mapping of (well/analyte) to extra row data to merge during data import

--- a/elisa/src/org/labkey/elisa/ManualImportHelper.java
+++ b/elisa/src/org/labkey/elisa/ManualImportHelper.java
@@ -10,6 +10,7 @@ import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.Well;
 import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.statistics.CurveFit;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpMaterial;
@@ -45,7 +46,7 @@ public class ManualImportHelper extends AbstractElisaImportHelper
     @Override
     public Map<Integer, Plate> getAnalyteToPlate(String plateName) throws ExperimentException
     {
-        Map<Integer, Plate> analyteMap = new HashMap<>();
+        Map<Integer, Plate> analyteMap = new IntHashMap<>();
         PlateReader reader = _provider.getPlateReader(BioTekPlateReader.LABEL);
         if (reader != null)
         {

--- a/elisa/src/org/labkey/elisa/query/CurveFitDb.java
+++ b/elisa/src/org/labkey/elisa/query/CurveFitDb.java
@@ -5,8 +5,8 @@ import org.labkey.api.data.Entity;
 public class CurveFitDb extends Entity
 {
     private Integer _rowId;
-    private Integer _runId;
-    private Integer _protocolId;
+    private Long _runId;
+    private Long _protocolId;
     private String _plateName;
     private Integer _spot;
     private Double _rSquared;
@@ -27,22 +27,22 @@ public class CurveFitDb extends Entity
         _rowId = rowId;
     }
 
-    public Integer getRunId()
+    public Long getRunId()
     {
         return _runId;
     }
 
-    public void setRunId(Integer runId)
+    public void setRunId(Long runId)
     {
         _runId = runId;
     }
 
-    public Integer getProtocolId()
+    public Long getProtocolId()
     {
         return _protocolId;
     }
 
-    public void setProtocolId(Integer protocolId)
+    public void setProtocolId(Long protocolId)
     {
         _protocolId = protocolId;
     }

--- a/elisa/src/org/labkey/elisa/query/ElisaManager.java
+++ b/elisa/src/org/labkey/elisa/query/ElisaManager.java
@@ -36,7 +36,6 @@ public class ElisaManager
         filter.addCondition(FieldKey.fromParts("PlateName"), plateName);
         filter.addCondition(FieldKey.fromParts("Spot"), spot);
         return new TableSelector(ElisaProtocolSchema.getTableInfoCurveFit(), filter, null).getObject(CurveFitDb.class);
-
     }
 
     public static void deleteContainerData(Container container)

--- a/elispotassay/src/org/labkey/elispot/AbstractElispotDataHandler.java
+++ b/elispotassay/src/org/labkey/elispot/AbstractElispotDataHandler.java
@@ -156,7 +156,7 @@ public abstract class AbstractElispotDataHandler extends AbstractExperimentDataH
         return dataRowLsid.build();
     }
 
-    public static Lsid getAntigenLsid(String antigenWellgroupName, String sampleName, int runId, String assayName, String analyte)
+    public static Lsid getAntigenLsid(String antigenWellgroupName, String sampleName, long runId, String assayName, String analyte)
     {
         assert (antigenWellgroupName != null);
         assert (sampleName != null);

--- a/elispotassay/src/org/labkey/elispot/ElispotAssayProvider.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotAssayProvider.java
@@ -174,10 +174,10 @@ public class ElispotAssayProvider extends AbstractPlateBasedAssayProvider implem
     }
 
     @Override
-    public Set<ExpData> getDatasForResultRows(Collection<Integer> rowIds, ExpProtocol protocol, ResolverCache cache)
+    public Set<ExpData> getDatasForResultRows(Collection<Long> rowIds, ExpProtocol protocol, ResolverCache cache)
     {
         Set<ExpData> result = new HashSet<>();
-        for (Integer rowId : rowIds)
+        for (var rowId : rowIds)
         {
             RunDataRow dataRow = ElispotManager.get().getRunDataRow(rowId);
             if (dataRow == null)

--- a/elispotassay/src/org/labkey/elispot/ElispotDataHandler.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotDataHandler.java
@@ -523,7 +523,7 @@ public class ElispotDataHandler extends AbstractElispotDataHandler implements Tr
         }
     }
 
-    private static Map<String, Object> makeAntigenRow(int runId, String specimenLsid, String wellgroupName, String antigenName,
+    private static Map<String, Object> makeAntigenRow(long runId, String specimenLsid, String wellgroupName, String antigenName,
                                                       Double mean, Double median, String objectUri, String protocolName,
                                                       String antigenWellgroupName, String analyte, Object cytokine)
     {

--- a/elispotassay/src/org/labkey/elispot/ElispotManager.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotManager.java
@@ -89,7 +89,7 @@ public class ElispotManager
     }
 
     @Nullable
-    public RunDataRow getRunDataRow(int rowId)
+    public RunDataRow getRunDataRow(long rowId)
     {
         Filter filter = new SimpleFilter(FieldKey.fromString("RowId"), rowId);
         return new TableSelector(getTableInfoElispotRunData()).getObject(filter, RunDataRow.class);
@@ -184,14 +184,14 @@ public class ElispotManager
         try (DbScope.Transaction transaction = scope.ensureTransaction())
         {
             // Delete all rows based on the runId
-            Set<Integer> runIds = new HashSet<>();
+            Set<Long> runIds = new HashSet<>();
             for (ExpData data : datas)
             {
                 runIds.add(data.getRunId());
             }
 
             // Since runIds may be from different folders, delete from each separately
-            for (Integer runId : runIds)
+            for (var runId : runIds)
             {
                 if (null != runId)
                 {

--- a/elispotassay/src/org/labkey/elispot/ElispotManager.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotManager.java
@@ -15,10 +15,11 @@
  */
 package org.labkey.elispot;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AbstractAssayProvider;
 import org.labkey.api.collections.ConcurrentCaseInsensitiveSortedMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
@@ -37,16 +38,12 @@ import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
-import org.labkey.api.assay.AbstractAssayProvider;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * Created by davebradlee on 3/19/15.
- */
 public class ElispotManager
 {
     private static final Logger _log = LogManager.getLogger(ElispotManager.class);
@@ -82,10 +79,9 @@ public class ElispotManager
         throw new IllegalStateException("Domain not found for protocol: " + protocol.getName());
     }
 
-    public int insertRunDataRow(User user, Map<String, Object> fields)
+    public void insertRunDataRow(User user, Map<String, Object> fields)
     {
-        Map<String, Object> results = Table.insert(user, getTableInfoElispotRunData(), fields);
-        return (Integer)results.get("RowId");
+        Table.insert(user, getTableInfoElispotRunData(), fields);
     }
 
     @Nullable
@@ -135,10 +131,9 @@ public class ElispotManager
         Table.update(user, getTableInfoElispotRunData(), fields, fields.get("RowId"));
     }
 
-    public String insertAntigenRow(User user, Map<String, Object> fields, ExpProtocol protocol)
+    public void insertAntigenRow(User user, Map<String, Object> fields, ExpProtocol protocol)
     {
-        Map<String, Object> results = Table.insert(user, getTableInfoElispotAntigen(protocol), fields);
-        return results.get("AntigenLsid").toString();
+        Table.insert(user, getTableInfoElispotAntigen(protocol), fields);
     }
 
     public void updateAntigenRow(User user, Map<String, Object> fields, ExpProtocol protocol)

--- a/elispotassay/src/org/labkey/elispot/ElispotUploadWizardAction.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotUploadWizardAction.java
@@ -17,6 +17,7 @@
 package org.labkey.elispot;
 
 import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
@@ -45,6 +46,7 @@ import org.labkey.api.assay.plate.PlateSamplePropertyHelper;
 import org.labkey.api.assay.PreviouslyUploadedDataCollector;
 import org.labkey.api.assay.plate.PlateReader;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.InsertView;
 import org.labkey.elispot.plate.PlateInfo;
 import org.springframework.validation.BindException;
@@ -70,6 +72,8 @@ import java.util.Set;
 @RequiresPermission(InsertPermission.class)
 public class ElispotUploadWizardAction extends UploadWizardAction<ElispotRunUploadForm, ElispotAssayProvider>
 {
+    private static final Logger LOG = LogHelper.getLogger(ElispotUploadWizardAction.class, "Elispot upload errors");
+
     public ElispotUploadWizardAction()
     {
         super(ElispotRunUploadForm.class);
@@ -566,6 +570,7 @@ public class ElispotUploadWizardAction extends UploadWizardAction<ElispotRunUplo
             }
             catch (ExperimentException e)
             {
+                LOG.error("Unexpected exception", e);
                 errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
             }
 

--- a/flow/src/org/labkey/flow/FlowServiceImpl.java
+++ b/flow/src/org/labkey/flow/FlowServiceImpl.java
@@ -64,7 +64,7 @@ public class FlowServiceImpl implements FlowService
 
             sql.append(" ORDER BY 1");
 
-            Integer[] dataids = new SqlSelector(FlowManager.get().getSchema(), sql).getArray(Integer.class);
+            Long[] dataids = new SqlSelector(FlowManager.get().getSchema(), sql).getArray(Long.class);
 
             return ExperimentService.get().getExpDatas(Arrays.asList(dataids));
         }

--- a/flow/src/org/labkey/flow/controllers/BaseFlowController.java
+++ b/flow/src/org/labkey/flow/controllers/BaseFlowController.java
@@ -217,9 +217,9 @@ public abstract class BaseFlowController extends SpringActionController
         url.replaceParameter(param.toString(), value);
     }
 
-    protected void putParam(ActionURL url, Enum<?> param, int value)
+    protected void putParam(ActionURL url, Enum<?> param, long value)
     {
-        putParam(url, param, Integer.toString(value));
+        putParam(url, param, Long.toString(value));
     }
 
     public HttpServletRequest getRequest()

--- a/flow/src/org/labkey/flow/controllers/ReportsController.java
+++ b/flow/src/org/labkey/flow/controllers/ReportsController.java
@@ -408,7 +408,7 @@ public class ReportsController extends BaseFlowController
                         PipelineService.get().queueJob(job);
 
                         // navigate to the job status page
-                        int jobId = PipelineService.get().getJobId(getUser(), getContainer(), job.getJobGUID());
+                        long jobId = PipelineService.get().getJobId(getUser(), getContainer(), job.getJobGUID());
                         throw new RedirectException(urlProvider(PipelineStatusUrls.class).urlDetails(getContainer(), jobId));
                     }
                 }

--- a/flow/src/org/labkey/flow/controllers/attribute/summary.jsp
+++ b/flow/src/org/labkey/flow/controllers/attribute/summary.jsp
@@ -44,7 +44,7 @@
             FlowEntry primary = entry.getKey();
             Collection<FlowEntry> aliases = entry.getValue();
 
-            Map<Integer, Number> counts = FlowManager.get().getUsageCount(primary._type, primary._rowId);
+            Map<Long, Number> counts = FlowManager.get().getUsageCount(primary._type, primary._rowId);
             long totalCount = 0;
             for (Number count : counts.values())
                 totalCount += count.longValue();

--- a/flow/src/org/labkey/flow/controllers/editscript/EditScriptForm.java
+++ b/flow/src/org/labkey/flow/controllers/editscript/EditScriptForm.java
@@ -97,12 +97,12 @@ public class EditScriptForm extends FlowObjectForm<FlowScript>
             _run = FlowRun.fromURL(getViewContext().getActionURL(), getRequest(), getViewContext().getContainer(), getUser());
             if (_run != null)
             {
-                FlowPreference.editScriptRunId.setValue(getRequest(), Integer.toString(_run.getRunId()));
+                FlowPreference.editScriptRunId.setValue(getRequest(), Long.toString(_run.getRunId()));
             }
             _comp = FlowCompensationMatrix.fromURL(getViewContext().getActionURL(), getRequest(), getContainer(), getUser());
             if (_comp != null)
             {
-                FlowPreference.editScriptCompId.setValue(getRequest(), Integer.toString(_comp.getRowId()));
+                FlowPreference.editScriptCompId.setValue(getRequest(), Long.toString(_comp.getRowId()));
             }
             String strWellId = getRequest().getParameter(FlowParam.wellId.toString());
             if (strWellId != null)
@@ -320,14 +320,14 @@ public class EditScriptForm extends FlowObjectForm<FlowScript>
         return getContainer().hasPermission(getUser(), UpdatePermission.class) && _runCount == 0;
     }
 
-    public Map<Integer, String> getExperimentRuns()
+    public Map<Long, String> getExperimentRuns()
     {
         return getExperimentRuns(false);
     }
 
-    public Map<Integer, String> getExperimentRuns(boolean realFiles)
+    public Map<Long, String> getExperimentRuns(boolean realFiles)
     {
-        LinkedHashMap<Integer, String> ret = new LinkedHashMap<>();
+        LinkedHashMap<Long, String> ret = new LinkedHashMap<>();
         List<FlowRun> runs = realFiles ?
                 FlowRun.getRunsWithRealFCSFiles(getContainer(), FlowProtocolStep.keywords) :
                 FlowRun.getRunsForContainer(getContainer(), FlowProtocolStep.keywords);

--- a/flow/src/org/labkey/flow/controllers/executescript/AnalysisScriptController.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/AnalysisScriptController.java
@@ -1216,7 +1216,7 @@ public class AnalysisScriptController extends BaseFlowController
                     if (matches != null)
                     {
                         FlowFCSFile perfectMatch = matches.first;
-                        int perfectMatchId = perfectMatch != null ? perfectMatch.getRowId() : 0;
+                        long perfectMatchId = perfectMatch != null ? perfectMatch.getRowId() : 0;
                         List<FlowFCSFile> candidates = matches.second;
 
                         if (perfectMatchId != 0 || (candidates != null && !candidates.isEmpty()))

--- a/flow/src/org/labkey/flow/controllers/executescript/ChooseRunsToAnalyzeForm.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/ChooseRunsToAnalyzeForm.java
@@ -170,7 +170,7 @@ public class ChooseRunsToAnalyzeForm extends FlowQueryForm implements DataRegion
             FlowExperiment analysis = FlowExperiment.getMostRecentAnalysis(getContainer());
             if (analysis != null)
             {
-                ff_targetExperimentId = Integer.toString(analysis.getExperimentId());
+                ff_targetExperimentId = Long.toString(analysis.getExperimentId());
             }
         }
         Collection<FlowScript> availableProtocols = Arrays.asList(FlowScript.getScripts(getContainer()));

--- a/flow/src/org/labkey/flow/controllers/executescript/ImportAnalysisForm.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/ImportAnalysisForm.java
@@ -55,7 +55,7 @@ public class ImportAnalysisForm implements HasAllowBindParameter
     private AnalysisEngine selectAnalysisEngine = null;
     private boolean createAnalysis;
     private String newAnalysisName;
-    private int existingAnalysisId;
+    private long existingAnalysisId;
     private String targetStudy;
 
     // FCSFile directories selected in the pipeline browser for association with the imported workspace analysis.
@@ -180,12 +180,12 @@ public class ImportAnalysisForm implements HasAllowBindParameter
         this.newAnalysisName = newAnalysisName;
     }
 
-    public int getExistingAnalysisId()
+    public long getExistingAnalysisId()
     {
         return existingAnalysisId;
     }
 
-    public void setExistingAnalysisId(int existingAnalysisId)
+    public void setExistingAnalysisId(long existingAnalysisId)
     {
         this.existingAnalysisId = existingAnalysisId;
     }

--- a/flow/src/org/labkey/flow/controllers/executescript/SamplesConfirmGridView.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/SamplesConfirmGridView.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.collections.NamedObject;
 import org.labkey.api.collections.NamedObjectList;
 import org.labkey.api.collections.RowMapFactory;
@@ -87,7 +88,7 @@ public class SamplesConfirmGridView extends GridView
     static FieldKey SAMPLE_NAME_FIELD_KEY = new FieldKey(null, "SampleName");
     static FieldKey GROUP_NAMES_FIELD_KEY = new FieldKey(null, "GroupNames");
 
-    Map<Integer, FlowRun> _runs = new HashMap<>();
+    Map<Long, FlowRun> _runs = new LongHashMap<>();
 
     public SamplesConfirmGridView(User user, Container container, SelectedSamples data, boolean resolving, Errors errors)
     {
@@ -436,7 +437,7 @@ public class SamplesConfirmGridView extends GridView
                 return _list;
 
             // Put most likely candidates on the top of the list
-            Set<Integer> candidateRowIds = new HashSet<>(candidates.size());
+            Set<Long> candidateRowIds = new HashSet<>(candidates.size());
             NamedObjectList list = new NamedObjectList();
             for (FlowFCSFile candidate : candidates)
             {

--- a/flow/src/org/labkey/flow/controllers/executescript/SelectedSamples.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/SelectedSamples.java
@@ -44,17 +44,17 @@ public class SelectedSamples
     {
         private boolean _selected;
         // FlowFCSFile rowid (may be 0 or null if there is no match)
-        private Integer _matchedFile;
+        private Long _matchedFile;
 
         // FlowFCSFile rowid (may be null if there are no candidates)
-        private int[] _candidateFile;
+        private long[] _candidateFile;
         private List<FlowFCSFile> _candidateFCSFiles;
 
         public ResolvedSample()
         {
         }
 
-        public ResolvedSample(boolean selected, int matchedFile, List<FlowFCSFile> candidateFCSFiles)
+        public ResolvedSample(boolean selected, long matchedFile, List<FlowFCSFile> candidateFCSFiles)
         {
             _selected = selected;
             _matchedFile = matchedFile;
@@ -66,7 +66,7 @@ public class SelectedSamples
             else
             {
                 _candidateFCSFiles = candidateFCSFiles;
-                _candidateFile = new int[candidateFCSFiles.size()];
+                _candidateFile = new long[candidateFCSFiles.size()];
                 for (int i = 0, len = candidateFCSFiles.size(); i < len; i++)
                     _candidateFile[i] = candidateFCSFiles.get(i).getRowId();
             }
@@ -82,12 +82,12 @@ public class SelectedSamples
             _selected = selected;
         }
 
-        public Integer getMatchedFile()
+        public Long getMatchedFile()
         {
             return _matchedFile;
         }
 
-        public void setMatchedFile(Integer matchedFile)
+        public void setMatchedFile(Long matchedFile)
         {
             _matchedFile = matchedFile;
         }
@@ -97,7 +97,7 @@ public class SelectedSamples
             return _matchedFile != null && _matchedFile > 0;
         }
 
-        public int[] getCandidateFile()
+        public long[] getCandidateFile()
         {
             return _candidateFile;
         }
@@ -111,7 +111,7 @@ public class SelectedSamples
             return _candidateFCSFiles;
         }
 
-        public void setCandidateFile(int[] candidateFile)
+        public void setCandidateFile(long[] candidateFile)
         {
             _candidateFile = candidateFile;
         }

--- a/flow/src/org/labkey/flow/controllers/executescript/importAnalysisChooseAnalysis.jsp
+++ b/flow/src/org/labkey/flow/controllers/executescript/importAnalysisChooseAnalysis.jsp
@@ -36,6 +36,7 @@
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.Set" %>
+<%@ page import="org.labkey.api.collections.LongHashMap" %>
 <%@ page import="org.labkey.api.assay.AbstractAssayProvider" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -60,7 +61,7 @@
 <%
     FlowExperiment[] analyses = FlowExperiment.getAnalyses(container);
     FlowExperiment firstNonDisabledAnalysis = null;
-    Map<Integer, String> disabledAnalyses = new HashMap<>();
+    Map<Long, String> disabledAnalyses = new LongHashMap<>();
     if (pipeRoot != null)
     {
         List<File> keywordDirs = new ArrayList<>();
@@ -154,7 +155,7 @@ those results must be put into different analysis folders.
                 <select id="existingAnalysisId" name="existingAnalysisId">
                     <%
                         FlowExperiment recentAnalysis = FlowExperiment.getMostRecentAnalysis(container);
-                        int selectedId = 0;
+                        long selectedId = 0;
                         if (firstNonDisabledAnalysis != null)
                             selectedId = firstNonDisabledAnalysis.getExperimentId();
                         if (recentAnalysis != null && !disabledAnalyses.containsKey(recentAnalysis.getExperimentId()))

--- a/flow/src/org/labkey/flow/controllers/protocol/showSamples2.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/showSamples2.jsp
@@ -137,10 +137,10 @@ There are <a id="all-samples" href="<%=h(protocol.getSampleTypeDetailsURL(st, ge
     <% } %>
     <%
         int i = 0;
-        for (Map.Entry<Integer, List<Integer>> entry : linkedSampleIdToFcsFileIds.entrySet())
+        for (Map.Entry<Long, List<Long>> entry : linkedSampleIdToFcsFileIds.entrySet())
         {
             i++;
-            List<Integer> fcsFileIds = entry.getValue();
+            List<Long> fcsFileIds = entry.getValue();
             var sampleId = entry.getKey();
             var sample = samples.get(entry.getKey());
             String sampleName = (String)sample.get(nameFieldKey);
@@ -154,7 +154,7 @@ There are <a id="all-samples" href="<%=h(protocol.getSampleTypeDetailsURL(st, ge
         <% } %>
         <td>
             <%
-                for (Integer fcsFileId : fcsFileIds)
+                for (Long fcsFileId : fcsFileIds)
                 {
                     var fcsFile = fcsFiles.get(fcsFileId);
                     String fcsFileName = (String)fcsFile.get(nameFieldKey);
@@ -170,7 +170,7 @@ There are <a id="all-samples" href="<%=h(protocol.getSampleTypeDetailsURL(st, ge
         <% for (var fcsFileField : fcsFileFields) { %>
         <td valign="top">
             <%
-                for (Integer fcsFileId : fcsFileIds)
+                for (Long fcsFileId : fcsFileIds)
                 {
                     var fcsFile = fcsFiles.get(fcsFileId);
             %><%=h(fcsFile.get(fcsFileField))%><br><%
@@ -202,7 +202,7 @@ There are <a id="all-samples" href="<%=h(protocol.getSampleTypeDetailsURL(st, ge
     </tr>
     <% } %>
     <%
-        for (Integer sampleId : unlinkedSampleIds)
+        for (Long sampleId : unlinkedSampleIds)
         {
             i++;
             var sample = samples.get(sampleId);
@@ -241,7 +241,7 @@ There are <a id="all-samples" href="<%=h(protocol.getSampleTypeDetailsURL(st, ge
     </tr>
     <% } %>
     <%
-        for (Integer fcsFileId : unlinkedFcsFileIds)
+        for (Long fcsFileId : unlinkedFcsFileIds)
         {
             i++;
             Map<FieldKey, Object> fcsFile = fcsFiles.get(fcsFileId);

--- a/flow/src/org/labkey/flow/controllers/run/RunController.java
+++ b/flow/src/org/labkey/flow/controllers/run/RunController.java
@@ -708,7 +708,7 @@ public class RunController extends BaseFlowController
                         UnexpectedException.rethrow(e);
                     }
 
-                    Integer jobId = null;
+                    Long jobId = null;
                     if (jobGuid != null)
                         jobId = PipelineService.get().getJobId(getUser(), getContainer(), jobGuid);
 

--- a/flow/src/org/labkey/flow/controllers/well/ChooseGraphForm.java
+++ b/flow/src/org/labkey/flow/controllers/well/ChooseGraphForm.java
@@ -51,7 +51,7 @@ public class ChooseGraphForm extends ViewForm
         return _wellId;
     }
 
-    public int getCompId()
+    public long getCompId()
     {
         if (_compId != 0)
             return _compId;
@@ -64,7 +64,7 @@ public class ChooseGraphForm extends ViewForm
         return 0;
     }
 
-    public int getScriptId()
+    public long getScriptId()
     {
         if (_scriptId != 0)
             return _scriptId;

--- a/flow/src/org/labkey/flow/controllers/well/chooseGraph.jsp
+++ b/flow/src/org/labkey/flow/controllers/well/chooseGraph.jsp
@@ -45,10 +45,10 @@
     boolean hasScripts = false;
     boolean hasComps = false;
     FlowWell well = form.getWell();
-    Map<Integer, String> scriptOptions = new LinkedHashMap<>();
+    Map<Long, String> scriptOptions = new LinkedHashMap<>();
     if (form.getScript() == null)
     {
-        scriptOptions.put(0, "None");
+        scriptOptions.put(0L, "None");
     }
     FlowScript wellScript = well.getScript();
     if (wellScript != null)
@@ -71,10 +71,10 @@
         }
     }
 
-    Map<Integer, String> compOptions = new LinkedHashMap<>();
+    Map<Long, String> compOptions = new LinkedHashMap<>();
     if (form.getCompensationMatrix() == null)
     {
-        compOptions.put(0, "None");
+        compOptions.put(0L, "None");
     }
     FlowCompensationMatrix wellCompensationMatrix = well.getCompensationMatrix();
     if (wellCompensationMatrix != null)

--- a/flow/src/org/labkey/flow/controllers/well/showWell.jsp
+++ b/flow/src/org/labkey/flow/controllers/well/showWell.jsp
@@ -511,7 +511,7 @@ if (!relatedFiles.isEmpty())
     %></table><%
 }
 
-LinkedHashMap<Integer, FlowFCSAnalysis> allAnalyses = new LinkedHashMap<>(10);
+LinkedHashMap<Long, FlowFCSAnalysis> allAnalyses = new LinkedHashMap<>(10);
 for (FlowFCSAnalysis analysis : well.getFCSAnalysisOutputs())
     allAnalyses.put(analysis.getRowId(), analysis);
 if (originalFile != null)

--- a/flow/src/org/labkey/flow/data/FlowAssayProvider.java
+++ b/flow/src/org/labkey/flow/data/FlowAssayProvider.java
@@ -254,10 +254,10 @@ public class FlowAssayProvider extends AbstractAssayProvider
     }
 
     @Override
-    public Set<ExpData> getDatasForResultRows(Collection<Integer> rowIds, ExpProtocol protocol, ResolverCache cache)
+    public Set<ExpData> getDatasForResultRows(Collection<Long> rowIds, ExpProtocol protocol, ResolverCache cache)
     {
         Set<ExpData> result = new HashSet<>();
-        for (Integer rowId : rowIds)
+        for (var rowId : rowIds)
         {
             FlowDataObject fdo = FlowDataObject.fromRowId(rowId);
             if (fdo != null)
@@ -273,7 +273,7 @@ public class FlowAssayProvider extends AbstractAssayProvider
     }
 
     @Override
-    protected String getSourceLSID(String runLSID, int dataId, int resultRowId)
+    protected String getSourceLSID(String runLSID, long dataId, int resultRowId)
     {
         // SourceLSID is used by assay to render links back to the original data for rows
         // that have been linked to a study dataset.
@@ -512,10 +512,10 @@ public class FlowAssayProvider extends AbstractAssayProvider
     }
 
     @Override
-    public Set<Container> getAssociatedStudyContainers(ExpProtocol protocol, Collection<Integer> rowIds)
+    public Set<Container> getAssociatedStudyContainers(ExpProtocol protocol, Collection<Long> rowIds)
     {
         Set<Container> result = new HashSet<>();
-        for (Integer dataRowId : rowIds)
+        for (var dataRowId : rowIds)
         {
             Container container = null;
             ExpData data = getDataForDataRow(dataRowId, protocol);

--- a/flow/src/org/labkey/flow/data/FlowCompensationMatrix.java
+++ b/flow/src/org/labkey/flow/data/FlowCompensationMatrix.java
@@ -185,7 +185,7 @@ public class FlowCompensationMatrix extends FlowDataObject implements Serializab
         }
         return getName();
     }
-    public int getCompId()
+    public long getCompId()
     {
         return getRowId();
     }

--- a/flow/src/org/labkey/flow/data/FlowDataObject.java
+++ b/flow/src/org/labkey/flow/data/FlowDataObject.java
@@ -17,6 +17,7 @@
 package org.labkey.flow.data;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.api.DataType;
@@ -52,7 +53,7 @@ abstract public class FlowDataObject extends FlowObject<ExpData>
         }
 
         List<AttrObject> attrs = FlowManager.get().getAttrObjects(flowDatas);
-        Map<Integer, AttrObject> attrMap = new HashMap<>(2*datas.size());
+        Map<Long, AttrObject> attrMap = new LongHashMap<>(2*datas.size());
         for (AttrObject attr : attrs)
         {
             attrMap.put(attr.getDataId(), attr);
@@ -86,17 +87,17 @@ abstract public class FlowDataObject extends FlowObject<ExpData>
         return ((FlowDataType) type).newInstance(data);
     }
 
-    static public FlowDataObject fromRowId(int id)
+    static public FlowDataObject fromRowId(long id)
     {
         return fromData(ExperimentService.get().getExpData(id));
     }
 
-    static public List<FlowDataObject> fromRowIds(int... ids)
+    static public List<FlowDataObject> fromRowIds(long... ids)
     {
         return fromDatas(ExperimentService.get().getExpDatas(ids));
     }
 
-    static public List<FlowDataObject> fromRowIds(Collection<Integer> ids)
+    static public List<FlowDataObject> fromRowIds(Collection<Long> ids)
     {
         return fromDatas(ExperimentService.get().getExpDatas(ids));
     }
@@ -180,7 +181,7 @@ abstract public class FlowDataObject extends FlowObject<ExpData>
         return new FlowRun(run);
     }
 
-    public int getRowId()
+    public long getRowId()
     {
         return getData().getRowId();
     }

--- a/flow/src/org/labkey/flow/data/FlowExperiment.java
+++ b/flow/src/org/labkey/flow/data/FlowExperiment.java
@@ -70,7 +70,7 @@ public class FlowExperiment extends FlowObject<ExpExperiment>
         return new FlowExperiment(exp);
     }
 
-    static public FlowExperiment fromExperimentId(int id)
+    static public FlowExperiment fromExperimentId(long id)
     {
         ExpExperiment experiment = ExperimentService.get().getExpExperiment(id);
         if (experiment == null)
@@ -211,7 +211,7 @@ public class FlowExperiment extends FlowObject<ExpExperiment>
         return getExpObject();
     }
 
-    public int getExperimentId()
+    public long getExperimentId()
     {
         return getExperiment().getRowId();
     }

--- a/flow/src/org/labkey/flow/data/FlowFCSFile.java
+++ b/flow/src/org/labkey/flow/data/FlowFCSFile.java
@@ -53,7 +53,7 @@ public class FlowFCSFile extends FlowWell
         super(data);
     }
 
-    static public List<FlowFCSFile> fromWellIds(int... ids)
+    static public List<FlowFCSFile> fromWellIds(long... ids)
     {
         List<FlowFCSFile> wells = new ArrayList<>(ids.length);
         List<FlowDataObject> flowobjs = fromRowIds(ids);

--- a/flow/src/org/labkey/flow/data/FlowProtocol.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocol.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.LongArrayList;
 import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
@@ -659,7 +660,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
             throw new RuntimeSQLException(e);
         }
 
-        List<Long> unlinkedSampleIds = new ArrayList<>(sampleIds);
+        List<Long> unlinkedSampleIds = new LongArrayList(sampleIds);
         unlinkedSampleIds.removeAll(samplesToFcsFiles.keySet());
 
         var rowIdFieldKey = FieldKey.fromParts("RowId");

--- a/flow/src/org/labkey/flow/data/FlowProtocol.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocol.java
@@ -16,6 +16,8 @@
 
 package org.labkey.flow.data;
 
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -79,7 +82,6 @@ import org.labkey.flow.query.FlowSchema;
 import org.labkey.flow.query.FlowTableType;
 import org.labkey.flow.script.KeywordsJob;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -370,7 +372,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
                 _log.warn("Flow sample join property '" + propertyName + "' not found on SampleType");
         }
 
-        Map<Integer, ExpMaterial> materialMap = new HashMap<>();
+        Map<Long, ExpMaterial> materialMap = new LongHashMap<>();
         List<? extends ExpMaterial> materials = getSamples(st, user);
         for (ExpMaterial material : materials)
         {
@@ -382,7 +384,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
         {
             while (rsSamples.next())
             {
-                int rowId = ((Number) colRowId.getValue(rsSamples)).intValue();
+                long rowId = colRowId.getLongValue(rsSamples);
                 ExpMaterial sample = materialMap.get(rowId);
                 if (sample == null)
                     continue;
@@ -449,7 +451,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
         int linked = 0;
 
         List<? extends ExpData> fcsFiles = ExperimentService.get().getExpDatas(getContainer(), FlowDataType.FCSFile, null);
-        Map<Integer, ExpData> fcsFileMap = new HashMap<>();
+        Map<Long, ExpData> fcsFileMap = new LongHashMap<>();
         for (ExpData fcsFile : fcsFiles)
         {
             fcsFileMap.put(fcsFile.getRowId(), fcsFile);
@@ -467,7 +469,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
             Set<ExpRun> fcsFileRuns = new HashSet<>();
             while (rs.next())
             {
-                Number fcsFileId = ((Number) colRowId.getValue(rs));
+                Long fcsFileId = colRowId.getLongValue(rs);
                 ExpData fcsFile = fcsFileMap.get(fcsFileId);
                 _log.debug("-- fcsFileId=" + fcsFileId + ", fcsFile=" + fcsFile);
                 if (fcsFile == null)
@@ -487,7 +489,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
                 _log.debug("   sampleKey=" + key);
 
                 ExpMaterial sample = sampleMap.get(key);
-                Integer newSampleId = sample == null ? null : sample.getRowId();
+                Long newSampleId = sample == null ? null : sample.getRowId();
                 Object oldSampleId = colSampleId.getValue(rs);
                 _log.debug("   newSampleId=" + newSampleId + ", oldSampleId=" + oldSampleId);
                 if (Objects.equals(newSampleId, oldSampleId))
@@ -570,15 +572,15 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
 
     public static class FCSFilesGroupedBySample
     {
-        public Map<Integer, Map<FieldKey, Object>> samples;
-        public Map<Integer, Map<FieldKey, Object>> fcsFiles;
+        public Map<Long, Map<FieldKey, Object>> samples;
+        public Map<Long, Map<FieldKey, Object>> fcsFiles;
         public List<FieldKey> sampleFields;
         public Collection<FieldKey> fcsFileFields;
-        public Map<Integer, Pair<Integer, String>> fcsFileRuns;
-        public Map<Integer, List<Integer>> linkedSampleIdToFcsFileIds;
+        public Map<Long, Pair<Long, String>> fcsFileRuns;
+        public Map<Long, List<Long>> linkedSampleIdToFcsFileIds;
         public int linkedFcsFileCount;
-        public List<Integer> unlinkedFcsFileIds;
-        public List<Integer> unlinkedSampleIds;
+        public List<Long> unlinkedFcsFileIds;
+        public List<Long> unlinkedSampleIds;
 
     }
 
@@ -610,20 +612,20 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
         tableMap.put("__FCSFiles", fcsTable);
         tableMap.put("__Samples", sampleTable);
 
-        List<Integer> sampleIds = new ArrayList<>();
-        List<Integer> fcsFileIds = new ArrayList<>();
-        Map<Integer, List<Integer>> samplesToFcsFiles = new LinkedHashMap<>();
-        List<Integer> unlinkedFcsFileIds = new ArrayList<>();
-        Map<Integer, Pair<Integer, String>> fcsFileRuns = new HashMap<>();
+        List<Long> sampleIds = new ArrayList<>();
+        List<Long> fcsFileIds = new ArrayList<>();
+        Map<Long, List<Long>> samplesToFcsFiles = new LinkedHashMap<>();
+        List<Long> unlinkedFcsFileIds = new ArrayList<>();
+        Map<Long, Pair<Long, String>> fcsFileRuns = new LongHashMap<>();
         int linkedFcsFileCount = 0;
 
         try (TableResultSet rs = QueryService.get().select(schema, sql, tableMap, false, false))
         {
             for (Map<String, Object> row : rs)
             {
-                Integer sampleRowId = (Integer) row.get("SampleRowId");
-                Integer fcsFileRowId = (Integer) row.get("FCSFileRowId");
-                Integer fcsFileRunId = (Integer) row.get("FCSFileRunId");
+                Long sampleRowId = MapUtils.getLong(row,"SampleRowId");
+                Long fcsFileRowId = MapUtils.getLong(row,"FCSFileRowId");
+                Long fcsFileRunId = MapUtils.getLong(row,"FCSFileRunId");
                 String fcsFileRunName = (String) row.get("FCSFileRunName");
 
                 if (sampleRowId != null)
@@ -657,13 +659,13 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
             throw new RuntimeSQLException(e);
         }
 
-        List<Integer> unlinkedSampleIds = new ArrayList<>(sampleIds);
+        List<Long> unlinkedSampleIds = new ArrayList<>(sampleIds);
         unlinkedSampleIds.removeAll(samplesToFcsFiles.keySet());
 
         var rowIdFieldKey = FieldKey.fromParts("RowId");
         var nameFieldKey = FieldKey.fromParts("Name");
 
-        Map<Integer, Map<FieldKey, Object>> samples = new HashMap<>();
+        Map<Long, Map<FieldKey, Object>> samples = new LongHashMap<>();
         var sampleColumns = new HashSet<FieldKey>();
         sampleColumns.add(rowIdFieldKey);
         sampleColumns.add(nameFieldKey);
@@ -674,7 +676,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
             while (results.next())
             {
                 var row = results.getFieldKeyRowMap();
-                Integer sampleId = (Integer)row.get(rowIdFieldKey);
+                Long sampleId = MapUtils.getLong(row,rowIdFieldKey);
                 samples.put(sampleId, new HashMap<>(row));
             }
         }
@@ -683,7 +685,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
             throw new RuntimeSQLException(e);
         }
 
-        Map<Integer, Map<FieldKey, Object>> fcsFiles = new HashMap<>();
+        Map<Long, Map<FieldKey, Object>> fcsFiles = new LongHashMap<>();
         var fcsFileColumns = new HashSet<FieldKey>();
         fcsFileColumns.add(rowIdFieldKey);
         fcsFileColumns.add(nameFieldKey);
@@ -695,7 +697,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
             while (results.next())
             {
                 var row = results.getFieldKeyRowMap();
-                Integer fcsFileId = (Integer) row.get(rowIdFieldKey);
+                Long fcsFileId = MapUtils.getLong(row,rowIdFieldKey);
                 fcsFiles.put(fcsFileId, new HashMap<>(row));
             }
         }
@@ -1006,7 +1008,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
             assertEquals(1, runs.size());
 
             FlowRun run = runs.get(0);
-            int runId = run.getRunId();
+            long runId = run.getRunId();
             FlowFCSFile[] fcsFiles = run.getFCSFiles();
             assertEquals(2, fcsFiles.length);
             assertEquals(0, fcsFiles[0].getSamples().size());

--- a/flow/src/org/labkey/flow/data/FlowProtocol.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocol.java
@@ -17,7 +17,7 @@
 package org.labkey.flow.data;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/flow/src/org/labkey/flow/data/FlowProtocolStep.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocolStep.java
@@ -18,6 +18,7 @@ package org.labkey.flow.data;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpProtocolAction;
@@ -28,7 +29,6 @@ import org.labkey.flow.controllers.FlowParam;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.Map;
 
 public class FlowProtocolStep implements Serializable
@@ -179,7 +179,7 @@ public class FlowProtocolStep implements Serializable
     static public void initProtocol(User user, FlowProtocol flowProtocol) throws Exception
     {
         ExpProtocol protocol = flowProtocol.getExpObject();
-        Map<Integer, ExpProtocolAction> existingSteps = new HashMap();
+        Map<Integer, ExpProtocolAction> existingSteps = new IntHashMap<>();
         for (ExpProtocolAction existingStep : protocol.getSteps())
         {
             existingSteps.put(existingStep.getActionSequence(), existingStep);

--- a/flow/src/org/labkey/flow/data/FlowRun.java
+++ b/flow/src/org/labkey/flow/data/FlowRun.java
@@ -210,12 +210,12 @@ public class FlowRun extends FlowObject<ExpRun>
         return new FlowCompensationMatrix(datas.get(0));
     }
     
-    public int getRunId()
+    public long getRunId()
     {
         return getExperimentRun().getRowId();
     }
 
-    static public FlowRun fromRunId(int id)
+    static public FlowRun fromRunId(long id)
     {
         if (id == 0)
             return null;
@@ -260,7 +260,7 @@ public class FlowRun extends FlowObject<ExpRun>
         return getScript().getAnalysisScript();
     }
 
-    private int getScriptId()
+    private long getScriptId()
     {
         List<? extends ExpData> datas = getExperimentRun().getInputDatas(InputRole.AnalysisScript.toString(), ExpProtocol.ApplicationType.ExperimentRun);
         if (datas.isEmpty())

--- a/flow/src/org/labkey/flow/data/FlowRunWorkspace.java
+++ b/flow/src/org/labkey/flow/data/FlowRunWorkspace.java
@@ -49,7 +49,7 @@ public class FlowRunWorkspace extends Workspace
         _groupAnalyses.put(PopulationName.fromString("analysis"), analysis);
         for (FlowFCSFile well : run.getFCSFiles())
         {
-            String key = Integer.toString(well.getWellId());
+            String key = Long.toString(well.getWellId());
             SampleInfo info = new SampleInfo(key, well.getName());
             FCSKeywordData fcs = FCSAnalyzer.get().readAllKeywords(FlowAnalyzer.getFCSRef(well));
             info.putAllKeywords(fcs.getAllKeywords());

--- a/flow/src/org/labkey/flow/data/FlowScript.java
+++ b/flow/src/org/labkey/flow/data/FlowScript.java
@@ -145,7 +145,7 @@ public class FlowScript extends FlowDataObject
         strScript = script;
     }
 
-    public int getScriptId()
+    public long getScriptId()
     {
         return getExpObject().getRowId();
     }

--- a/flow/src/org/labkey/flow/data/FlowWell.java
+++ b/flow/src/org/labkey/flow/data/FlowWell.java
@@ -57,7 +57,7 @@ public class FlowWell extends FlowDataObject
     // For serialization
     protected FlowWell() {}
 
-    static public FlowWell fromWellId(int id)
+    static public FlowWell fromWellId(long id)
     {
         FlowDataObject flowobj = fromRowId(id);
         if (flowobj instanceof FlowWell)
@@ -65,7 +65,7 @@ public class FlowWell extends FlowDataObject
         return null;
     }
 
-    static public List<? extends FlowWell> fromWellIds(int... ids)
+    static public List<? extends FlowWell> fromWellIds(long... ids)
     {
         List<FlowWell> wells = new ArrayList<>(ids.length);
         List<FlowDataObject> flowobjs = fromRowIds(ids);
@@ -75,7 +75,7 @@ public class FlowWell extends FlowDataObject
         return wells;
     }
 
-    static public List<FlowWell> fromWellIds(Collection<Integer> ids)
+    static public List<FlowWell> fromWellIds(Collection<Long> ids)
     {
         List<FlowWell> wells = new ArrayList<>(ids.size());
         List<FlowDataObject> flowobjs = fromRowIds(ids);
@@ -263,7 +263,7 @@ public class FlowWell extends FlowDataObject
         return prefix + " '" + getName() + "'";
     }
 
-    public int getWellId()
+    public long getWellId()
     {
         return getRowId();
     }

--- a/flow/src/org/labkey/flow/data/FlowWorkspace.java
+++ b/flow/src/org/labkey/flow/data/FlowWorkspace.java
@@ -95,7 +95,7 @@ public class FlowWorkspace extends FlowDataObject
         super(data);
     }
 
-    public int getWorkspaceId()
+    public long getWorkspaceId()
     {
         return getRowId();
     }

--- a/flow/src/org/labkey/flow/persist/AttrObject.java
+++ b/flow/src/org/labkey/flow/persist/AttrObject.java
@@ -22,7 +22,7 @@ public class AttrObject
 {
     Container _container;
     int _rowId;
-    int _dataId;
+    long _dataId;
     int _typeId;
     String _uri;
 
@@ -36,12 +36,12 @@ public class AttrObject
         _rowId = rowid;
     }
 
-    public int getDataId()
+    public long getDataId()
     {
         return _dataId;
     }
 
-    public void setDataId(int dataId)
+    public void setDataId(long dataId)
     {
         _dataId = dataId;
     }

--- a/flow/src/org/labkey/flow/persist/AttributeCache.java
+++ b/flow/src/org/labkey/flow/persist/AttributeCache.java
@@ -26,6 +26,7 @@ import org.labkey.api.cache.BlockingCache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbScope;
@@ -89,7 +90,7 @@ abstract public class AttributeCache<A extends Comparable<A>, E extends Attribut
             _entries = all;
 
             Map<String, Z> byName = new CaseInsensitiveHashMap<>();
-            Map<Integer, Z> byRowId = new HashMap<>();
+            Map<Integer, Z> byRowId = new IntHashMap<>();
             MultiValuedMap<Integer, Integer> aliases = new ArrayListValuedHashMap<>();
             for (Z entry : all)
             {

--- a/flow/src/org/labkey/flow/persist/AttributeSetHelper.java
+++ b/flow/src/org/labkey/flow/persist/AttributeSetHelper.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SqlSelector;
@@ -168,7 +169,7 @@ public class AttributeSetHelper
                 // Issue 41225: flow: import failure for duplicate aliased statistics
                 // Track the list of statistics and values for each preferredId key.
                 // If there is a duplicate statistic (e.g., two stats that are aliased) verify they have the same value.
-                Map<Integer, List<Map.Entry<StatisticSpec, Double>>> valuesForPreferredId = new HashMap<>();
+                Map<Integer, List<Map.Entry<StatisticSpec, Double>>> valuesForPreferredId = new IntHashMap<>();
 
                 String sql = "INSERT INTO " + mgr.getTinfoStatistic() + " (ObjectId, StatisticId, OriginalStatisticId, Value) VALUES (?,?,?,?)";
                 List<List<?>> paramsList = new ArrayList<>();

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 import org.labkey.api.audit.AuditLogService;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Aggregate;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
@@ -962,7 +963,7 @@ public class FlowManager
                 .append("WHERE fo.rowid = val.objectid\n")
                 .append("  AND val.").append(valueTableAttrIdColumn).append(" = ").appendValue(rowId).append("\n");
 
-        final Map<Integer, Collection<FlowDataObject>> usages = new HashMap<>();
+        final Map<Integer, Collection<FlowDataObject>> usages = new IntHashMap<>();
         SqlSelector selector = new SqlSelector(getSchema(), sql);
         selector.forEachMap(row -> {
             Integer attributeRowId = (Integer)row.get("OriginalAttrId");

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -872,7 +872,7 @@ public class FlowManager
     /**
      * Get a usage count for an attribute and its aliases.
      */
-    public Map<Integer, Number> getUsageCount(AttributeType type, int rowId)
+    public Map<Long, Number> getUsageCount(AttributeType type, int rowId)
     {
         FlowEntry entry = getAttributeEntry(type, rowId);
         if (entry == null)
@@ -893,7 +893,7 @@ public class FlowManager
                 .append("GROUP BY val.").append(valueTableOriginalAttrIdColumn).append("\n");
 
         SqlSelector selector = new SqlSelector(getSchema(), sql);
-        return selector.getValueMap();
+        return selector.getValueMap(Long.class);
     }
 
     /**

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -92,6 +92,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertNotNull;
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
 import static org.labkey.flow.data.AttributeType.keyword;
 
 public class FlowManager
@@ -424,7 +425,7 @@ public class FlowManager
         map = Table.insert(null, table, map);
 
         // Set Id to RowId if we aren't inserting an alias
-        Integer rowId = (Integer)map.get("RowId");
+        Integer rowId = asInteger(map.get("RowId"));
         assert rowId != null;
         if (aliasId <= 0)
         {

--- a/flow/src/org/labkey/flow/persist/PersistTests.java
+++ b/flow/src/org/labkey/flow/persist/PersistTests.java
@@ -57,6 +57,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
 
 /**
  * User: kevink
@@ -577,7 +578,7 @@ public class PersistTests
                             "Container", c.getId(),
                             "Name", UPPER_NAME,
                             "Id", -1));
-            upperId = (Integer)map.get("RowId");
+            upperId = asInteger(map.get("RowId"));
 
             // Set the Id column to indicate that it is not an alias
             map.put("Id", upperId);
@@ -591,7 +592,7 @@ public class PersistTests
                                 "Container", c.getId(),
                                 "Name", lower_name,
                                 "Id", -1));
-                lowerId = (Integer)map.get("RowId");
+                lowerId = asInteger(map.get("RowId"));
 
                 // Set the Id column to indicate that it is not an alias
                 map.put("Id", lowerId);

--- a/flow/src/org/labkey/flow/reports/FlowReport.java
+++ b/flow/src/org/labkey/flow/reports/FlowReport.java
@@ -185,7 +185,7 @@ abstract public class FlowReport extends AbstractReport
      * The exp.object in the Container for this FlowReport instance.
      * The report results will use this as the owner id.
      */
-    public @Nullable Integer getOntologyObjectId(Container container)
+    public @Nullable Long getOntologyObjectId(Container container)
     {
         return FlowReportManager.getReportOntologyObjectId(this, container);
     }
@@ -194,7 +194,7 @@ abstract public class FlowReport extends AbstractReport
      * The exp.object in the Container for this FlowReport instance.
      * The report results will use this as the owner id.
      */
-    public @Nullable Integer ensureOntologyObjectId(Container container)
+    public @Nullable Long ensureOntologyObjectId(Container container)
     {
         return FlowReportManager.ensureReportOntologyObjectId(this, container);
     }

--- a/flow/src/org/labkey/flow/reports/FlowReportJob.java
+++ b/flow/src/org/labkey/flow/reports/FlowReportJob.java
@@ -269,7 +269,7 @@ public class FlowReportJob extends RReportJob
             }
         };
 
-        Integer ownerId = FlowReportManager.ensureReportOntologyObjectId(_report, getContainer());
+        Long ownerId = FlowReportManager.ensureReportOntologyObjectId(_report, getContainer());
 
         try (DataIterator iter = loader.getDataIterator(new DataIteratorContext()))
         {

--- a/flow/src/org/labkey/flow/reports/FlowReportManager.java
+++ b/flow/src/org/labkey/flow/reports/FlowReportManager.java
@@ -258,7 +258,7 @@ public class FlowReportManager
 //        Integer[] ids = Table.executeArray(table, table.getColumn("ObjectURI"), new SimpleFilter("ObjectURI", uri), null, Integer.class);
 //    }
 
-    public static Integer getReportOntologyObjectId(FlowReport report, Container container)
+    public static Long getReportOntologyObjectId(FlowReport report, Container container)
     {
         String uri = getReportExpObjectURI(report, container);
         if (uri == null)
@@ -268,13 +268,13 @@ public class FlowReportManager
         return obj == null ? null : obj.getObjectId();
     }
 
-    public static Integer ensureReportOntologyObjectId(FlowReport report, Container container)
+    public static Long ensureReportOntologyObjectId(FlowReport report, Container container)
     {
         String uri = getReportExpObjectURI(report, container);
         if (uri == null)
             return null;
 
-        return OntologyManager.ensureObject(container, uri, (Integer) null);
+        return OntologyManager.ensureObject(container, uri, (Long) null);
     }
 
     public static String FLOW_REPORT_RESULT_OBJECT_LSID_PART = "FlowReportResult";
@@ -298,7 +298,7 @@ public class FlowReportManager
     public static void deleteReportResults(FlowReport report, Container container)
     {
         // Delete all owned objects of the report's exp.object
-        Integer objectId = getReportOntologyObjectId(report, container);
+        Long objectId = getReportOntologyObjectId(report, container);
         if (objectId != null)
             OntologyManager.deleteOntologyObjects(container, true, objectId);
     }

--- a/flow/src/org/labkey/flow/script/FlowJob.java
+++ b/flow/src/org/labkey/flow/script/FlowJob.java
@@ -168,7 +168,7 @@ public abstract class FlowJob extends PipelineJob
     {
         if (_statusHref == null)
         {
-            Integer jobId = PipelineService.get().getJobId(getUser(), getContainer(), getJobGUID());
+            Long jobId = PipelineService.get().getJobId(getUser(), getContainer(), getJobGUID());
             if (jobId != null)
             {
                 _statusHref = PageFlowUtil.urlProvider(PipelineStatusUrls.class).urlDetails(getContainer(), jobId);

--- a/flow/src/org/labkey/flow/view/FlowQueryView.java
+++ b/flow/src/org/labkey/flow/view/FlowQueryView.java
@@ -249,19 +249,19 @@ public class FlowQueryView extends QueryView
             URLHelper target = urlChangeView();
             MenuButton button = new MenuButton("Analysis Folder");
 
-            Map<Integer, String> availableExperiments = new LinkedHashMap<>();
-            availableExperiments.put(0, "All Analysis Folders");
+            Map<Long, String> availableExperiments = new LinkedHashMap<>();
+            availableExperiments.put(0L, "All Analysis Folders");
 
             for (FlowExperiment experiment : experiments)
                 availableExperiments.put(experiment.getExperimentId(), experiment.getName());
 
             FlowExperiment current = getSchema().getExperiment();
-            int currentId = current == null ? 0 : current.getExperimentId();
+            long currentId = current == null ? 0 : current.getExperimentId();
 
             if (!availableExperiments.containsKey(currentId))
                 availableExperiments.put(current.getExperimentId(), current.getName());
 
-            for (Map.Entry<Integer, String> entry : availableExperiments.entrySet())
+            for (Map.Entry<Long, String> entry : availableExperiments.entrySet())
             {
                 URLHelper url = target.clone();
                 if (entry.getKey().intValue() != 0)

--- a/luminex/src/org/labkey/luminex/LuminexAssayProvider.java
+++ b/luminex/src/org/labkey/luminex/LuminexAssayProvider.java
@@ -266,7 +266,7 @@ public class LuminexAssayProvider extends AbstractAssayProvider
     }
 
     @Override
-    public Set<ExpData> getDatasForResultRows(Collection<Integer> rowIds, ExpProtocol protocol, ResolverCache cache)
+    public Set<ExpData> getDatasForResultRows(Collection<Long> rowIds, ExpProtocol protocol, ResolverCache cache)
     {
         Set<ExpData> result = new HashSet<>();
         List<Integer> dataRowIds = new TableSelector(LuminexProtocolSchema.getTableInfoDataRow(), Collections.singleton("DataId"),
@@ -283,9 +283,9 @@ public class LuminexAssayProvider extends AbstractAssayProvider
     }
 
     @Override
-    protected String getSourceLSID(String runLSID, int dataId, int resultRowId)
+    protected String getSourceLSID(String runLSID, long dataId, int resultRowId)
     {
-        return new Lsid(LUMINEX_DATA_ROW_LSID_PREFIX, Integer.toString(dataId)).toString();
+        return new Lsid(LUMINEX_DATA_ROW_LSID_PREFIX, Long.toString(dataId)).toString();
     }
 
     @Override
@@ -497,7 +497,7 @@ public class LuminexAssayProvider extends AbstractAssayProvider
                 .append(" WHERE dataid IN ( SELECT rowId FROM ")
                 .append(ExperimentService.get().getTinfoData())
                 .append(" WHERE runid ");
-        List<Integer> runRowIds = runs.stream().map(ExpRun::getRowId).toList();
+        List<Long> runRowIds = runs.stream().map(ExpRun::getRowId).toList();
         dataRowTable.getSchema().getSqlDialect().appendInClauseSql(updateSql, runRowIds);
         updateSql.append(")");
 

--- a/luminex/src/org/labkey/luminex/LuminexController.java
+++ b/luminex/src/org/labkey/luminex/LuminexController.java
@@ -676,9 +676,9 @@ public class LuminexController extends SpringActionController
         protected void deleteObjects(DeleteForm form) throws SQLException, InvalidKeyException, BatchValidationException, QueryUpdateServiceException
         {
             List<Map<String, Object>> keys = new ArrayList<>();
-            Set<Integer> selections = DataRegionSelection.getSelectedIntegers(getViewContext(), true);
+            Set<Long> selections = DataRegionSelection.getSelectedIntegers(getViewContext(), true);
 
-            for (Integer selection : selections)
+            for (var selection : selections)
             {
                 Map<String, Object> entry = new HashMap<>();
                 entry.put("RowId", selection);
@@ -731,7 +731,7 @@ public class LuminexController extends SpringActionController
 
             GuideSetsDeleteBean bean = new GuideSetsDeleteBean(form.getReturnUrl(), form.getDataRegionSelectionKey(), form.getProtocol().getRowId(), getContainer(), form.getProtocol().getName());
 
-            Set<Integer> selections = DataRegionSelection.getSelectedIntegers(getViewContext(), false);
+            Set<Long> selections = DataRegionSelection.getSelectedIntegers(getViewContext(), false);
 
             SimpleFilter filter = new SimpleFilter();
             filter.addInClause(FieldKey.fromParts("RowId"), selections);
@@ -874,7 +874,7 @@ public class LuminexController extends SpringActionController
 
         private final List<GuideSet> _guideSets;
 
-        public GuideSetsDeleteBean(String returnUrl, String selectionKey, int protocolId, Container container, String assayName)
+        public GuideSetsDeleteBean(String returnUrl, String selectionKey, long protocolId, Container container, String assayName)
         {
             _guideSets = new ArrayList<>();
             setReturnUrl(returnUrl);
@@ -912,7 +912,7 @@ public class LuminexController extends SpringActionController
             settings.setBaseSort(new Sort("-RowId")); // Issue 22935
             setHelpTopic("applyGuideSets");
 
-            final int protocolId = _protocol.getRowId();
+            final long protocolId = _protocol.getRowId();
             GraphLinkQueryView view = new GraphLinkQueryView(null, null, _protocol, schema, settings, errors)
             {
                 @Override

--- a/luminex/src/org/labkey/luminex/LuminexDataHandler.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataHandler.java
@@ -504,7 +504,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
                 }
             }
 
-            List<Integer> dataIds = new ArrayList<>();
+            List<Long> dataIds = new ArrayList<>();
             for (ExpData sourceFile : sourceFiles)
             {
                 insertExcelProperties(excelRunDomain, sourceFile, parser, user, protocol);
@@ -534,7 +534,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
     }
 
     /** Saves the data rows, updating if they already exist, inserting if not */
-    private void saveDataRows(ExpRun expRun, User user, ExpProtocol protocol, Map<DataRowKey, Map<String, Object>> rows, List<Integer> dataIds)
+    private void saveDataRows(ExpRun expRun, User user, ExpProtocol protocol, Map<DataRowKey, Map<String, Object>> rows, List<Long> dataIds)
             throws SQLException, BatchValidationException
     {
         // Do a query to find all the rows that have already been inserted
@@ -622,7 +622,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
 
     private static class DataRowKey
     {
-        private final int _dataId;
+        private final long _dataId;
         private final int _analyteId;
         private final String _well;
         private final String _type;
@@ -657,7 +657,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
         @Override
         public int hashCode()
         {
-            int result = _dataId;
+            int result = (int)_dataId;
             result = 31 * result + _analyteId;
             result = 31 * result + (_well != null ? _well.hashCode() : 0);
             result = 31 * result + (_type != null ? _type.hashCode() : 0);
@@ -1626,7 +1626,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
         Container container = data.getContainer();
         // Clear out the values - this is necessary if this is a XAR import where the run properties would
         // have been loaded as part of the ExperimentRun itself.
-        Integer objectId = OntologyManager.ensureObject(container, data.getLSID());
+        Long objectId = OntologyManager.ensureObject(container, data.getLSID());
         for (DomainProperty prop : domain.getProperties())
         {
             OntologyManager.deleteProperty(data.getLSID(), prop.getPropertyURI(), container, protocol.getContainer());
@@ -1942,7 +1942,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
     @Override
     public void beforeDeleteData(List<ExpData> data, User user)
     {
-        List<Integer> ids = new ArrayList<>();
+        List<Long> ids = new ArrayList<>();
         data.forEach(d -> ids.add(d.getRowId()));
         ListUtils.partition(ids, DELETE_BATCH_SIZE).forEach(this::deleteDatas);
     }
@@ -1951,7 +1951,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
      * Delete all exclusions for a set of Ids
      * @param dataIds Set of Ids to remove exclusions for
      */
-    private void cleanUpExclusions(List<Integer> dataIds, final SqlExecutor executor)
+    private void cleanUpExclusions(List<Long> dataIds, final SqlExecutor executor)
     {
         SQLFragment idSQL = new SQLFragment();
         OntologyManager.getTinfoObject().getSqlDialect().appendInClauseSql(idSQL, dataIds);
@@ -1971,7 +1971,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
                 " WHERE RowId ").append(idSQL).append("))"));
     }
 
-    private void deleteDatas(List<Integer> dataIds)
+    private void deleteDatas(List<Long> dataIds)
     {
         SQLFragment idSQL = new SQLFragment();
         OntologyManager.getTinfoObject().getSqlDialect().appendInClauseSql(idSQL, dataIds);
@@ -2051,7 +2051,7 @@ public class LuminexDataHandler extends AbstractExperimentDataHandler implements
         Set<String> titrations = parser.getTitrations();
 
         // either the run's RowId (for the re-run transform script case) or the replaced run's RowId (in the re-import run case)
-        Integer runId = LuminexManager.get().getRunRowIdForUploadContext(run, ((AssayUploadXarContext)context).getContext());
+        Long runId = LuminexManager.get().getRunRowIdForUploadContext(run, ((AssayUploadXarContext)context).getContext());
 
         Set<String> excludedWells = LuminexManager.get().getWellExclusionKeysForRun(runId, protocol, info.getContainer(), info.getUser());
 

--- a/luminex/src/org/labkey/luminex/LuminexExclusionPipelineJob.java
+++ b/luminex/src/org/labkey/luminex/LuminexExclusionPipelineJob.java
@@ -33,7 +33,7 @@ public class LuminexExclusionPipelineJob extends PipelineJob
 {
     private LuminexSaveExclusionsForm _form;
     private LuminexManager.ExclusionType _exclusionType;
-    private Integer _runId;
+    private Long _runId;
 
     private transient AssayProvider _assayProvider;
     private transient ExpRun _run;

--- a/luminex/src/org/labkey/luminex/LuminexManager.java
+++ b/luminex/src/org/labkey/luminex/LuminexManager.java
@@ -15,9 +15,11 @@
  */
 package org.labkey.luminex;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -133,7 +135,7 @@ public class LuminexManager
             }
 
             @Override
-            public Map<String, Object> getRowMap(LuminexSingleExclusionCommand form, Integer runId, boolean keysOnly)
+            public Map<String, Object> getRowMap(LuminexSingleExclusionCommand form, Long runId, boolean keysOnly)
             {
                 Map<String, Object> row = new HashMap<>();
                 if (!keysOnly)
@@ -180,7 +182,7 @@ public class LuminexManager
             }
 
             @Override
-            public Map<String, Object> getRowMap(LuminexSingleExclusionCommand form, Integer runId, boolean keysOnly)
+            public Map<String, Object> getRowMap(LuminexSingleExclusionCommand form, Long runId, boolean keysOnly)
             {
                 Map<String, Object> row = new HashMap<>();
                 if (!keysOnly)
@@ -215,7 +217,7 @@ public class LuminexManager
             }
 
             @Override
-            public Map<String, Object> getRowMap(LuminexSingleExclusionCommand form, Integer runId, boolean keysOnly)
+            public Map<String, Object> getRowMap(LuminexSingleExclusionCommand form, Long runId, boolean keysOnly)
             {
                 Map<String, Object> row = new HashMap<>();
                 if (!keysOnly)
@@ -246,7 +248,7 @@ public class LuminexManager
             }
 
             @Override
-            public Map<String, Object> getRowMap(LuminexSingleExclusionCommand form, Integer runId, boolean keysOnly)
+            public Map<String, Object> getRowMap(LuminexSingleExclusionCommand form, Long runId, boolean keysOnly)
             {
                 Map<String, Object> row = new HashMap<>();
                 if (!keysOnly)
@@ -272,10 +274,10 @@ public class LuminexManager
 
         public abstract String getTableName();
         public abstract String getInfo(List<LuminexSingleExclusionCommand> commands);
-        public abstract Map<String, Object> getRowMap(LuminexSingleExclusionCommand form, Integer runId, boolean keysOnly);
+        public abstract Map<String, Object> getRowMap(LuminexSingleExclusionCommand form, Long runId, boolean keysOnly);
     }
 
-    public Analyte[] getAnalytes(int dataRowId)
+    public Analyte[] getAnalytes(long dataRowId)
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("DataId"), dataRowId);
         Sort sort = new Sort("RowId");
@@ -296,33 +298,33 @@ public class LuminexManager
         return analytes;
     }
 
-    public long getExclusionCount(int rowId)
+    public long getExclusionCount(long rowId)
     {
         long exclusionCount = new TableSelector(LuminexProtocolSchema.getTableInfoRunExclusion(), new SimpleFilter(FieldKey.fromParts("RunId"), rowId), null).getRowCount();
         exclusionCount += new TableSelector(LuminexProtocolSchema.getTableInfoWellExclusion(), new SimpleFilter(FieldKey.fromParts("DataId", "RunId"), rowId), null).getRowCount();
         return exclusionCount;
     }
 
-    private Map<Integer, ExpData> getReplacementInputMap(ExpProtocol protocol, ExpRun replacedRun, ExpRun run)
+    private Map<Long, ExpData> getReplacementInputMap(ExpProtocol protocol, ExpRun replacedRun, ExpRun run)
     {
         //Map old data inputs to new based on dataFileHeaderKey
         //NOTE: exclusions in renamed/new files will be dropped
-        Map<String, Integer> oldInputs = new HashMap<>();
-        Map<Integer, ExpData> inputIdMap = new HashMap<>(); //key: oldId
+        Map<String, Long> oldInputs = new HashMap<>();
+        Map<Long, ExpData> inputIdMap = new LongHashMap<>(); //key: oldId
         replacedRun.getDataOutputs().forEach(o ->  {
             oldInputs.put(getDataFileHeaderKey(protocol, o), o.getRowId());
         });
         run.getDataOutputs().stream()
                 .filter(newFile -> oldInputs.containsKey(getDataFileHeaderKey(protocol, newFile)))
                 .forEach( newFile -> {
-                    Integer oldId = oldInputs.get(getDataFileHeaderKey(protocol, newFile));
+                    Long oldId = MapUtils.getLong(oldInputs, getDataFileHeaderKey(protocol, newFile));
                     inputIdMap.put(oldId, newFile);
                 });
 
         return inputIdMap;
     }
 
-    private LuminexSingleExclusionCommand generateExclusionCommands(Map<String, Object> oldExclusion, Integer dataFileId)
+    private LuminexSingleExclusionCommand generateExclusionCommands(Map<String, Object> oldExclusion, Long dataFileId)
     {
         LuminexSingleExclusionCommand command = new LuminexSingleExclusionCommand();
         command.setCommand("insert");
@@ -338,7 +340,7 @@ public class LuminexManager
         return command;
     }
 
-    private Collection<Map<String, Object>> getWellExclusions(Set<Integer> dataIds)
+    private Collection<Map<String, Object>> getWellExclusions(Set<Long> dataIds)
     {
         if(dataIds == null || dataIds.isEmpty())
             return null;
@@ -361,7 +363,7 @@ public class LuminexManager
         return new SqlSelector(getSchema(), sql).getMapCollection();
     }
 
-    private LuminexSingleExclusionCommand generateRunExclusionCommands(Map<Integer, ExpData> inputIdMap, Map<String, Analyte> analyteMap, int replacedRunId)
+    private LuminexSingleExclusionCommand generateRunExclusionCommands(Map<Long, ExpData> inputIdMap, Map<String, Analyte> analyteMap, long replacedRunId)
     {
         Collection<Map<String, Object>> exclusions = getRunExclusions(inputIdMap.keySet(), replacedRunId);
 
@@ -391,7 +393,7 @@ public class LuminexManager
         return !command.getAnalyteRowIds().isEmpty() ? command : null;
     }
 
-    private Collection<Map<String,Object>> getRunExclusions(Set<Integer> integers, int replacedRunId)
+    private Collection<Map<String,Object>> getRunExclusions(Set<Long> integers, long replacedRunId)
     {
         //Get full list of exclusions by analyte
         SQLFragment sql = new SQLFragment();
@@ -407,7 +409,7 @@ public class LuminexManager
         return new SqlSelector(getSchema(), sql).getMapCollection();
     }
 
-    private Collection<LuminexSingleExclusionCommand> generateWellExclusionCommands(Integer newRunId, LuminexRunContext context, Map<Integer, ExpData> inputIdMap, Map<String, Analyte> analyteMap)
+    private Collection<LuminexSingleExclusionCommand> generateWellExclusionCommands(Long newRunId, LuminexRunContext context, Map<Long, ExpData> inputIdMap, Map<String, Analyte> analyteMap)
     {
         Collection<Map<String, Object>> exclusions = getWellExclusions(inputIdMap.keySet());
         if(exclusions == null)
@@ -465,7 +467,7 @@ public class LuminexManager
         return replacementCommands.values();
     }
 
-    public Long getRetainedRunExclusionCount(Integer replacedRunId, Set<String> analyteNames)
+    public Long getRetainedRunExclusionCount(Long replacedRunId, Set<String> analyteNames)
     {
         SQLFragment sql = new SQLFragment();
         sql.append( "SELECT COUNT(DISTINCT re.RunId) FROM ")
@@ -482,7 +484,7 @@ public class LuminexManager
         return new SqlSelector(LuminexProtocolSchema.getSchema(), sql).getObject(Long.class);
     }
 
-    public Collection<WellExclusion> getRetainedWellExclusions(Integer replacedRunId)
+    public Collection<WellExclusion> getRetainedWellExclusions(Long replacedRunId)
     {
         SQLFragment sql = new SQLFragment();
         sql.append( "SELECT opvRSN.StringValue AS ReaderSerialNumber, opvAD.DateTimeValue AS AcquisitionDate, ")
@@ -519,7 +521,7 @@ public class LuminexManager
     public void retainExclusions(LuminexRunContext uploadContext, ExpRun replacedRun, ExpRun run) throws ValidationException
     {
         //Map existing Files & analytes to new run
-        Map<Integer, ExpData> inputIdMap = getReplacementInputMap(uploadContext.getProtocol(), replacedRun, run);
+        Map<Long, ExpData> inputIdMap = getReplacementInputMap(uploadContext.getProtocol(), replacedRun, run);
         Map<String, Analyte> analyteMap = getAnalyteMap(replacedRun, run);
 
         Collection<LuminexSingleExclusionCommand> wellExclusionCommands = generateWellExclusionCommands(run.getRowId(), uploadContext, inputIdMap, analyteMap);
@@ -565,7 +567,7 @@ public class LuminexManager
         return results;
     }
 
-    public void createExclusions(User user, Container c, Collection<LuminexSingleExclusionCommand> commands, Integer runId,
+    public void createExclusions(User user, Container c, Collection<LuminexSingleExclusionCommand> commands, Long runId,
                                  @Nullable ExclusionType baseExclusionType, ExpProtocol protocol, AssayProvider assayProvider,
                                  boolean rerunTransform, Logger logger)
     throws SQLException, QueryUpdateServiceException, BatchValidationException, DuplicateKeyException, InvalidKeyException
@@ -641,7 +643,7 @@ public class LuminexManager
         }
     }
 
-    public Integer getRunRowIdForUploadContext(ExpRun run, AssayRunUploadContext context)
+    public Long getRunRowIdForUploadContext(ExpRun run, AssayRunUploadContext context)
     {
         //If not a rerun just use current run's id
         if (context.getReRunId() == null)
@@ -652,12 +654,12 @@ public class LuminexManager
             run.getRowId(); //Else use current runId
     }
 
-    public Set<String> getWellExclusionKeysForRun(Integer runId, ExpProtocol protocol, Container container, User user)
+    public Set<String> getWellExclusionKeysForRun(Long runId, ExpProtocol protocol, Container container, User user)
     {
         return getWellKeysForRun(runId, protocol, container, user, true);
     }
 
-    private Set<String> getWellKeysForRun(Integer runId, ExpProtocol protocol, Container container, User user, boolean onlyExcludedWells)
+    private Set<String> getWellKeysForRun(Long runId, ExpProtocol protocol, Container container, User user, boolean onlyExcludedWells)
     {
         Set<String> excludedWellKeys = new HashSet<>();
 

--- a/luminex/src/org/labkey/luminex/LuminexManager.java
+++ b/luminex/src/org/labkey/luminex/LuminexManager.java
@@ -15,7 +15,7 @@
  */
 package org.labkey.luminex;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;

--- a/luminex/src/org/labkey/luminex/LuminexManager.java
+++ b/luminex/src/org/labkey/luminex/LuminexManager.java
@@ -420,7 +420,7 @@ public class LuminexManager
         //Map existing exclusions to new input files
         exclusions.forEach(exclusion ->
         {
-            Integer dataId = (Integer)exclusion.get("DataId");
+            Long dataId = MapUtils.getLong(exclusion,"DataId");
             String analyteName = (String)exclusion.get("AnalyteName");
             ExpData file = inputIdMap.get(dataId);
             Analyte newAnalyte = analyteMap.get(analyteName);

--- a/luminex/src/org/labkey/luminex/LuminexReplicate.java
+++ b/luminex/src/org/labkey/luminex/LuminexReplicate.java
@@ -25,7 +25,7 @@ public class LuminexReplicate
 {
     private final String _description;
     private final Double _dilution;
-    private final int _dataId;
+    private final long _dataId;
     private Double _expConc;
     private String _type;
 
@@ -55,7 +55,7 @@ public class LuminexReplicate
         return _dilution;
     }
 
-    public int getDataId()
+    public long getDataId()
     {
         return _dataId;
     }
@@ -92,7 +92,7 @@ public class LuminexReplicate
     {
         int result = _description != null ? _description.hashCode() : 0;
         result = 31 * result + (_dilution != null ? _dilution.hashCode() : 0);
-        result = 31 * result + _dataId;
+        result = 31 * result + (int)_dataId;
         result = 31 * result + (_expConc != null ? _expConc.hashCode() : 0);
         result = 31 * result + (_type != null ? _type.hashCode() : 0);
         return result;

--- a/luminex/src/org/labkey/luminex/LuminexRunAsyncContext.java
+++ b/luminex/src/org/labkey/luminex/LuminexRunAsyncContext.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.util.PropertiesUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.assay.pipeline.AssayRunAsyncContext;
+import org.labkey.api.collections.StringHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.property.DomainProperty;
@@ -42,10 +43,10 @@ import java.util.Set;
 public class LuminexRunAsyncContext extends AssayRunAsyncContext<LuminexAssayProvider> implements LuminexRunContext
 {
     private String[] _analyteNames;
-    private final Map<String, Map<Integer, String>> _analytePropertiesById = new HashMap<>();
-    private final Map<String, Map<String, String>> _analyteColumnPropertiesByName = new HashMap<>();
-    private final Map<String, Map<String, String>> _analytePropertiesByName = new HashMap<>();
-    private final Map<String, Set<String>> _titrationsByAnalyte = new HashMap<>();
+    private final Map<String, Map<Integer, String>> _analytePropertiesById = new StringHashMap<>();
+    private final Map<String, Map<String, String>> _analyteColumnPropertiesByName = new StringHashMap<>();
+    private final Map<String, Map<String, String>> _analytePropertiesByName = new StringHashMap<>();
+    private final Map<String, Set<String>> _titrationsByAnalyte = new StringHashMap<>();
     private List<Titration> _titrations;
     private List<SinglePointControl> _singlePointControls;
     private Boolean _retainExclusions;
@@ -146,7 +147,7 @@ public class LuminexRunAsyncContext extends AssayRunAsyncContext<LuminexAssayPro
     {
         if (_analyteProperties == null)
         {
-            _analyteProperties = new HashMap<>();
+            _analyteProperties = new StringHashMap<>();
         }
         Map<DomainProperty, String> result = _analyteProperties.get(analyteName);
         if (result == null)
@@ -167,7 +168,7 @@ public class LuminexRunAsyncContext extends AssayRunAsyncContext<LuminexAssayPro
     {
         if (_analyteColumnProperties == null)
         {
-            _analyteColumnProperties = new HashMap<>();
+            _analyteColumnProperties = new StringHashMap<>();
         }
         Map<ColumnInfo, String> result = _analyteColumnProperties.get(analyteName);
         if (result == null)
@@ -219,7 +220,7 @@ public class LuminexRunAsyncContext extends AssayRunAsyncContext<LuminexAssayPro
     /** Convert to a map that can be serialized - ColumnInfo can't be */
     private Map<String, String> convertDomainsToNames(Map<DomainProperty, String> properties)
     {
-        Map<String, String> result = new HashMap<>();
+        Map<String, String> result = new StringHashMap<>();
         for (Map.Entry<DomainProperty, String> entry : properties.entrySet())
         {
             result.put(entry.getKey().getName(), entry.getValue());
@@ -229,7 +230,7 @@ public class LuminexRunAsyncContext extends AssayRunAsyncContext<LuminexAssayPro
 
     private Map<String, String> convertColumnPropertiesToNames(Map<ColumnInfo, String> properties)
     {
-        Map<String, String> result = new HashMap<>();
+        Map<String, String> result = new StringHashMap<>();
         for (Map.Entry<ColumnInfo, String> entry : properties.entrySet())
         {
             result.put(entry.getKey().getName(), entry.getValue());

--- a/luminex/src/org/labkey/luminex/LuminexRunCreator.java
+++ b/luminex/src/org/labkey/luminex/LuminexRunCreator.java
@@ -67,7 +67,7 @@ public class LuminexRunCreator extends DefaultAssayRunCreator<LuminexAssayProvid
             List<ExpData> outputs = run.getDataOutputs();
             for (ExpData output : outputs)
             {
-                int dataId = output.getRowId();
+                var dataId = output.getRowId();
 
                 for (Analyte analyte : LuminexManager.get().getAnalytes(dataId))
                 {

--- a/luminex/src/org/labkey/luminex/LuminexSaveExclusionsForm.java
+++ b/luminex/src/org/labkey/luminex/LuminexSaveExclusionsForm.java
@@ -37,7 +37,7 @@ public class LuminexSaveExclusionsForm implements ApiJsonForm
 {
     private Integer _assayId;
     private String _tableName;
-    private Integer _runId;
+    private Long _runId;
 
     private final List<LuminexSingleExclusionCommand> _commands = new ArrayList<>();
 
@@ -55,7 +55,7 @@ public class LuminexSaveExclusionsForm implements ApiJsonForm
 
         _assayId = getIntPropIfExists(json, "assayId");
         _tableName = json.optString("tableName", null);
-        _runId = getIntPropIfExists(json, "runId");
+        _runId = getLongPropIfExists(json, "runId");
 
         JSONArray commands = json.getJSONArray("commands");
         for (int i = 0; i < commands.length(); i++)
@@ -64,7 +64,7 @@ public class LuminexSaveExclusionsForm implements ApiJsonForm
             LuminexSingleExclusionCommand command = new LuminexSingleExclusionCommand();
             command.setCommand(commandJSON.optString("command", null));
             command.setKey(getIntPropIfExists(commandJSON, "key"));
-            command.setDataId(getIntPropIfExists(commandJSON, "dataId"));
+            command.setDataId(getLongPropIfExists(commandJSON, "dataId"));
             command.setDescription(commandJSON.optString("description", null));
             command.setType(commandJSON.optString("type", null));
             command.setDilution(getDoublePropIfExists(commandJSON, "dilution"));
@@ -86,7 +86,7 @@ public class LuminexSaveExclusionsForm implements ApiJsonForm
         return _tableName;
     }
 
-    public Integer getRunId()
+    public Long getRunId()
     {
         return _runId;
     }
@@ -109,6 +109,11 @@ public class LuminexSaveExclusionsForm implements ApiJsonForm
     private Integer getIntPropIfExists(JSONObject json, String propName)
     {
         return json.has(propName) ? json.getInt(propName) : null;
+    }
+
+    private Long getLongPropIfExists(JSONObject json, String propName)
+    {
+        return json.has(propName) ? json.getLong(propName) : null;
     }
 
     private Double getDoublePropIfExists(JSONObject json, String propName)

--- a/luminex/src/org/labkey/luminex/LuminexSingleExclusionCommand.java
+++ b/luminex/src/org/labkey/luminex/LuminexSingleExclusionCommand.java
@@ -30,7 +30,7 @@ public class LuminexSingleExclusionCommand
 {
     private String _command;
     private Integer _key;
-    private Integer _dataId;
+    private Long _dataId;
     private String _description;
     private Double _dilution;
     private String _type;
@@ -72,12 +72,12 @@ public class LuminexSingleExclusionCommand
         _key = key;
     }
 
-    public Integer getDataId()
+    public Long getDataId()
     {
         return _dataId;
     }
 
-    public void setDataId(Integer dataId)
+    public void setDataId(Long dataId)
     {
         _dataId = dataId;
     }

--- a/luminex/src/org/labkey/luminex/LuminexUnitTestContext.java
+++ b/luminex/src/org/labkey/luminex/LuminexUnitTestContext.java
@@ -261,7 +261,7 @@ public class LuminexUnitTestContext extends AssayRunUploadForm<LuminexAssayProvi
         mock.checking(new Expectations()
         {{
                 allowing(expProtocol).getRowId();
-                will(returnValue(100));
+                will(returnValue(100L));
                 allowing(expProtocol).getName();
                 will(returnValue(AssayRunAsyncContext.UNIT_TESTING_PROTOCOL_NAME));
          }});

--- a/luminex/src/org/labkey/luminex/LuminexUploadWizardAction.java
+++ b/luminex/src/org/labkey/luminex/LuminexUploadWizardAction.java
@@ -490,7 +490,7 @@ public class LuminexUploadWizardAction extends UploadWizardAction<LuminexRunUplo
 
     private int getRetainedWellExclusions(LuminexRunUploadForm form) throws ExperimentException
     {
-        Collection<WellExclusion> notRetained = LuminexManager.get().getRetainedWellExclusions(form.getReRun().getRowId()         );
+        Collection<WellExclusion> notRetained = LuminexManager.get().getRetainedWellExclusions(form.getReRun().getRowId());
 
         //Get dataFileHeaderKey from the Run excel header property
         LuminexExcelParser parser = form.getParser();

--- a/luminex/src/org/labkey/luminex/model/AbstractAnalyteQCFlag.java
+++ b/luminex/src/org/labkey/luminex/model/AbstractAnalyteQCFlag.java
@@ -23,7 +23,7 @@ public abstract class AbstractAnalyteQCFlag extends ExpQCFlag
 
     public AbstractAnalyteQCFlag() {}
 
-    public AbstractAnalyteQCFlag(int runId, String flagType, String description, int analyte)
+    public AbstractAnalyteQCFlag(long runId, String flagType, String description, int analyte)
     {
         super(runId, flagType, description);
         setAnalyte(analyte);

--- a/luminex/src/org/labkey/luminex/model/AbstractLuminexControl.java
+++ b/luminex/src/org/labkey/luminex/model/AbstractLuminexControl.java
@@ -15,8 +15,6 @@
  */
 package org.labkey.luminex.model;
 
-import org.labkey.luminex.model.Titration;
-
 import java.io.Serializable;
 
 /**
@@ -26,7 +24,7 @@ import java.io.Serializable;
 public abstract class AbstractLuminexControl implements Serializable
 {
     private int _rowId;
-    private int _runId;
+    private long _runId;
     private String _name;
 
     public AbstractLuminexControl() {}
@@ -47,12 +45,12 @@ public abstract class AbstractLuminexControl implements Serializable
         _rowId = rowId;
     }
 
-    public int getRunId()
+    public long getRunId()
     {
         return _runId;
     }
 
-    public void setRunId(int runId)
+    public void setRunId(long runId)
     {
         _runId = runId;
     }

--- a/luminex/src/org/labkey/luminex/model/AbstractLuminexControlAnalyte.java
+++ b/luminex/src/org/labkey/luminex/model/AbstractLuminexControlAnalyte.java
@@ -78,7 +78,7 @@ public abstract class AbstractLuminexControlAnalyte implements Serializable
         return analyte;
     }
 
-    public ExpRun getRun(int rowId)
+    public ExpRun getRun(long rowId)
     {
         ExpRun run = ExperimentService.get().getExpRun(rowId);
         if (run == null)

--- a/luminex/src/org/labkey/luminex/model/Analyte.java
+++ b/luminex/src/org/labkey/luminex/model/Analyte.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 */
 public class Analyte
 {
-    private int _dataId;
+    private long _dataId;
     private String _lsid;
     private String _name;
     private String _beadNumber;
@@ -53,7 +53,7 @@ public class Analyte
         _sheetName = name;
     }
 
-    public int getDataId()
+    public long getDataId()
     {
         return _dataId;
     }
@@ -63,7 +63,7 @@ public class Analyte
         return _name;
     }
 
-    public void setDataId(int dataId)
+    public void setDataId(long dataId)
     {
         _dataId = dataId;
     }

--- a/luminex/src/org/labkey/luminex/model/AnalyteSinglePointControlQCFlag.java
+++ b/luminex/src/org/labkey/luminex/model/AnalyteSinglePointControlQCFlag.java
@@ -29,7 +29,7 @@ public class AnalyteSinglePointControlQCFlag extends AbstractAnalyteQCFlag
         super();
     }
 
-    public AnalyteSinglePointControlQCFlag(int runId, String description, int analyte, int singlePointControl)
+    public AnalyteSinglePointControlQCFlag(long runId, String description, int analyte, int singlePointControl)
     {
         super(runId, LuminexDataHandler.QC_FLAG_SINGLE_POINT_CONTROL_FI_FLAG_TYPE, description, analyte);
         setSinglePointControl(singlePointControl);
@@ -67,7 +67,7 @@ public class AnalyteSinglePointControlQCFlag extends AbstractAnalyteQCFlag
     @Override
     public int hashCode()
     {
-        int result = getRunId();
+        int result = (int)getRunId();
         result = 31 * result + (getFlagType() != null ? getFlagType().hashCode() : 0);
         result = 31 * result + (getDescription() != null ? getDescription().hashCode() : 0);
         result = 31 * result + getAnalyte();

--- a/luminex/src/org/labkey/luminex/model/AnalyteTitrationQCFlag.java
+++ b/luminex/src/org/labkey/luminex/model/AnalyteTitrationQCFlag.java
@@ -25,7 +25,7 @@ public class AnalyteTitrationQCFlag extends AbstractAnalyteQCFlag
 
     public AnalyteTitrationQCFlag() {}
 
-    public AnalyteTitrationQCFlag(int runId, String flagType, String description, int analyte, int titration)
+    public AnalyteTitrationQCFlag(long runId, String flagType, String description, int analyte, int titration)
     {
         super(runId, flagType, description, analyte);
         setTitration(titration);
@@ -62,7 +62,7 @@ public class AnalyteTitrationQCFlag extends AbstractAnalyteQCFlag
     @Override
     public int hashCode()
     {
-        int result = getRunId();
+        int result = (int)getRunId();
         result = 31 * result + (getFlagType() != null ? getFlagType().hashCode() : 0);
         result = 31 * result + (getDescription() != null ? getDescription().hashCode() : 0);
         result = 31 * result + getAnalyte();

--- a/luminex/src/org/labkey/luminex/model/CVQCFlag.java
+++ b/luminex/src/org/labkey/luminex/model/CVQCFlag.java
@@ -24,13 +24,13 @@ import org.labkey.api.exp.ExpQCFlag;
 public class CVQCFlag extends ExpQCFlag
 {
     private int _analyte;
-    private int _dataId;
+    private long _dataId;
     private String _wellType;
     private String _wellDescription;
 
     public CVQCFlag() {}
 
-    public CVQCFlag(int runId, String flagType, String description, int analyte, int dataId, String wellType, String wellDescription)
+    public CVQCFlag(long runId, String flagType, String description, int analyte, long dataId, String wellType, String wellDescription)
     {
         super(runId, flagType, description);
         setAnalyte(analyte);
@@ -51,12 +51,12 @@ public class CVQCFlag extends ExpQCFlag
         setIntKey1(analyte);
     }
 
-    public int getDataId()
+    public long getDataId()
     {
         return _dataId;
     }
 
-    public void setDataId(int dataId)
+    public void setDataId(long dataId)
     {
         _dataId = dataId;
         setIntKey2(dataId);
@@ -111,11 +111,11 @@ public class CVQCFlag extends ExpQCFlag
     @Override
     public int hashCode()
     {
-        int result = getRunId();
+        int result = (int)getRunId();
         result = 31 * result + (getFlagType() != null ? getFlagType().hashCode() : 0);
         result = 31 * result + (getDescription() != null ? getDescription().hashCode() : 0);
         result = 31 * result + _analyte;
-        result = 31 * result + _dataId;
+        result = 31 * result + (int)_dataId;
         result = 31 * result + (_wellType != null ? _wellType.hashCode() : 0);
         result = 31 * result + (_wellDescription != null ? _wellDescription.hashCode() : 0);
         return result;

--- a/luminex/src/org/labkey/luminex/model/GuideSet.java
+++ b/luminex/src/org/labkey/luminex/model/GuideSet.java
@@ -46,7 +46,7 @@ public class GuideSet
     private Integer _modifiedBy;
 
     // uneditable properties
-    private int _protocolId;
+    private long _protocolId;
     private boolean _valueBased;
     private boolean _isTitration;
     private String _controlName;
@@ -82,12 +82,12 @@ public class GuideSet
         _rowId = rowId;
     }
 
-    public int getProtocolId()
+    public long getProtocolId()
     {
         return _protocolId;
     }
 
-    public void setProtocolId(int protocolId)
+    public void setProtocolId(long protocolId)
     {
         _protocolId = protocolId;
     }

--- a/luminex/src/org/labkey/luminex/model/LuminexDataRow.java
+++ b/luminex/src/org/labkey/luminex/model/LuminexDataRow.java
@@ -65,7 +65,7 @@ public class LuminexDataRow
     private String _concInRangeString;
     private Double _concInRange;
     private String _concInRangeOORIndicator;
-    private int _data;
+    private long _data;
     private Double _dilution;
     private String _dataRowGroup;
     private String _ratio;
@@ -80,7 +80,7 @@ public class LuminexDataRow
 
     /** Unfortunate to have these denormalized values here, but required for acceptable query performance */
     private Container _container;
-    private int _protocol;
+    private long _protocol;
 
     // Extra properties that aren't stored directly in the database
     private String _dataFile;
@@ -294,12 +294,12 @@ public class LuminexDataRow
         _concInRangeOORIndicator = concInRangeOORIndicator;
     }
 
-    public void setData(int data)
+    public void setData(long data)
     {
         _data = data;
     }
 
-    public int getData()
+    public long getData()
     {
         return _data;
     }
@@ -474,12 +474,12 @@ public class LuminexDataRow
         _container = container;
     }
 
-    public int getProtocol()
+    public long getProtocol()
     {
         return _protocol;
     }
 
-    public void setProtocol(int protocol)
+    public void setProtocol(long protocol)
     {
         _protocol = protocol;
     }

--- a/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
@@ -122,7 +122,7 @@ public class AnalyteSinglePointControlTable extends AbstractLuminexTable
                 @Override
                 public void renderGridCellContents(RenderContext ctx, HtmlWriter out)
                 {
-                    int protocolId = schema.getProtocol().getRowId();
+                    long protocolId = schema.getProtocol().getRowId();
                     int analyte = (int)ctx.get("analyte");
                     int singlePointControl = (int)ctx.get("singlePointControl");
                     String onClickPattern = "LABKEY.LeveyJenningsPlotHelper.getLeveyJenningsPlotWindow(%d,%d,%d,'%s','SinglePoint');";

--- a/luminex/src/org/labkey/luminex/query/AnalyteTitrationTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteTitrationTable.java
@@ -122,7 +122,7 @@ public class AnalyteTitrationTable extends AbstractCurveFitPivotTable
                 @Override
                 public void renderGridCellContents(RenderContext ctx, HtmlWriter out)
                 {
-                    int protocolId = schema.getProtocol().getRowId();
+                    long protocolId = schema.getProtocol().getRowId();
                     int analyte = (int)ctx.get("analyte");
                     int titration = (int)ctx.get("titration");
 

--- a/luminex/src/org/labkey/luminex/query/ExclusionUIDisplayColumn.java
+++ b/luminex/src/org/labkey/luminex/query/ExclusionUIDisplayColumn.java
@@ -49,11 +49,11 @@ public class ExclusionUIDisplayColumn extends DataColumn
     private final FieldKey _runFieldKey;
     private final FieldKey _wellIDKey;
     private final FieldKey _exclusionCommentKey;
-    private final Integer _protocolId;
+    private final Long _protocolId;
     private final Container _container;
     private final User _user;
 
-    public ExclusionUIDisplayColumn(ColumnInfo colInfo, Integer protocolId, Container container, User user)
+    public ExclusionUIDisplayColumn(ColumnInfo colInfo, Long protocolId, Container container, User user)
     {
         super(colInfo);
         _container = container;

--- a/luminex/src/org/labkey/luminex/query/GuideSetTable.java
+++ b/luminex/src/org/labkey/luminex/query/GuideSetTable.java
@@ -554,7 +554,7 @@ public class GuideSetTable extends AbstractCurveFitPivotTable
 
         private void validateProtocol(GuideSet bean) throws ValidationException
         {
-            int protocolId = bean.getProtocolId();
+            long protocolId = bean.getProtocolId();
             if (protocolId == 0)
             {
                 bean.setProtocolId(_protocol.getRowId());

--- a/luminex/src/org/labkey/luminex/query/LuminexProtocolSchema.java
+++ b/luminex/src/org/labkey/luminex/query/LuminexProtocolSchema.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayProtocolSchema;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.query.ResultsQueryView;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.AbstractTableInfo;
 import org.labkey.api.data.ButtonBar;
 import org.labkey.api.data.ColumnInfo;
@@ -628,7 +629,7 @@ public class LuminexProtocolSchema extends AssayProtocolSchema
             @Override
             public void renderGridCellContents(RenderContext ctx, HtmlWriter out)
             {
-                Map<Integer, String> pdfs = new HashMap<>();
+                Map<Integer, String> pdfs = new IntHashMap<>();
                 for (Map.Entry<FieldKey, FieldKey> entry : _pdfColumns.entrySet())
                 {
                     Number rowId = (Number)ctx.get(entry.getKey());

--- a/luminex/test/src/org/labkey/test/util/luminex/LuminexGuideSetHelper.java
+++ b/luminex/test/src/org/labkey/test/util/luminex/LuminexGuideSetHelper.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.util.luminex;
 
-import org.labkey.api.collections.IntHashMap;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
@@ -43,7 +42,7 @@ public class LuminexGuideSetHelper
     private static final Locator GS_WINDOW_LOC =
             Locator.tag("div").withClasses("x-window", "leveljenningsreport");
     public static final String[] GUIDE_SET_ANALYTE_NAMES = {"GS Analyte A", "GS Analyte B"};
-    private static final Map<Integer, String> timestamps = new IntHashMap<>();
+    private static final Map<Integer, String> timestamps = new HashMap<>();
     final LuminexTest _test;
     
     public Calendar TESTDATE = Calendar.getInstance();

--- a/luminex/test/src/org/labkey/test/util/luminex/LuminexGuideSetHelper.java
+++ b/luminex/test/src/org/labkey/test/util/luminex/LuminexGuideSetHelper.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.util.luminex;
 
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
@@ -42,7 +43,7 @@ public class LuminexGuideSetHelper
     private static final Locator GS_WINDOW_LOC =
             Locator.tag("div").withClasses("x-window", "leveljenningsreport");
     public static final String[] GUIDE_SET_ANALYTE_NAMES = {"GS Analyte A", "GS Analyte B"};
-    private static final Map<Integer, String> timestamps = new HashMap<>();
+    private static final Map<Integer, String> timestamps = new IntHashMap<>();
     final LuminexTest _test;
     
     public Calendar TESTDATE = Calendar.getInstance();

--- a/microarray/src/org/labkey/api/study/assay/matrix/AbstractMatrixRunCreator.java
+++ b/microarray/src/org/labkey/api/study/assay/matrix/AbstractMatrixRunCreator.java
@@ -127,7 +127,7 @@ public abstract class AbstractMatrixRunCreator <ProviderType extends AbstractAss
         AssayRunUploadContext<ProviderType> context,
         Map<ExpMaterial, String> inputMaterials,
         @NotNull RemapCache cache,
-        @NotNull Map<Integer, ExpMaterial> materialCache
+        @NotNull Map<Long, ExpMaterial> materialCache
     ) throws ExperimentException
     {
         // Attach the materials found in the matrix file to the run

--- a/microarray/src/org/labkey/microarray/MicroarrayManager.java
+++ b/microarray/src/org/labkey/microarray/MicroarrayManager.java
@@ -65,6 +65,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 public class MicroarrayManager
 {
     private static final MicroarrayManager _instance = new MicroarrayManager();
@@ -146,7 +148,7 @@ public class MicroarrayManager
             row.put("Container", container);
 
             List<Map<String, Object>> results = featureSetUpdateService.insertRows(user, container, Collections.singletonList(row), errors, null, null);
-            return (Integer) results.get(0).get("RowId");
+            return asInteger(results.get(0).get("RowId"));
         }
 
         return null;

--- a/microarray/src/org/labkey/microarray/matrix/ExpressionMatrixAssayProvider.java
+++ b/microarray/src/org/labkey/microarray/matrix/ExpressionMatrixAssayProvider.java
@@ -209,8 +209,8 @@ public class ExpressionMatrixAssayProvider extends AbstractAssayProvider
     {
         return new XarCallbacks()
         {
-            Map<Integer,String> mapRowIdName = null;
-            Map<String,Integer> mapNameRowId = null;
+            Map<Long,String> mapRowIdName = null;
+            Map<String,Long> mapNameRowId = null;
 
             @Override
             public void beforeXarExportRun(ExpRun run, ExperimentRunType xrun)
@@ -221,14 +221,14 @@ public class ExpressionMatrixAssayProvider extends AbstractAssayProvider
                     QuerySchema microarray = DefaultSchema.get(user, container).getSchema("Microarray");
                     if (null == microarray)
                         return;
-                    Map map = QueryService.get().selector(microarray, "SELECT RowId, Name FROM FeatureAnnotationSet")
-                            .getValueMap();
-                    mapRowIdName = (Map<Integer,String>)map;
+                    Map<Long,String> map = QueryService.get().selector(microarray, "SELECT RowId, Name FROM FeatureAnnotationSet")
+                            .getValueMap(Long.class);
+                    mapRowIdName = (Map<Long,String>)map;
                     // Make sure this is really <Integer,String>?
                     if (!mapRowIdName.isEmpty())
                     {
-                        Map.Entry<Integer,String> e = mapRowIdName.entrySet().iterator().next();
-                        assert e.getKey() instanceof Integer;
+                        Map.Entry<Long,String> e = mapRowIdName.entrySet().iterator().next();
+                        assert e.getKey() instanceof Long;
                         assert e.getValue() instanceof String;
                     }
                 }
@@ -253,15 +253,16 @@ public class ExpressionMatrixAssayProvider extends AbstractAssayProvider
                     QuerySchema microarray = DefaultSchema.get(user, container).getSchema("Microarray");
                     if (null == microarray)
                         return;
-                    Map map = QueryService.get().selector(microarray, "SELECT Name, RowId FROM FeatureAnnotationSet")
-                            .getValueMap();
-                    mapNameRowId = (Map<String,Integer>)map;
+                    Map<String,Long> map = new HashMap<>();
+                    QueryService.get().selector(microarray, "SELECT Name, RowId FROM FeatureAnnotationSet")
+                            .forEach(rs -> map.put(rs.getString(1),rs.getLong(2)));
+                    mapNameRowId = map;
                     // Make sure this is really <Integer,String>?
                     if (!mapNameRowId.isEmpty())
                     {
-                        Map.Entry<String,Integer> e = mapNameRowId.entrySet().iterator().next();
+                        Map.Entry<String,Long> e = mapNameRowId.entrySet().iterator().next();
                         assert e.getKey() instanceof String;
-                        assert e.getValue() instanceof Integer;
+                        assert e.getValue() instanceof Long;
                     }
                 }
                 for (SimpleValueType sv : xrun.getProperties().getSimpleValArray())
@@ -269,7 +270,7 @@ public class ExpressionMatrixAssayProvider extends AbstractAssayProvider
                     if (StringUtils.equals(FEATURE_SET_PROPERTY_NAME,sv.getName()))
                     {
                         String featureAnnotationSetName = sv.getStringValue();
-                        Integer featureAnnotationRowId = mapNameRowId.get(featureAnnotationSetName);
+                        Long featureAnnotationRowId = mapNameRowId.get(featureAnnotationSetName);
                         sv.setValueType(SimpleTypeNames.INTEGER);
                         sv.setStringValue(featureAnnotationRowId==null ? null : String.valueOf(featureAnnotationRowId));
                     }

--- a/microarray/src/org/labkey/microarray/matrix/ExpressionMatrixDataHandler.java
+++ b/microarray/src/org/labkey/microarray/matrix/ExpressionMatrixDataHandler.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.RemapCache;
@@ -108,7 +109,7 @@ public class ExpressionMatrixDataHandler extends AbstractMatrixDataHandler
             }
 
             RemapCache cache = new RemapCache();
-            Map<Integer, ExpMaterial> materialCache = new HashMap<>();
+            Map<Long, ExpMaterial> materialCache = new LongHashMap<>();
 
             Map<String, String> runProps = getRunPropertyValues(expRun, runDomain);
 
@@ -149,8 +150,8 @@ public class ExpressionMatrixDataHandler extends AbstractMatrixDataHandler
 
     @Override
     public void insertMatrixData(Container c, User user,
-                                            Map<String, ExpMaterial> samplesMap, DataLoader loader,
-                                            Map<String, String> runProps, Integer dataRowId) throws ExperimentException
+                                 Map<String, ExpMaterial> samplesMap, DataLoader loader,
+                                 Map<String, String> runProps, Long dataRowId) throws ExperimentException
     {
         assert MicroarrayUserSchema.getSchema().getScope().isTransactionActive() : "Should be invoked in the context of an existing transaction";
 
@@ -205,8 +206,8 @@ public class ExpressionMatrixDataHandler extends AbstractMatrixDataHandler
                     if (sampleName.equals(FEATURE_ID_COLUMN_NAME) || row.get(sampleName) == null)
                         continue;
 
-                    statement.setInt(1, dataRowId);
-                    statement.setInt(2, samplesMap.get(sampleName).getRowId());
+                    statement.setLong(1, dataRowId);
+                    statement.setLong(2, samplesMap.get(sampleName).getRowId());
                     statement.setInt(3, featureId);
                     statement.setDouble(4, ((Number) row.get(sampleName)).doubleValue());
                     statement.addBatch();

--- a/ms2/src/org/labkey/ms2/BibliospecSpectrumRenderer.java
+++ b/ms2/src/org/labkey/ms2/BibliospecSpectrumRenderer.java
@@ -19,6 +19,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.util.FileUtil;
@@ -126,9 +128,9 @@ public class BibliospecSpectrumRenderer implements SpectrumRenderer
                      PreparedStatement modificationPS = connection.prepareStatement("INSERT INTO Modifications (RefSpectraId, Position, Mass) VALUES (?, ?, ?)"))
                 {
                     // Run ID->Modification list
-                    Map<Integer, List<MS2Modification>> modificationsCache = new HashMap<>();
+                    Map<Long, List<MS2Modification>> modificationsCache = new LongHashMap<>();
 
-                    Map<Integer, Integer> fractionIdsIncluded = new HashMap<>();
+                    Map<Integer, Integer> fractionIdsIncluded = new IntHashMap<>();
 
                     // Iterate over all of the spectra
                     while (iter.hasNext())
@@ -183,7 +185,7 @@ public class BibliospecSpectrumRenderer implements SpectrumRenderer
                         }
 
                         // Hold on to the index->mass difference info so we can insert into the Modifications table as well
-                        Map<Integer, Float> peptideModifications = new HashMap<>();
+                        Map<Integer, Float> peptideModifications = new IntHashMap<>();
 
                         peptidePS.setString(1, spectrum.getTrimmedSequence());
                         peptidePS.setString(2, getExportModifiedSequence(spectrum.getSequence(), modifications, peptideModifications));
@@ -380,7 +382,7 @@ public class BibliospecSpectrumRenderer implements SpectrumRenderer
             mod3.setMassDiff(17);
             mod3.setSymbol("'");
 
-            HashMap<Integer, Float> peptideMods = new HashMap<>();
+            HashMap<Integer, Float> peptideMods = new IntHashMap<>();
             assertEquals("ABFDSC[+57.0]CC", renderer.getExportModifiedSequence("X.ABFDSC*CC.X", Arrays.asList(mod1), peptideMods));
             assertEquals(Collections.singletonMap(6, 57.0f), peptideMods);
 

--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -362,7 +362,7 @@ public class MS2Controller extends SpringActionController
     }
 
     /** @return URL with .lastFilter if user has configured their default view that way and with a run id */
-    public static ActionURL getShowRunURL(User user, Container c, int runId)
+    public static ActionURL getShowRunURL(User user, Container c, long runId)
     {
         ActionURL url = getShowRunURL(user, c);
         url.addParameter(RunForm.PARAMS.run, String.valueOf(runId));
@@ -2062,9 +2062,9 @@ public class MS2Controller extends SpringActionController
         public boolean handlePost(FormType form, BindException errors) throws RunListException
         {
             ActionURL currentURL = getViewContext().getActionURL();
-            int runListId = RunListCache.cacheSelectedRuns(getRequiresSameType(), form, getViewContext());
+            long runListId = RunListCache.cacheSelectedRuns(getRequiresSameType(), form, getViewContext());
             _successUrl = currentURL.clone();
-            _successUrl.addParameter("runList", Integer.toString(runListId));
+            _successUrl.addParameter("runList", Long.toString(runListId));
 
             return true;
         }
@@ -3322,7 +3322,7 @@ public class MS2Controller extends SpringActionController
         @Override
         public ModelAndView getView(DetailsForm form, BindException errors)
         {
-            int runId;
+            long runId;
             int seqId;
             if (form.run != 0)
             {
@@ -3909,7 +3909,7 @@ public class MS2Controller extends SpringActionController
     public static class SeqRunIdPair
     {
         private int _seqId;
-        private int _run;
+        private long _run;
 
         public void setSeqId(int seqId)
         {
@@ -3921,12 +3921,12 @@ public class MS2Controller extends SpringActionController
             return _seqId;
         }
 
-        public void setRun(int run)
+        public void setRun(long run)
         {
             _run = run;
         }
 
-        public int getRun()
+        public long getRun()
         {
             return _run;
         }
@@ -4585,7 +4585,7 @@ public class MS2Controller extends SpringActionController
             run, expanded, grouping, highestScore
         }
 
-        int run = 0;
+        long run = 0;
         int fraction = 0;
         int tryptic;
         boolean expanded = false;
@@ -4616,12 +4616,12 @@ public class MS2Controller extends SpringActionController
             return this.highestScore;
         }
 
-        public void setRun(int run)
+        public void setRun(long run)
         {
             this.run = run;
         }
 
-        public int getRun()
+        public long getRun()
         {
             return run;
         }

--- a/ms2/src/org/labkey/ms2/MS2Controller.java
+++ b/ms2/src/org/labkey/ms2/MS2Controller.java
@@ -44,6 +44,7 @@ import org.labkey.api.action.SpringActionController;
 import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
+import org.labkey.api.collections.LongArrayList;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerDisplayColumn;
@@ -2572,7 +2573,7 @@ public class MS2Controller extends SpringActionController
                 exportRows = new ArrayList<>();
             }
 
-            List<Long> peptideIds = new ArrayList<>(exportRows.size());
+            List<Long> peptideIds = new LongArrayList(exportRows.size());
 
             // Technically, should only limit this in Excel export case... but there's no way to individually select 65K peptides
             for (int i = 0; i < Math.min(exportRows.size(), ExcelWriter.ExcelDocumentType.xlsx.getMaxRows()); i++)

--- a/ms2/src/org/labkey/ms2/MS2Importer.java
+++ b/ms2/src/org/labkey/ms2/MS2Importer.java
@@ -54,6 +54,8 @@ import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 /**
  * User: arauch
  * Date: Aug 18, 2005
@@ -297,7 +299,7 @@ public abstract class MS2Importer
         runMap.put("Type", getType());    // TODO: Change how we handle type: For pepXML, this is null at this point... okay for Comet
 
         Map<String,Object> returnMap = Table.insert(_user, MS2Manager.getTableInfoRuns(), runMap);
-        return (Integer)returnMap.get("Run");
+        return asInteger(returnMap.get("Run"));
     }
 
     protected boolean isMzXmlFile(File file)

--- a/ms2/src/org/labkey/ms2/MS2Manager.java
+++ b/ms2/src/org/labkey/ms2/MS2Manager.java
@@ -281,7 +281,7 @@ public class MS2Manager
         return getSchema().getTable("FastaAdmin");
     }
 
-    public static MS2Run getRun(int runId)
+    public static MS2Run getRun(long runId)
     {
         MS2Run run = _getRunFromCache(runId);
 
@@ -463,9 +463,9 @@ public class MS2Manager
         }
     }
 
-    public static List<Integer> getRunIds(List<MS2Run> runs)
+    public static List<Long> getRunIds(List<MS2Run> runs)
     {
-        List<Integer> runIds = new ArrayList<>(runs.size());
+        List<Long> runIds = new ArrayList<>(runs.size());
 
         for (MS2Run run : runs)
             runIds.add(run.getRun());
@@ -497,7 +497,7 @@ public class MS2Manager
         return new SqlSelector(getSchema(), sql, path, c, Boolean.FALSE).getObject(ProteinProphetFile.class);
     }
 
-    public static ProteinProphetFile getProteinProphetFileByRun(int runId)
+    public static ProteinProphetFile getProteinProphetFileByRun(long runId)
     {
         return lookupProteinProphetFile(runId, "Run");
     }
@@ -507,7 +507,7 @@ public class MS2Manager
         return lookupProteinProphetFile(proteinProphetFileId, "RowId");
     }
 
-    private static ProteinProphetFile lookupProteinProphetFile(int id, String columnName)
+    private static ProteinProphetFile lookupProteinProphetFile(long id, String columnName)
     {
         String sql = "SELECT " +
                 getTableInfoProteinProphetFiles() + ".* FROM " +
@@ -640,7 +640,7 @@ public class MS2Manager
         }
     }
 
-    public static RelativeQuantAnalysisSummary getQuantSummaryForRun(int runId)
+    public static RelativeQuantAnalysisSummary getQuantSummaryForRun(long runId)
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("run"), runId);
 
@@ -650,7 +650,7 @@ public class MS2Manager
     /**
      * Return the analysis type for relative quantitation in a given run.
      */
-    public static String getQuantAnalysisType(int runId)
+    public static String getQuantAnalysisType(long runId)
     {
         RelativeQuantAnalysisSummary summary = getQuantSummaryForRun(runId);
         return (null == summary ? null : summary.getAnalysisType());
@@ -659,13 +659,13 @@ public class MS2Manager
     /**
      * Return the algorithm used for relative quantitation in a given run.
      */
-    public static String getQuantAnalysisAlgorithm(int runId)
+    public static String getQuantAnalysisAlgorithm(long runId)
     {
         RelativeQuantAnalysisSummary summary = getQuantSummaryForRun(runId);
         return (null == summary ? null : summary.getAnalysisAlgorithm());
     }
 
-    public static PeptideProphetSummary getPeptideProphetSummary(int runId)
+    public static PeptideProphetSummary getPeptideProphetSummary(long runId)
     {
         PeptideProphetSummary summary = _getPeptideProphetSummaryFromCache(runId);
 
@@ -683,7 +683,7 @@ public class MS2Manager
     // Now, verify DELETE permission on old container(s) and move runs to the new container
     public static void moveRuns(final User user, List<MS2Run> runList, Container newContainer) throws UnauthorizedException
     {
-        List<Integer> runIds = new ArrayList<>(runList.size());
+        List<Long> runIds = new ArrayList<>(runList.size());
 
         for (MS2Run run : runList)
             runIds.add(run.getRun());
@@ -709,7 +709,7 @@ public class MS2Manager
         _removeRunsFromCache(runIds);
     }
 
-    public static void renameRun(int runId, String newDescription)
+    public static void renameRun(long runId, String newDescription)
     {
         if (newDescription == null || newDescription.isEmpty())
             return;
@@ -720,7 +720,7 @@ public class MS2Manager
     }
 
     // For safety, simply mark runs as deleted.  This allows them to be (manually) restored.
-    public static void markAsDeleted(List<Integer> runIds, Container c, User user)
+    public static void markAsDeleted(List<Long> runIds, Container c, User user)
     {
         if (runIds.isEmpty())
             return;
@@ -728,7 +728,7 @@ public class MS2Manager
         // Save these to delete after we've deleted the runs
         List<ExpRun> experimentRunsToDelete = new ArrayList<>();
 
-        for (Integer runId : runIds)
+        for (Long runId : runIds)
         {
             MS2Run run = getRun(runId.intValue());
             if (run != null)
@@ -756,12 +756,12 @@ public class MS2Manager
 
     public static void markAsDeleted(Container c, User user)
     {
-        List<Integer> runIds = new SqlSelector(getSchema(), "SELECT Run FROM " + getTableInfoRuns() + " WHERE Container=?", c).getArrayList(Integer.class);
+        List<Long> runIds = new SqlSelector(getSchema(), "SELECT Run FROM " + getTableInfoRuns() + " WHERE Container=?", c).getArrayList(Long.class);
         markAsDeleted(runIds, c, user);
     }
 
     // pulled out into separate method so could be called by itself from data handlers
-    public static void markDeleted(List<Integer> runIds, Container c)
+    public static void markDeleted(List<Long> runIds, Container c)
     {
         SQLFragment markDeleted = new SQLFragment("UPDATE " + getTableInfoRuns() + " SET ExperimentRunLSID = NULL, Deleted=?, Modified=? ", Boolean.TRUE, new Date());
         SimpleFilter where = SimpleFilter.createContainerFilter(c);
@@ -992,7 +992,7 @@ public class MS2Manager
         executor.execute("DELETE FROM " + getTableInfoProteinProphetFiles() + " WHERE RowId " + rowIdComparison, params);
     }
 
-    public static MS2Fraction[] getFractions(int runId)
+    public static MS2Fraction[] getFractions(long runId)
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("run"), runId);
 
@@ -1144,20 +1144,20 @@ public class MS2Manager
         }
     }
 
-    private static void _addRunToCache(int runId, MS2Run run)
+    private static void _addRunToCache(long runId, MS2Run run)
     {
         RUN_CACHE.put(RUN_CACHE_PREFIX + runId, run);
     }
 
 
-    private static MS2Run _getRunFromCache(int runId)
+    private static MS2Run _getRunFromCache(long runId)
     {
         return RUN_CACHE.get(RUN_CACHE_PREFIX + runId);
     }
 
-    private static void _removeRunsFromCache(List<Integer> runIds)
+    private static void _removeRunsFromCache(List<Long> runIds)
     {
-        for (Integer runId : runIds)
+        for (Long runId : runIds)
             RUN_CACHE.remove(RUN_CACHE_PREFIX + runId);
     }
 
@@ -1168,7 +1168,7 @@ public class MS2Manager
     }
 
 
-    private static PeptideProphetSummary _getPeptideProphetSummaryFromCache(int runId)
+    private static PeptideProphetSummary _getPeptideProphetSummaryFromCache(long runId)
     {
         return PEPTIDE_PROPHET_SUMMARY_CACHE.get(PEPTIDE_PROPHET_SUMMARY_CACHE_PREFIX + runId);
     }
@@ -1521,7 +1521,7 @@ public class MS2Manager
         }
     }
 
-    public static DecoySummaryBean getDecoySummaryForRun(int run, Float desiredFdr)
+    public static DecoySummaryBean getDecoySummaryForRun(long run, Float desiredFdr)
     {
         DbSchema schema = getSchema();
         SQLFragment sql = new SQLFragment("SELECT coalesce(t.targets, 0) targetCount, coalesce(d.decoys,0) decoyCount, coalesce(t.score1, d.score1, 0) scoreThreshold FROM\n")

--- a/ms2/src/org/labkey/ms2/MS2Manager.java
+++ b/ms2/src/org/labkey/ms2/MS2Manager.java
@@ -26,6 +26,7 @@ import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.LongArrayList;
 import org.labkey.api.data.BeanObjectFactory;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -465,7 +466,7 @@ public class MS2Manager
 
     public static List<Long> getRunIds(List<MS2Run> runs)
     {
-        List<Long> runIds = new ArrayList<>(runs.size());
+        List<Long> runIds = new LongArrayList(runs.size());
 
         for (MS2Run run : runs)
             runIds.add(run.getRun());
@@ -683,7 +684,7 @@ public class MS2Manager
     // Now, verify DELETE permission on old container(s) and move runs to the new container
     public static void moveRuns(final User user, List<MS2Run> runList, Container newContainer) throws UnauthorizedException
     {
-        List<Long> runIds = new ArrayList<>(runList.size());
+        List<Long> runIds = new LongArrayList(runList.size());
 
         for (MS2Run run : runList)
             runIds.add(run.getRun());

--- a/ms2/src/org/labkey/ms2/MS2Run.java
+++ b/ms2/src/org/labkey/ms2/MS2Run.java
@@ -42,7 +42,7 @@ public abstract class MS2Run implements Serializable
 
     protected final static String[] EMPTY_STRING_ARRAY = new String[0];
 
-    protected int run;
+    protected long run;
     protected GUID containerId;
     protected String description;
     protected String path;
@@ -240,13 +240,13 @@ public abstract class MS2Run implements Serializable
         return _fastaIds;
     }
 
-    public int getRun()
+    public long getRun()
     {
         return run;
     }
 
 
-    public void setRun(int run)
+    public void setRun(long run)
     {
         this.run = run;
     }

--- a/ms2/src/org/labkey/ms2/MascotDatImporter.java
+++ b/ms2/src/org/labkey/ms2/MascotDatImporter.java
@@ -17,6 +17,7 @@
 package org.labkey.ms2;
 
 import org.apache.logging.log4j.Logger;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.exp.XarContext;
@@ -40,8 +41,8 @@ import java.util.Map;
  */
 public class MascotDatImporter extends PeptideImporter
 {
-    Map<Integer, MascotDatLoader.DatPeptide> _peptides = new HashMap<>();
-    Map<Integer, MascotDatLoader.DatPeptide> _decoyPeptides = new HashMap<>();
+    Map<Integer, MascotDatLoader.DatPeptide> _peptides = new IntHashMap<>();
+    Map<Integer, MascotDatLoader.DatPeptide> _decoyPeptides = new IntHashMap<>();
 
     public MascotDatImporter(User user, Container c, String description, String fullFileName, Logger log, XarContext context)
     {

--- a/ms2/src/org/labkey/ms2/PepXmlExperimentDataHandler.java
+++ b/ms2/src/org/labkey/ms2/PepXmlExperimentDataHandler.java
@@ -181,7 +181,7 @@ public class PepXmlExperimentDataHandler extends AbstractExperimentDataHandler
     }
 
     @Override
-    public void runMoved(ExpData newData, Container container, Container targetContainer, String oldRunLSID, String newRunLSID, User user, int oldDataRowID) throws ExperimentException
+    public void runMoved(ExpData newData, Container container, Container targetContainer, String oldRunLSID, String newRunLSID, User user, long oldDataRowID) throws ExperimentException
     {
         super.runMoved(newData, container, targetContainer, oldRunLSID, newRunLSID, user, oldDataRowID);
         updateRunLSID(newData, container, targetContainer, newRunLSID, user);

--- a/ms2/src/org/labkey/ms2/PeptideProphetGraphs.java
+++ b/ms2/src/org/labkey/ms2/PeptideProphetGraphs.java
@@ -138,7 +138,7 @@ public class PeptideProphetGraphs
         outputChart(response, chart);
     }
 
-    public static void renderObservedVsPPScore(HttpServletResponse response, Container c, int runId, int charge, boolean cumulative) throws IOException, SQLException
+    public static void renderObservedVsPPScore(HttpServletResponse response, Container c, long runId, int charge, boolean cumulative) throws IOException, SQLException
     {
         String chargeSQL = "SELECT count(*) " +
                         "FROM " + MS2Manager.getTableInfoPeptides().getSelectName() + " " +

--- a/ms2/src/org/labkey/ms2/ProteinGroupProteins.java
+++ b/ms2/src/org/labkey/ms2/ProteinGroupProteins.java
@@ -16,6 +16,7 @@
 
 package org.labkey.ms2;
 
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SQLFragment;
@@ -25,7 +26,6 @@ import org.labkey.api.protein.ProteinSchema;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +48,7 @@ public class ProteinGroupProteins
 
     private Map<Integer, List<ProteinSummary>> calculateSummaries(ResultSet rs, String columnName)
     {
-        Map<Integer, List<ProteinSummary>> result = new HashMap<>();
+        Map<Integer, List<ProteinSummary>> result = new IntHashMap<>();
 
         int firstGroupId = Integer.MAX_VALUE;
         int lastGroupId = Integer.MIN_VALUE;

--- a/ms2/src/org/labkey/ms2/ProteinProphetImporter.java
+++ b/ms2/src/org/labkey/ms2/ProteinProphetImporter.java
@@ -223,7 +223,7 @@ public class ProteinProphetImporter
                         "WHERE p.TrimmedPeptide = t.TrimmedPeptide AND p.Charge = t.Charge AND p.Run = ?";
 
                 mergePeptideStmt = connection.prepareStatement(mergePeptideSQL);
-                mergePeptideStmt.setInt(1, run.getRun());
+                mergePeptideStmt.setLong(1, run.getRun());
                 mergePeptideStmt.executeUpdate();
                 log.info("Finished with moving data into ms2.PeptidesMemberships after " + (System.currentTimeMillis() - insertStartTime) + " ms");
 

--- a/ms2/src/org/labkey/ms2/RunListCache.java
+++ b/ms2/src/org/labkey/ms2/RunListCache.java
@@ -53,7 +53,7 @@ public class RunListCache
 
     // We store just the list of run IDs, not the runs themselves. Even though we're
     // just storing the list, we do all error & security checks upfront to alert the user early.
-    public static int cacheSelectedRuns(boolean requireSameType, MS2Controller.RunListForm form, ViewContext ctx) throws RunListException
+    public static long cacheSelectedRuns(boolean requireSameType, MS2Controller.RunListForm form, ViewContext ctx) throws RunListException
     {
         String selectionKey = ctx.getRequest().getParameter(DataRegionSelection.DATA_REGION_SELECTION_KEY);
         if (selectionKey == null)

--- a/ms2/src/org/labkey/ms2/query/MS2Schema.java
+++ b/ms2/src/org/labkey/ms2/query/MS2Schema.java
@@ -20,6 +20,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.action.BaseViewAction;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.AggregateColumnInfo;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
@@ -1176,7 +1177,7 @@ public class MS2Schema extends UserSchema
         }
     }
 
-    private final static Map<Integer, NormalizedProteinGroupsTracker> NORMALIZED_PROTEIN_GROUP_CACHE = new HashMap<>();
+    private final static Map<Integer, NormalizedProteinGroupsTracker> NORMALIZED_PROTEIN_GROUP_CACHE = new IntHashMap<>();
 
     private String ensureNormalizedProteinGroups(int runListId) throws SQLException
     {
@@ -1261,7 +1262,7 @@ public class MS2Schema extends UserSchema
 
         //todo: can we support column ordering that matches the MS2 Runs grid on the dashboard?
         
-        List<Integer> runIds = new ArrayList<>();
+        List<Long> runIds = new ArrayList<>();
         if (_runs != null)
         {
             for (MS2Run run : _runs)
@@ -1390,7 +1391,7 @@ public class MS2Schema extends UserSchema
 
         CrosstabSettings settings = new CrosstabSettings(baseTable);
         SimpleFilter filter = new SimpleFilter();
-        List<Integer> runIds = new ArrayList<>();
+        List<Long> runIds = new ArrayList<>();
         if (_runs != null)
         {
             for (MS2Run run : _runs)

--- a/ms2/src/org/labkey/ms2/query/ProteinGroupTableInfo.java
+++ b/ms2/src/org/labkey/ms2/query/ProteinGroupTableInfo.java
@@ -228,7 +228,7 @@ public class ProteinGroupTableInfo extends FilteredTable<MS2Schema>
                     ActionURL url = new ActionURL(MS2Controller.ShowProteinAction.class, _userSchema.getContainer());
                     if (_runs != null && _runs.size() == 1)
                     {
-                        url.addParameter("run", Integer.toString(_runs.get(0).getRun()));
+                        url.addParameter("run", Long.toString(_runs.get(0).getRun()));
                     }
                     result1.setURL(url.addParameter("proteinGroupId", "${RowId}").addParameter("seqId", "${" + colInfo.getName() + "}"));
                     return result1;

--- a/ms2/src/org/labkey/ms2/reader/SensitivitySummary.java
+++ b/ms2/src/org/labkey/ms2/reader/SensitivitySummary.java
@@ -28,7 +28,7 @@ public class SensitivitySummary
     protected float[] _minProb;
     protected float[] _sensitivity;
     protected float[] _error;
-    private int _runId;
+    private long _runId;
 
     public byte[] getMinProbSeries()
     {
@@ -102,12 +102,12 @@ public class SensitivitySummary
         }
     }
 
-    public int getRun()
+    public long getRun()
     {
         return _runId;
     }
 
-    public void setRun(int runId)
+    public void setRun(long runId)
     {
         _runId = runId;
     }

--- a/ms2/src/org/systemsbiology/jrap/SAX2IndexHandler.java
+++ b/ms2/src/org/systemsbiology/jrap/SAX2IndexHandler.java
@@ -40,8 +40,8 @@
 package org.systemsbiology.jrap;
 
 import java.util.Map;
-import java.util.HashMap;
 
+import org.labkey.api.collections.IntHashMap;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -63,7 +63,7 @@ public final class SAX2IndexHandler extends DefaultHandler
     protected boolean foundScanOffset = false;
 
     /** Data structure to hold index table */
-    Map<Integer, Long> offsets = new HashMap<>();
+    Map<Integer, Long> offsets = new IntHashMap<>();
     private int _currentId;
     private int _maxScan = -1;
 

--- a/nab/src/org/labkey/nab/GetNabRunsAction.java
+++ b/nab/src/org/labkey/nab/GetNabRunsAction.java
@@ -23,6 +23,7 @@ import org.labkey.api.assay.AssayProtocolSchema;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.dilution.DilutionDataHandler;
+import org.labkey.api.collections.LongArrayList;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.Results;
@@ -145,18 +146,18 @@ public class GetNabRunsAction extends ReadOnlyApiAction<GetNabRunsAction.GetNabR
 
         QueryView queryView = QueryView.create(getViewContext(), assaySchema, settings, errors);
         DataView dataView = queryView.createDataView();
-        List<Integer> rowIds = new ArrayList<>();
+        List<Long> rowIds = new LongArrayList();
         try (Results results = dataView.getDataRegion().getResults(dataView.getRenderContext()))
         {
             while (results.next())
-                rowIds.add(results.getInt("RowId"));
+                rowIds.add(results.getLong("RowId"));
         }
         catch (SQLException e)
         {
             throw new RuntimeSQLException(e);
         }
         List<ExpRun> runs = new ArrayList<>();
-        for (Integer rowId : rowIds)
+        for (Long rowId : rowIds)
         {
             ExpRun run = ExperimentService.get().getExpRun(rowId.intValue());
             if (run != null)
@@ -195,7 +196,6 @@ public class GetNabRunsAction extends ReadOnlyApiAction<GetNabRunsAction.GetNabR
         {
             runList.add(new NabRunPropertyMap(dataHandler.getAssayResults(run, form.getViewContext().getUser()),
                     form.isIncludeStats(), form.isIncludeWells(), form.isCalculateNeut(), form.isIncludeFitParameters()));
-
         }
         // Recursively replace all +Infinity, -Infinity, and NaN values with JSON-legal values
         return new ApiSimpleResponse(response);

--- a/nab/src/org/labkey/nab/GetStudyNabGraphURLAction.java
+++ b/nab/src/org/labkey/nab/GetStudyNabGraphURLAction.java
@@ -42,11 +42,11 @@ public class GetStudyNabGraphURLAction extends ReadOnlyApiAction<GraphSelectedFo
     @Override
     public ApiResponse execute(GraphSelectedForm form, BindException errors)
     {
-        Map<Pair<Integer, String>, ExpProtocol> readableIds = NabManager.get().getReadableStudyObjectIds(getContainer(), getUser(), form.getId());
+        Map<Pair<Long, String>, ExpProtocol> readableIds = NabManager.get().getReadableStudyObjectIds(getContainer(), getUser(), form.getId());
 
         StringBuilder objectIdParam = new StringBuilder();
         String sep = "";
-        for (Pair<Integer, String> id : readableIds.keySet())
+        for (Pair<Long, String> id : readableIds.keySet())
         {
             objectIdParam.append(sep).append(id.getKey());
             sep = ",";

--- a/nab/src/org/labkey/nab/GetStudyNabRunsAction.java
+++ b/nab/src/org/labkey/nab/GetStudyNabRunsAction.java
@@ -22,6 +22,7 @@ import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.dilution.DilutionDataHandler;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.security.RequiresPermission;
@@ -41,18 +42,18 @@ import java.util.Set;
 @ApiVersion(10.1)
 public class GetStudyNabRunsAction extends ReadOnlyApiAction<GetStudyNabRunsAction.GetStudyNabRunsForm>
 {
-    Map<Integer, Map<String, Object>> _extraObjectIdProps = new HashMap<>();
+    Map<Long, Map<String, Object>> _extraObjectIdProps = new LongHashMap<>();
 
     public static class GetStudyNabRunsForm extends GetNabRunsBaseForm
     {
-        private int[] _objectIds;
+        private long[] _objectIds;
 
-        public int[] getObjectIds()
+        public long[] getObjectIds()
         {
             return _objectIds;
         }
 
-        public void setObjectIds(int[] objectIds)
+        public void setObjectIds(long[] objectIds)
         {
             _objectIds = objectIds;
         }
@@ -86,10 +87,10 @@ public class GetStudyNabRunsAction extends ReadOnlyApiAction<GetStudyNabRunsActi
 
     protected Collection<ExpRun> getRuns(GetStudyNabRunsForm form, BindException errors)
     {
-        Map<Pair<Integer, String>, ExpProtocol> readableObjectIds = NabManager.get().getReadableStudyObjectIds(getContainer(), getUser(), form.getObjectIds());
+        Map<Pair<Long, String>, ExpProtocol> readableObjectIds = NabManager.get().getReadableStudyObjectIds(getContainer(), getUser(), form.getObjectIds());
         Set<ExpRun> runs = new HashSet<>();
 
-        for (Pair<Integer, String> id : readableObjectIds.keySet())
+        for (Pair<Long, String> id : readableObjectIds.keySet())
         {
             // build up additional properties to associate with the object id
             if (!_extraObjectIdProps.containsKey(id.getKey()))

--- a/nab/src/org/labkey/nab/NabAssayController.java
+++ b/nab/src/org/labkey/nab/NabAssayController.java
@@ -355,7 +355,7 @@ public class NabAssayController extends SpringActionController
 
     public static class NabGraphSelectedBean extends GraphSelectedBean
     {
-        public NabGraphSelectedBean(ViewContext context, ExpProtocol protocol, int[] cutoffs, int[] dataObjectIds, String captionColumn, String chartTitle)
+        public NabGraphSelectedBean(ViewContext context, ExpProtocol protocol, int[] cutoffs, long[] dataObjectIds, String captionColumn, String chartTitle)
         {
             super(context, protocol, cutoffs, dataObjectIds, captionColumn, chartTitle);
         }
@@ -376,9 +376,9 @@ public class NabAssayController extends SpringActionController
                     SimpleFilter existingFilter = (SimpleFilter) view.getRenderContext().getBaseFilter();
                     if (existingFilter != null)
                         filter.addAllClauses(existingFilter);
-                    List<Integer> objectIds = new ArrayList<>(_dataObjectIds.length);
-                    for (int dataObjectId : _dataObjectIds)
-                        objectIds.add(Integer.valueOf(dataObjectId));
+                    List<Long> objectIds = new ArrayList<>(_dataObjectIds.length);
+                    for (long dataObjectId : _dataObjectIds)
+                        objectIds.add(Long.valueOf(dataObjectId));
 
                     filter.addInClause(FieldKey.fromString("RowId"), objectIds);
                     view.getDataRegion().setRecordSelectorValueColumns("RowId");
@@ -400,7 +400,7 @@ public class NabAssayController extends SpringActionController
     public static class NabGraphSelectedAction extends GraphSelectedAction<GraphSelectedForm>
     {
         @Override
-        protected GraphSelectedBean createSelectionBean(ViewContext context, ExpProtocol protocol, int[] cutoffs, int[] dataObjectIds, String caption, String title)
+        protected GraphSelectedBean createSelectionBean(ViewContext context, ExpProtocol protocol, int[] cutoffs, long[] dataObjectIds, String caption, String title)
         {
             return new NabGraphSelectedBean(context, protocol, cutoffs, dataObjectIds, caption, title);
         }

--- a/nab/src/org/labkey/nab/NabAssayController.java
+++ b/nab/src/org/labkey/nab/NabAssayController.java
@@ -73,6 +73,7 @@ import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.LongArrayList;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
@@ -376,7 +377,7 @@ public class NabAssayController extends SpringActionController
                     SimpleFilter existingFilter = (SimpleFilter) view.getRenderContext().getBaseFilter();
                     if (existingFilter != null)
                         filter.addAllClauses(existingFilter);
-                    List<Long> objectIds = new ArrayList<>(_dataObjectIds.length);
+                    List<Long> objectIds = new LongArrayList(_dataObjectIds.length);
                     for (long dataObjectId : _dataObjectIds)
                         objectIds.add(Long.valueOf(dataObjectId));
 

--- a/nab/src/org/labkey/nab/NabAssayProvider.java
+++ b/nab/src/org/labkey/nab/NabAssayProvider.java
@@ -151,10 +151,10 @@ public class NabAssayProvider extends AbstractDilutionAssayProvider<NabRunUpload
     }
 
     @Override
-    public Set<ExpData> getDatasForResultRows(Collection<Integer> rowIds, ExpProtocol protocol, ResolverCache cache)
+    public Set<ExpData> getDatasForResultRows(Collection<Long> rowIds, ExpProtocol protocol, ResolverCache cache)
     {
         Set<ExpData> result = new HashSet<>();
-        for (Integer rowId : rowIds)
+        for (Long rowId : rowIds)
         {
             NabSpecimen nabSpecimen = NabManager.get().getNabSpecimen(rowId);
             if (null != nabSpecimen)
@@ -417,7 +417,7 @@ public class NabAssayProvider extends AbstractDilutionAssayProvider<NabRunUpload
     @Override
     protected void moveAssayResults(List<ExpRun> runs, ExpProtocol protocol, Container sourceContainer, Container targetContainer, User user, AssayMoveData assayMoveData)
     {
-        List<Integer> runRowIds = runs.stream().map(ExpRun::getRowId).toList();
+        List<Long> runRowIds = runs.stream().map(ExpRun::getRowId).toList();
 
         TableInfo wellDataTable = NabManager.getTableInfoWellData();
         SQLFragment updateSql = new SQLFragment("UPDATE ").append(wellDataTable)

--- a/nab/src/org/labkey/nab/NabDataHandler.java
+++ b/nab/src/org/labkey/nab/NabDataHandler.java
@@ -115,7 +115,7 @@ public abstract class NabDataHandler extends DilutionDataHandler
     protected void importRows(ExpData data, ExpRun run, ExpProtocol protocol, DataIteratorBuilder rawData, User user) throws ExperimentException
     {
         Map<Integer, String> cutoffFormats = getCutoffFormats(protocol, run);
-        Map<String, Pair<Integer, String>> wellGroupNameToNabSpecimen = new HashMap<>();
+        Map<String, Pair<Long, String>> wellGroupNameToNabSpecimen = new HashMap<>();
 
         populateDilutionStats(data, run, protocol, rawData, wellGroupNameToNabSpecimen);
         populateWellData(protocol, run, user, cutoffFormats, wellGroupNameToNabSpecimen);
@@ -125,7 +125,7 @@ public abstract class NabDataHandler extends DilutionDataHandler
      * Populates cutoff and AUC information from the passed in raw data
      */
     public void populateDilutionStats(ExpData data, ExpRun run, ExpProtocol protocol, DataIteratorBuilder rawData,
-                                      Map<String, Pair<Integer, String>> wellgroupNameToNabSpecimen) throws ExperimentException
+                                      Map<String, Pair<Long, String>> wellgroupNameToNabSpecimen) throws ExperimentException
     {
         _populateDilutionStats(data, run, protocol, rawData, wellgroupNameToNabSpecimen, true, Collections.emptyList(), Collections.emptyList());
     }
@@ -148,7 +148,7 @@ public abstract class NabDataHandler extends DilutionDataHandler
      * @param cutoffRows if commitData is false, then cutoff data will be returned in this collection
      */
     private void _populateDilutionStats(ExpData data, ExpRun run, ExpProtocol protocol, DataIteratorBuilder rawData,
-                                        Map<String, Pair<Integer, String>> wellGroupNameToNabSpecimen, boolean commitData,
+                                        Map<String, Pair<Long, String>> wellGroupNameToNabSpecimen, boolean commitData,
                                         List<Map<String, Object>> specimenRows, List<Map<String, Object>> cutoffRows) throws ExperimentException
     {
         Container container = run.getContainer();
@@ -206,7 +206,7 @@ public abstract class NabDataHandler extends DilutionDataHandler
                 nabSpecimenEntries.put("VirusLsid", createVirusWellGroupLsid(data, virusWellGroupName));
                 nabSpecimenEntries.put(FIT_PARAMETERS_PROPERTY_NAME, group.get(FIT_PARAMETERS_PROPERTY_NAME));
 
-                int nabRowid = 0;
+                long nabRowid = 0;
                 if (commitData)
                 {
                     nabRowid = NabManager.get().insertNabSpecimenRow(null, nabSpecimenEntries);

--- a/nab/src/org/labkey/nab/NabDataHandler.java
+++ b/nab/src/org/labkey/nab/NabDataHandler.java
@@ -27,6 +27,7 @@ import org.labkey.api.assay.nab.NabSpecimen;
 import org.labkey.api.assay.nab.query.NAbSpecimenTable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.LongArrayList;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
@@ -76,7 +77,7 @@ public abstract class NabDataHandler extends DilutionDataHandler
             return summaries;
 
         Map<Integer, DilutionAssayRun> dataToAssay = new IntHashMap<>();
-        List<Long> nabSpecimenIds = new ArrayList<>(dataObjectIds.length);
+        List<Long> nabSpecimenIds = new LongArrayList(dataObjectIds.length);
         for (long nabSpecimenId : dataObjectIds)
             nabSpecimenIds.add(nabSpecimenId);
         List<NabSpecimen> nabSpecimens = NabManager.get().getNabSpecimens(nabSpecimenIds);

--- a/nab/src/org/labkey/nab/NabDataHandler.java
+++ b/nab/src/org/labkey/nab/NabDataHandler.java
@@ -26,6 +26,7 @@ import org.labkey.api.assay.dilution.DilutionSummary;
 import org.labkey.api.assay.nab.NabSpecimen;
 import org.labkey.api.assay.nab.query.NAbSpecimenTable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
@@ -68,15 +69,15 @@ public abstract class NabDataHandler extends DilutionDataHandler
     }
 
     @Override
-    public Map<DilutionSummary, DilutionAssayRun> getDilutionSummaries(User user, StatsService.CurveFitType fit, int... dataObjectIds) throws ExperimentException
+    public Map<DilutionSummary, DilutionAssayRun> getDilutionSummaries(User user, StatsService.CurveFitType fit, long... dataObjectIds) throws ExperimentException
     {
         Map<DilutionSummary, DilutionAssayRun> summaries = new LinkedHashMap<>();
         if (dataObjectIds == null || dataObjectIds.length == 0)
             return summaries;
 
-        Map<Integer, DilutionAssayRun> dataToAssay = new HashMap<>();
-        List<Integer> nabSpecimenIds = new ArrayList<>(dataObjectIds.length);
-        for (int nabSpecimenId : dataObjectIds)
+        Map<Integer, DilutionAssayRun> dataToAssay = new IntHashMap<>();
+        List<Long> nabSpecimenIds = new ArrayList<>(dataObjectIds.length);
+        for (long nabSpecimenId : dataObjectIds)
             nabSpecimenIds.add(nabSpecimenId);
         List<NabSpecimen> nabSpecimens = NabManager.get().getNabSpecimens(nabSpecimenIds);
         for (NabSpecimen nabSpecimen : nabSpecimens)

--- a/nab/src/org/labkey/nab/NabManager.java
+++ b/nab/src/org/labkey/nab/NabManager.java
@@ -85,7 +85,7 @@ public class NabManager extends AbstractNabManager
         super.deleteRunData(datas);
 
         // Get dataIds that match the ObjectUri and make filter on NabSpecimen
-        Set<Integer> protocolIds = new HashSet<>();
+        Set<Long> protocolIds = new HashSet<>();
         for (ExpData data : datas)
         {
             ExpRun run = data.getRun();
@@ -97,11 +97,11 @@ public class NabManager extends AbstractNabManager
             }
         }
 
-        for (Integer protocolId : protocolIds)
+        for (Long protocolId : protocolIds)
             NabProtocolSchema.clearProtocolFromCutoffCache(protocolId);
     }
 
-    public ExpRun getNAbRunByObjectId(int objectId)
+    public ExpRun getNAbRunByObjectId(long objectId)
     {
         // objectId is really a nabSpecimenId
         TableInfo tableInfo = getSchema().getTable(NAB_SPECIMEN_TABLE_NAME);
@@ -120,7 +120,7 @@ public class NabManager extends AbstractNabManager
      * Returns the readable study dataset rows that correspond to the specified object ID array
      * @return a map of row information to ExpProtocol, where the row information is a pair of row ID and LSID values.
      */
-    public Map<Pair<Integer, String>, ExpProtocol> getReadableStudyObjectIds(Container studyContainer, User user, int[] objectIds)
+    public Map<Pair<Long, String>, ExpProtocol> getReadableStudyObjectIds(Container studyContainer, User user, long[] objectIds)
     {
         if (objectIds == null || objectIds.length == 0)
             throw new IllegalArgumentException("getReadableStudyObjectIds must be passed a non-empty list of object ids.");
@@ -150,12 +150,12 @@ public class NabManager extends AbstractNabManager
             }
         }
 
-        Collection<Integer> allObjectIds = new HashSet<>();
-        for (int objectId : objectIds)
+        Collection<Long> allObjectIds = new HashSet<>();
+        for (long objectId : objectIds)
             allObjectIds.add(objectId);
         SimpleFilter filter = new SimpleFilter(new SimpleFilter.InClause(FieldKey.fromString("RowId"), allObjectIds));
 
-        final Map<Pair<Integer, String>, ExpProtocol> readableObjectIds = new HashMap<>();
+        final Map<Pair<Long, String>, ExpProtocol> readableObjectIds = new HashMap<>();
 
         // For each readable study data table, find any NAb runs that match the requested objectIds, and add them to the run list:
         for (Map.Entry<TableInfo, ExpProtocol> entry : dataTables.entrySet())
@@ -163,7 +163,7 @@ public class NabManager extends AbstractNabManager
             TableInfo dataTable = entry.getKey();
             final ExpProtocol protocol = entry.getValue();
             TableSelector selector = new TableSelector(dataTable, PageFlowUtil.set("RowId", "Lsid"), filter, null);
-            selector.forEach(rs -> readableObjectIds.put(new Pair<>(rs.getInt("RowId"), rs.getString("Lsid")), protocol));
+            selector.forEach(rs -> readableObjectIds.put(new Pair<>(rs.getLong("RowId"), rs.getString("Lsid")), protocol));
         }
         return readableObjectIds;
     }

--- a/nab/src/org/labkey/nab/NabRunPropertyMap.java
+++ b/nab/src/org/labkey/nab/NabRunPropertyMap.java
@@ -52,7 +52,7 @@ public class NabRunPropertyMap extends HashMap<String, Object>
     }
 
     public NabRunPropertyMap(DilutionAssayRun assay, boolean includeStats, boolean includeWells, boolean calculateNeut,
-                             boolean includeFitParameters, Map<Integer, Map<String, Object>> extraObjectIdProps)
+                             boolean includeFitParameters, Map<Long, Map<String, Object>> extraObjectIdProps)
     {
         put("runId", assay.getRun().getRowId());
         put("properties", new PropertyNameMap(assay.getRunProperties()));

--- a/nab/src/org/labkey/nab/StudyNabGraphAction.java
+++ b/nab/src/org/labkey/nab/StudyNabGraphAction.java
@@ -55,7 +55,7 @@ public class StudyNabGraphAction extends SimpleViewAction<GraphSelectedForm>
     @Override
     public ModelAndView getView(GraphSelectedForm graphForm, BindException errors) throws Exception
     {
-        Map<Pair<Integer, String>, ExpProtocol> ids = NabManager.get().getReadableStudyObjectIds(getContainer(), getUser(), graphForm.getId());
+        Map<Pair<Long, String>, ExpProtocol> ids = NabManager.get().getReadableStudyObjectIds(getContainer(), getUser(), graphForm.getId());
         if (ids.values().isEmpty())
             throw new NotFoundException("No IDs available for charting.");
         // We don't care which protocol we get- we just need any valid protocol to get to the provider (which should be
@@ -72,9 +72,9 @@ public class StudyNabGraphAction extends SimpleViewAction<GraphSelectedForm>
                     throw new IllegalStateException("Cannot graph data from different providers on the same chart");
             }
         }
-        int[] objectIds = new int[ids.size()];
+        long[] objectIds = new long[ids.size()];
         int i = 0;
-        for (Pair<Integer, String> id : ids.keySet())
+        for (Pair<Long, String> id : ids.keySet())
         {
             objectIds[i++] = id.getKey();
         }

--- a/nab/src/org/labkey/nab/multiplate/HighThroughputNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/HighThroughputNabDataHandler.java
@@ -25,6 +25,7 @@ import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.WellData;
 import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.ExperimentException;
@@ -118,9 +119,9 @@ public abstract class HighThroughputNabDataHandler extends NabDataHandler implem
         if (wellDataRows.isEmpty())
             throw new ExperimentException("Well data could not be found for run " + run.getName() + ". Run details are not available.");
 
-        Map<Integer, double[][]> matrices = new HashMap<>();
-        Map<Integer, boolean[][]> exclusions = new HashMap<>();
-        Map<Integer, String> plateToVirusMap = new HashMap<>();
+        Map<Integer, double[][]> matrices = new IntHashMap<>();
+        Map<Integer, boolean[][]> exclusions = new IntHashMap<>();
+        Map<Integer, String> plateToVirusMap = new IntHashMap<>();
         for (WellDataRow wellDataRow : wellDataRows)
         {
             Integer plateNum = wellDataRow.getPlateNumber();

--- a/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabDataHandler.java
@@ -116,7 +116,7 @@ public class SinglePlateDilutionNabDataHandler extends HighThroughputNabDataHand
                 int plateCol = location.getValue();
 
                 Object dataValue = rowData.get(resultColumnHeader);
-                if (!(dataValue instanceof Integer))
+                if (!(dataValue instanceof Integer || dataValue instanceof Long))
                 {
                     throw createParseError(dataFile, "No valid result value found on line " + line + ".  Expected integer " +
                             "result values in the last data file column (\"" + resultColumnHeader + "\") found: " + dataValue);
@@ -138,7 +138,7 @@ public class SinglePlateDilutionNabDataHandler extends HighThroughputNabDataHand
                                 " and virus name : " + virusName);
                 }
 
-                wellValues[plateRow - 1][plateCol - 1] = (Integer) dataValue;
+                wellValues[plateRow - 1][plateCol - 1] = ((Number)dataValue).doubleValue();
                 if (++wellCount == wellsPerPlate)
                 {
                     Plate plate = PlateService.get().createPlate(template, wellValues, null, PlateService.NO_RUNID, plateCount + 1);

--- a/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabDataHandler.java
@@ -24,6 +24,7 @@ import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.LongArrayList;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.PropertyDescriptor;
@@ -212,7 +213,7 @@ public class SinglePlateDilutionNabDataHandler extends HighThroughputNabDataHand
             return summaries;
 
         Map<Integer, DilutionAssayRun> dataToAssay = new IntHashMap<>();
-        List<Long> nabSpecimenIds = new ArrayList<>(dataObjectIds.length);
+        List<Long> nabSpecimenIds = new LongArrayList(dataObjectIds.length);
         for (long nabSpecimenId : dataObjectIds)
             nabSpecimenIds.add(nabSpecimenId);
         List<NabSpecimen> nabSpecimens = NabManager.get().getNabSpecimens(nabSpecimenIds);

--- a/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabDataHandler.java
+++ b/nab/src/org/labkey/nab/multiplate/SinglePlateDilutionNabDataHandler.java
@@ -23,6 +23,7 @@ import org.labkey.api.assay.nab.NabSpecimen;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.PropertyDescriptor;
@@ -98,7 +99,7 @@ public class SinglePlateDilutionNabDataHandler extends HighThroughputNabDataHand
             int plateCount = 0;
             double[][] wellValues = new double[template.getRows()][template.getColumns()];
             List<Plate> plates = new ArrayList<>();
-            Map<Integer, String> plateToVirusMap = new HashMap<>();
+            Map<Integer, String> plateToVirusMap = new IntHashMap<>();
 
             for (Map<String, Object> rowData : loader)
             {
@@ -204,15 +205,15 @@ public class SinglePlateDilutionNabDataHandler extends HighThroughputNabDataHand
     }
 
     @Override
-    public Map<DilutionSummary, DilutionAssayRun> getDilutionSummaries(User user, StatsService.CurveFitType fit, int... dataObjectIds) throws ExperimentException
+    public Map<DilutionSummary, DilutionAssayRun> getDilutionSummaries(User user, StatsService.CurveFitType fit, long... dataObjectIds) throws ExperimentException
     {
         Map<DilutionSummary, DilutionAssayRun> summaries = new LinkedHashMap<>();
         if (dataObjectIds == null || dataObjectIds.length == 0)
             return summaries;
 
-        Map<Integer, DilutionAssayRun> dataToAssay = new HashMap<>();
-        List<Integer> nabSpecimenIds = new ArrayList<>(dataObjectIds.length);
-        for (int nabSpecimenId : dataObjectIds)
+        Map<Integer, DilutionAssayRun> dataToAssay = new IntHashMap<>();
+        List<Long> nabSpecimenIds = new ArrayList<>(dataObjectIds.length);
+        for (long nabSpecimenId : dataObjectIds)
             nabSpecimenIds.add(nabSpecimenId);
         List<NabSpecimen> nabSpecimens = NabManager.get().getNabSpecimens(nabSpecimenIds);
 

--- a/nab/src/org/labkey/nab/query/NabProtocolSchema.java
+++ b/nab/src/org/labkey/nab/query/NabProtocolSchema.java
@@ -53,7 +53,7 @@ import java.util.Set;
 
 public class NabProtocolSchema extends AssayProtocolSchema
 {
-    private static final BlockingCache<Integer, Set<Double>> CUTOFF_CACHE = DatabaseCache.get(NabManager.getSchema().getScope(), 100, "NAbCutoffValues", (key, argument) -> {
+    private static final BlockingCache<Long, Set<Double>> CUTOFF_CACHE = DatabaseCache.get(NabManager.getSchema().getScope(), 100, "NAbCutoffValues", (key, argument) -> {
         ExpProtocol protocol = (ExpProtocol)argument;
         return Collections.unmodifiableSet(DilutionManager.getCutoffValues(protocol));
     });
@@ -128,7 +128,7 @@ public class NabProtocolSchema extends AssayProtocolSchema
         return CUTOFF_CACHE.get(protocol.getRowId(), protocol);
     }
 
-    public static void clearProtocolFromCutoffCache(int protocolId)
+    public static void clearProtocolFromCutoffCache(long protocolId)
     {
         CUTOFF_CACHE.remove(protocolId);
     }

--- a/protein/api-src/org/labkey/api/protein/CoverageProtein.java
+++ b/protein/api-src/org/labkey/api/protein/CoverageProtein.java
@@ -6,12 +6,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -458,7 +458,7 @@ public class CoverageProtein extends SimpleProtein
     {
         final char _c;
         int _levels;
-        final Map<Integer, String> tdMap = new HashMap<>();
+        final Map<Integer, String> tdMap = new IntHashMap<>();
 
         public SequencePos(char c, int curIdx, List<ProteinFeature> features)
         {

--- a/protein/api-src/org/labkey/api/protein/ProteinManager.java
+++ b/protein/api-src/org/labkey/api/protein/ProteinManager.java
@@ -36,6 +36,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 public class ProteinManager
 {
     public static FastaFile getFastaFile(int fastaId)
@@ -193,7 +195,7 @@ public class ProteinManager
             map.put("name", identifierType);
             map.put("entryDate", new Date());
             map = Table.insert(null, ProteinSchema.getTableInfoIdentTypes(), map);
-            identTypeId = (Integer)map.get("identTypeId");
+            identTypeId = asInteger(map.get("identTypeId"));
         }
         return identTypeId;
     }

--- a/protein/api-src/org/labkey/api/protein/annotation/CustomAnnotationSetManager.java
+++ b/protein/api-src/org/labkey/api/protein/annotation/CustomAnnotationSetManager.java
@@ -97,7 +97,7 @@ public class CustomAnnotationSetManager
         }
     }
 
-    public static CustomAnnotationSet getCustomAnnotationSet(Container c, int id, boolean includeProject)
+    public static CustomAnnotationSet getCustomAnnotationSet(Container c, long id, boolean includeProject)
     {
         SQLFragment sql = new SQLFragment();
         sql.append("SELECT * FROM ");

--- a/protein/src/org/labkey/protein/ProteinController.java
+++ b/protein/src/org/labkey/protein/ProteinController.java
@@ -437,8 +437,8 @@ public class ProteinController extends SpringActionController
         @Override
         public boolean handlePost(Object o, BindException errors)
         {
-            Set<Integer> setIds = DataRegionSelection.getSelectedIntegers(getViewContext(), true);
-            for (Integer id : setIds)
+            Set<Long> setIds = DataRegionSelection.getSelectedIntegers(getViewContext(), true);
+            for (Long id : setIds)
             {
                 CustomAnnotationSet set = CustomAnnotationSetManager.getCustomAnnotationSet(getContainer(), id, false);
                 if (set != null)
@@ -606,7 +606,7 @@ public class ProteinController extends SpringActionController
                     descriptors.add(pd);
                 }
 
-                int ownerObjectId = OntologyManager.ensureObject(getContainer(), annotationSet.getLsid());
+                long ownerObjectId = OntologyManager.ensureObject(getContainer(), annotationSet.getLsid());
                 OntologyManager.ImportHelper helper = new CustomAnnotationImportHelper(stmt, connection, annotationSet.getLsid(), lookupStringColumnName);
 
                 OntologyManager.insertTabDelimited(getContainer(), getUser(), ownerObjectId, helper, descriptors, MapDataIterator.of(rows).getDataIterator(new DataIteratorContext()), false, null);

--- a/protein/src/org/labkey/protein/ProteinModule.java
+++ b/protein/src/org/labkey/protein/ProteinModule.java
@@ -66,7 +66,7 @@ public class ProteinModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 25.001;
+        return 25.002;
     }
 
     @Override

--- a/viability/resources/schemas/dbscripts/postgresql/viability-25.000-25.001.sql
+++ b/viability/resources/schemas/dbscripts/postgresql/viability-25.000-25.001.sql
@@ -1,0 +1,1 @@
+MiALTER TABLE viability.Results ALTER COLUMN ObjectId TYPE BIGINT;

--- a/viability/resources/schemas/dbscripts/postgresql/viability-25.000-25.001.sql
+++ b/viability/resources/schemas/dbscripts/postgresql/viability-25.000-25.001.sql
@@ -1,1 +1,1 @@
-MiALTER TABLE viability.Results ALTER COLUMN ObjectId TYPE BIGINT;
+ALTER TABLE viability.Results ALTER COLUMN ObjectId TYPE BIGINT;

--- a/viability/src/org/labkey/viability/ViabilityAssayProvider.java
+++ b/viability/src/org/labkey/viability/ViabilityAssayProvider.java
@@ -242,10 +242,10 @@ public class ViabilityAssayProvider extends AbstractAssayProvider
     }
 
     @Override
-    public Set<ExpData> getDatasForResultRows(Collection<Integer> rowIds, ExpProtocol protocol, ResolverCache cache)
+    public Set<ExpData> getDatasForResultRows(Collection<Long> rowIds, ExpProtocol protocol, ResolverCache cache)
     {
         Set<ExpData> result = new HashSet<>();
-        for (Integer rowId : rowIds)
+        for (Long rowId : rowIds)
         {
             ExpData data = ViabilityManager.getResultExpData(rowId);
             if (data != null)

--- a/viability/src/org/labkey/viability/ViabilityManager.java
+++ b/viability/src/org/labkey/viability/ViabilityManager.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.labkey.api.assay.AbstractAssayProvider;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
+import org.labkey.api.collections.LongArrayList;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -495,7 +496,7 @@ public class ViabilityManager
         DbScope scope = ViabilitySchema.getSchema().getScope();
         try (DbScope.Transaction tx = scope.ensureTransaction())
         {
-            List<Long> dataIDs = new ArrayList<>(datas.size());
+            List<Long> dataIDs = new LongArrayList(datas.size());
             for (ExpData data : datas)
                 dataIDs.add(data.getRowId());
 
@@ -505,7 +506,7 @@ public class ViabilityManager
 
             ts.forEachMapBatch(1000, (rows) -> {
 
-                List<Long> resultIDs = new ArrayList<>(rows.size());
+                List<Long> resultIDs = new LongArrayList(rows.size());
                 long[] objectIDs = new long[rows.size()];
 
                 int i = 0;

--- a/viability/src/org/labkey/viability/ViabilityManager.java
+++ b/viability/src/org/labkey/viability/ViabilityManager.java
@@ -16,6 +16,7 @@
 
 package org.labkey.viability;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -138,7 +139,7 @@ public class ViabilityManager
                 new Sort("SpecimenIndex")).getArray(String.class);
     }
 
-    static Map<PropertyDescriptor, Object> getProperties(int objectID)
+    static Map<PropertyDescriptor, Object> getProperties(long objectID)
     {
         assert objectID > 0;
         OntologyObject obj = OntologyManager.getOntologyObject(objectID);
@@ -169,7 +170,7 @@ public class ViabilityManager
         if (result.getRowID() == 0)
         {
             String lsid = new Lsid(ViabilityAssayProvider.RESULT_LSID_PREFIX, result.getDataID() + "-" + result.getPoolID() + "-" + rowIndex).toString();
-            int id = OntologyManager.ensureObject(c, lsid);
+            long id = OntologyManager.ensureObject(c, lsid);
 
             result.setObjectID(id);
             ViabilityResult inserted = Table.insert(user, ViabilitySchema.getTableInfoResults(), result);
@@ -450,7 +451,7 @@ public class ViabilityManager
     /**
      * Delete a ViabilityResult row by rowid.
      */
-    public static void deleteResult(Container c, int resultRowID, int resultObjectID)
+    public static void deleteResult(Container c, int resultRowID, long resultObjectID)
     {
         deleteSpecimens(resultRowID);
         Table.delete(ViabilitySchema.getTableInfoResults(), resultRowID);
@@ -459,18 +460,18 @@ public class ViabilityManager
         OntologyManager.deleteOntologyObject(obj.getObjectURI(), c, true);
     }
 
-    private static void deleteSpecimens(int resultRowId)
+    private static void deleteSpecimens(long resultRowId)
     {
         Table.delete(ViabilitySchema.getTableInfoResultSpecimens(), new SimpleFilter(FieldKey.fromParts("ResultID"), resultRowId));
     }
 
-    private static void deleteSpecimens(Collection<Integer> resultRowIds)
+    private static void deleteSpecimens(Collection<Long> resultRowIds)
     {
         Table.delete(ViabilitySchema.getTableInfoResultSpecimens(), new SimpleFilter(FieldKey.fromParts("ResultID"), resultRowIds, CompareType.IN));
     }
 
     /** Delete the properties for objectID, but not the object itself. */
-    private static void deleteProperties(Container c, int objectID)
+    private static void deleteProperties(Container c, long objectID)
     {
         OntologyManager.deleteProperties(c, objectID);
     }
@@ -480,7 +481,7 @@ public class ViabilityManager
      * @param resultRowId The row id of the result.
      * @return The ExpData of the viability result row or null.
      */
-    /*package*/ static ExpData getResultExpData(int resultRowId)
+    /*package*/ static ExpData getResultExpData(long resultRowId)
     {
         Integer dataId = new TableSelector(ViabilitySchema.getTableInfoResults(), Collections.singleton("DataID"), new SimpleFilter(FieldKey.fromParts("RowID"), resultRowId), null).getObject(Integer.class);
         if (dataId != null)
@@ -494,7 +495,7 @@ public class ViabilityManager
         DbScope scope = ViabilitySchema.getSchema().getScope();
         try (DbScope.Transaction tx = scope.ensureTransaction())
         {
-            List<Integer> dataIDs = new ArrayList<>(datas.size());
+            List<Long> dataIDs = new ArrayList<>(datas.size());
             for (ExpData data : datas)
                 dataIDs.add(data.getRowId());
 
@@ -504,14 +505,14 @@ public class ViabilityManager
 
             ts.forEachMapBatch(1000, (rows) -> {
 
-                List<Integer> resultIDs = new ArrayList<>(rows.size());
-                int[] objectIDs = new int[rows.size()];
+                List<Long> resultIDs = new ArrayList<>(rows.size());
+                long[] objectIDs = new long[rows.size()];
 
                 int i = 0;
                 for (Map<String, Object> row : rows)
                 {
-                    resultIDs.add(((Integer) row.get("RowID")).intValue());
-                    objectIDs[i] = ((Integer) row.get("ObjectID")).intValue();
+                    resultIDs.add( MapUtils.getLong(row,"RowID") );
+                    objectIDs[i] = MapUtils.getLong(row,"ObjectID");
                     i++;
                 }
 
@@ -603,7 +604,7 @@ public class ViabilityManager
             assertFalse("login before running this test", user.isGuest());
 
             int resultId;
-            int objectId;
+            long objectId;
             String objectURI;
 
             // INSERT

--- a/viability/src/org/labkey/viability/ViabilityManager.java
+++ b/viability/src/org/labkey/viability/ViabilityManager.java
@@ -16,7 +16,7 @@
 
 package org.labkey.viability;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;

--- a/viability/src/org/labkey/viability/ViabilityModule.java
+++ b/viability/src/org/labkey/viability/ViabilityModule.java
@@ -42,7 +42,7 @@ public class ViabilityModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 25.000;
+        return 25.001;
     }
 
     @Override

--- a/viability/src/org/labkey/viability/ViabilityResult.java
+++ b/viability/src/org/labkey/viability/ViabilityResult.java
@@ -33,10 +33,10 @@ public class ViabilityResult
     private int rowID;
 
     private String containerID;
-    private int protocolID;
-    private int runID;
-    private int dataID;
-    private int objectID;
+    private long protocolID;
+    private long runID;
+    private long dataID;
+    private long objectID;
     private String participantID;
     private Double visitID;
     private Date date;
@@ -157,42 +157,42 @@ public class ViabilityResult
         this.containerID = containerID;
     }
 
-    public int getProtocolID()
+    public long getProtocolID()
     {
         return protocolID;
     }
 
-    public void setProtocolID(int protocolID)
+    public void setProtocolID(long protocolID)
     {
         this.protocolID = protocolID;
     }
 
-    public int getRunID()
+    public long getRunID()
     {
         return runID;
     }
 
-    public void setRunID(int runID)
+    public void setRunID(long runID)
     {
         this.runID = runID;
     }
 
-    public int getDataID()
+    public long getDataID()
     {
         return dataID;
     }
 
-    public void setDataID(int dataID)
+    public void setDataID(long dataID)
     {
         this.dataID = dataID;
     }
 
-    public int getObjectID()
+    public long getObjectID()
     {
         return objectID;
     }
 
-    public void setObjectID(int objectID)
+    public void setObjectID(long objectID)
     {
         this.objectID = objectID;
     }


### PR DESCRIPTION
#### Rationale
Implement support for tables with BIGINT primary keys.  E.g. RowId/ObjectId BIGSERIAL
Because of the large number of shared classes, utilities, services, etc, a lot of code was migrated to used Long.  Code should now assume that an generic integer object key (as opposed to a known table PK), could be a Long.

This PR is aimed at a) Supporting ObjectID BIGSERIAL b) making it possible (but not automatic) to migrate tables that want to use RowId BIGSERIAL.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
New safer collection classes
  class Int/LongHashMap
  class Int/LongHashSet
explicit Class for key values in Map Objects returned by BaseSelector
  Selector.getValueMap(Class key)
safe "cast" using asInteger or asLong, as opposed to (Integer) and (Long)

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->