### PR TITLE
Issue 53620: Luminex assay import analyte properties "Same" checkbox issues for "Subtract Negative Bead" and "Use Standard" columns

### DIFF
--- a/luminex/src/org/labkey/luminex/LuminexUploadWizardAction.java
+++ b/luminex/src/org/labkey/luminex/LuminexUploadWizardAction.java
@@ -442,8 +442,10 @@ public class LuminexUploadWizardAction extends UploadWizardAction<LuminexRunUplo
                     ).appendTo(out);
 
                     StringBuilder onchange = new StringBuilder("b = this.checked;");
-                    for (DisplayColumn col : getColumns())
+                    // Index starts at 1 -- always leave the first column visible (Issue 53620)
+                    for (int i = 1; i < getColumns().size(); i++)
                     {
+                        DisplayColumn col = getColumns().get(i);
                         onchange.append("document.getElementsByName('").append(col.getFormFieldName(ctx)).append("')[0].style.display = b ? 'none' : 'block';\n");
                     }
                     onchange.append("if (b) { ").append(groupName).append("Updated(); }");

--- a/luminex/src/org/labkey/luminex/query/NegativeBeadDisplayColumnGroup.java
+++ b/luminex/src/org/labkey/luminex/query/NegativeBeadDisplayColumnGroup.java
@@ -49,7 +49,10 @@ public class NegativeBeadDisplayColumnGroup extends DisplayColumnGroup
                 InputBuilder.checkbox().name(id).id(id).appendTo(out);
                 StringBuilder onChange = new StringBuilder("b = this.checked;\n");
 
-                getColumns().forEach(col -> {
+                // Index starts at 1 -- always leave the first column visible (Issue 53620)
+                for (int i = 1; i < getColumns().size(); i++)
+                {
+                    DisplayColumn col = getColumns().get(i);
                     if (col.getColumnInfo() != null)
                     {
                         onChange.append("s = document.getElementsByName('")
@@ -59,7 +62,7 @@ public class NegativeBeadDisplayColumnGroup extends DisplayColumnGroup
                             .append(col.getFormFieldName(ctx))
                             .append("')[0].style.display = b || s == 0 ? 'none' : 'block';\n");
                     }
-                });
+                }
 
                 onChange.append(" if (b) { ")
                     .append(inputName)

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexRTransformTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexRTransformTest.java
@@ -126,6 +126,7 @@ public final class LuminexRTransformTest extends LuminexTest
         setFormElement(Locator.name("stndCurveFitInput"), "FI");
         setFormElement(Locator.name("unkCurveFitInput"), "FI-Bkgd-Neg");
         setFormElement(Locator.name("__primaryFile__"), TEST_ASSAY_LUM_FILE4);
+        scrollIntoView(Locator.lkButton("Next"), true);
         clickButton("Next", defaultWaitForPage * 2);
 
         // make sure the Standard checkboxes are checked
@@ -139,12 +140,11 @@ public final class LuminexRTransformTest extends LuminexTest
         setFormElement(Locator.xpath("//input[@type='text' and contains(@name, '_LotNumber')][1]"), TEST_ANALYTE_LOT_NUMBER);
         // set negative control and negative bead values
         checkCheckbox(Locator.name("_analyte_" + ANALYTE3 + "_NegativeControl"));
+        checkCheckbox(Locator.name("_analyte_" + ANALYTE1 + "_NegativeBeadCheckBox")); // Issue 53620: "Same" checkbox for subtract negative bead
         selectOptionByText(Locator.name("_analyte_" + ANALYTE1 + "_NegativeBead"), ANALYTE3);
-        selectOptionByText(Locator.name("_analyte_" + ANALYTE2 + "_NegativeBead"), ANALYTE3);
         // switch to using MyNegative bead for subtraction
         checkCheckbox(Locator.name("_analyte_" + ANALYTE4 + "_NegativeControl"));
         selectOptionByText(Locator.name("_analyte_" + ANALYTE1 + "_NegativeBead"), ANALYTE4);
-        selectOptionByText(Locator.name("_analyte_" + ANALYTE2 + "_NegativeBead"), ANALYTE4);
         clickButton("Save and Finish");
     }
 

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -660,6 +660,7 @@ public abstract class LuminexTest extends BaseWebDriverTest
         setFormElement(Locator.name("__primaryFile__"), file);
         if (expectDuplicateFile)
             waitForText("A file with name '" + file.getName() + "' already exists");
+        scrollIntoView(Locator.lkButton("Next"), true);
         clickButton("Next");
     }
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53620

This was introduced with the refactor from the related PRs. The loop for the "Same" checkbox selection on the analyte properties assay import step should keep the first row input visible.

#### Related Pull Requests
- https://github.com/LabKey/commonAssays/pull/711/files#diff-a5453465673bca9f4aaa05ae238c732286c42464d95f90f54d9f5564221027d2L431
- https://github.com/LabKey/commonAssays/pull/858/files#diff-b7b72886cd5f0a5f26a73d97ae6c511ba52b3c641cd0d82020f2553f677ed567L49

#### Changes
- Luminex analyte properties should keep first row input visible when clicking "Same" checkbox for the column
- Luminex test case update to use analyte properties "Same" checkbox
