### PR TITLE
Drop unused elispotlk.rundata.ObjectId column and other cruft

### DIFF
--- a/elispotassay/resources/schemas/dbscripts/postgresql/elispotlk-0.00-18.30.sql
+++ b/elispotassay/resources/schemas/dbscripts/postgresql/elispotlk-0.00-18.30.sql
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-/* elispotlk-15.10-15.20.sql */
-
 CREATE SCHEMA elispotlk;
--- Until 21.11.5, the elispotassay module did not claim ownership of the "elispotantigen" schema. So, deleting that
--- module and its schema would leave "elispotantigen" behind and any subsequent bootstrap would fail. See #44610.
-SELECT core.fn_dropIfExists('*', 'elispotantigen', 'SCHEMA', NULL);
 CREATE SCHEMA elispotantigen;
 
 CREATE TABLE elispotlk.rundata
@@ -50,34 +45,6 @@ CREATE TABLE elispotlk.rundata
 );
 
 CREATE INDEX idx_elispotrundata_runid ON elispotlk.rundata(RunId);
-
-INSERT INTO elispotlk.rundata (RunId, Specimenlsid, SpotCount, WellgroupName, WellgroupLocation, NormalizedSpotCount, AntigenWellgroupName, ObjectUri, ObjectId)
-SELECT
-    RunId,SpecimenLSID, SpotCount, WellGroupName, WellgroupLocation, NormalizedSpotCount,
-    CASE WHEN AntigenWellgroupNameTemp IS NULL THEN AntigenName ELSE AntigenWellgroupNameTemp END AS AntigenWellgroupName,
-    ObjectURI, ObjectId
-FROM (
-	SELECT
-		(SELECT RunId FROM exp.Data d, exp.Object parent WHERE d.LSID = parent.ObjectURI and parent.ObjectId = o.OwnerObjectId) AS RunId,
-
-		(SELECT StringValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-			WHERE pd.PropertyURI LIKE '%:SpecimenLsid' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS SpecimenLSID,
-		(SELECT FloatValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-			WHERE pd.PropertyURI LIKE '%:SpotCount' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS SpotCount,
-		(SELECT StringValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-			WHERE pd.PropertyURI LIKE '%:WellgroupName' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS WellGroupName,
-		(SELECT StringValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-			WHERE pd.PropertyURI LIKE '%:WellgroupLocation' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS WellgroupLocation,
-		(SELECT FloatValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-			WHERE pd.PropertyURI LIKE '%:NormalizedSpotCount' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS NormalizedSpotCount,
-        (SELECT StringValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-            WHERE pd.PropertyURI LIKE '%:AntigenWellgroupName' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS AntigenWellgroupNameTemp,
-        (SELECT StringValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-            WHERE pd.PropertyURI LIKE '%:AntigenName' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS AntigenName,
-		ObjectURI,
-		ObjectId
-	FROM exp.Object o WHERE ObjectURI LIKE '%ElispotAssayDataRow%') x
-	WHERE specimenlsid IS NOT NULL AND RunID IS NOT NULL;
 
 ALTER TABLE elispotlk.rundata ADD COLUMN Cytokine VARCHAR(4000);
 ALTER TABLE elispotlk.rundata ADD COLUMN SpotSize REAL;

--- a/elispotassay/resources/schemas/dbscripts/postgresql/elispotlk-25.000-25.001.sql
+++ b/elispotassay/resources/schemas/dbscripts/postgresql/elispotlk-25.000-25.001.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2015-2018 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Drop unused column
+ALTER TABLE elispotlk.rundata DROP COLUMN ObjectId;

--- a/elispotassay/resources/schemas/dbscripts/sqlserver/elispotlk-0.00-18.30.sql
+++ b/elispotassay/resources/schemas/dbscripts/sqlserver/elispotlk-0.00-18.30.sql
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-/* elispotlk-15.10-15.20.sql */
-
 CREATE SCHEMA elispotlk;
-GO
--- Until 21.11.5, the elispotassay module did not claim ownership of the "elispotantigen" schema. So, deleting that
--- module and its schema would leave "elispotantigen" behind and any subsequent bootstrap would fail. See #44610.
-EXEC core.fn_dropIfExists '*', 'elispotantigen', 'SCHEMA';
 GO
 CREATE SCHEMA elispotantigen;
 GO
@@ -53,34 +47,6 @@ CREATE TABLE elispotlk.rundata
 );
 
 CREATE INDEX idx_elispotrundata_runid ON elispotlk.rundata(RunId);
-
-INSERT INTO elispotlk.rundata (RunId, Specimenlsid, SpotCount, WellgroupName, WellgroupLocation, NormalizedSpotCount, AntigenWellgroupName, ObjectUri, ObjectId)
-SELECT
-    RunId,SpecimenLSID, SpotCount, WellGroupName, WellgroupLocation, NormalizedSpotCount,
-    CASE WHEN AntigenWellgroupNameTemp IS NULL THEN AntigenName ELSE AntigenWellgroupNameTemp END AS AntigenWellgroupName,
-    ObjectURI, ObjectId
-FROM (
-	SELECT
-		(SELECT RunId FROM exp.Data d, exp.Object parent WHERE d.LSID = parent.ObjectURI and parent.ObjectId = o.OwnerObjectId) AS RunId,
-
-		(SELECT StringValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-			WHERE pd.PropertyURI LIKE '%:SpecimenLsid' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS SpecimenLSID,
-		(SELECT FloatValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-			WHERE pd.PropertyURI LIKE '%:SpotCount' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS SpotCount,
-		(SELECT StringValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-			WHERE pd.PropertyURI LIKE '%:WellgroupName' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS WellGroupName,
-		(SELECT StringValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-			WHERE pd.PropertyURI LIKE '%:WellgroupLocation' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS WellgroupLocation,
-		(SELECT FloatValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-			WHERE pd.PropertyURI LIKE '%:NormalizedSpotCount' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS NormalizedSpotCount,
-		(SELECT StringValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-			WHERE pd.PropertyURI LIKE '%:AntigenWellgroupName' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS AntigenWellgroupNameTemp,
-        (SELECT StringValue FROM exp.ObjectProperty op, exp.PropertyDescriptor pd
-            WHERE pd.PropertyURI LIKE '%:AntigenName' AND op.PropertyId = pd.PropertyId AND op.ObjectId = o.ObjectId) AS AntigenName,
-		ObjectURI,
-		ObjectId
-	FROM exp.Object o WHERE ObjectURI LIKE '%ElispotAssayDataRow%') x
-	WHERE specimenlsid IS NOT NULL AND RunID IS NOT NULL;
 
 ALTER TABLE elispotlk.rundata ADD Cytokine NVARCHAR(4000);
 ALTER TABLE elispotlk.rundata ADD SpotSize REAL;

--- a/elispotassay/resources/schemas/dbscripts/sqlserver/elispotlk-25.000-25.001.sql
+++ b/elispotassay/resources/schemas/dbscripts/sqlserver/elispotlk-25.000-25.001.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2015-2018 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Drop unused column
+ALTER TABLE elispotlk.rundata DROP COLUMN ObjectId;

--- a/elispotassay/resources/schemas/elispotlk.xml
+++ b/elispotassay/resources/schemas/elispotlk.xml
@@ -37,7 +37,6 @@
             <column columnName="Activity"/>
             <column columnName="Intensity"/>
             <column columnName="ObjectUri"/>
-            <column columnName="ObjectId"/>
         </columns>
     </table>
     <table tableName="Antigen" tableDbType="NOT_IN_DB">

--- a/elispotassay/src/org/labkey/elispot/AbstractElispotDataHandler.java
+++ b/elispotassay/src/org/labkey/elispot/AbstractElispotDataHandler.java
@@ -109,7 +109,6 @@ public abstract class AbstractElispotDataHandler extends AbstractExperimentDataH
                 String dataRowLsid = ElispotDataHandler.getDataRowLsid(runData.get(0).getLSID(), rowPos, colPos).toString();
 
                 Map<String, Object> runDataFields = new HashMap<>();
-                runDataFields.put("ObjectId", 0);
                 runDataFields.put("ObjectUri", dataRowLsid);
                 runDataFields.put("RunId", run.getRowId());
                 runDataFields.put(ELISPOT_INPUT_MATERIAL_DATA_PROPERTY, row.get(ELISPOT_INPUT_MATERIAL_DATA_PROPERTY));

--- a/elispotassay/src/org/labkey/elispot/ElispotModule.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotModule.java
@@ -46,7 +46,7 @@ public class ElispotModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 25.000;
+        return 25.001;
     }
 
     @Override

--- a/elispotassay/src/org/labkey/elispot/RunDataRow.java
+++ b/elispotassay/src/org/labkey/elispot/RunDataRow.java
@@ -39,7 +39,6 @@ public class RunDataRow
     private Double _activity;
     private Double _intensity;
     private String _objectUri;
-    private int _objectId;          // TODO: remove when we remove use of exp.Object
 
     private Map<String, Object> _antigenRow = null;
 
@@ -192,16 +191,6 @@ public class RunDataRow
     public void setObjectUri(String objectUri)
     {
         _objectUri = objectUri;
-    }
-
-    public int getObjectId()
-    {
-        return _objectId;
-    }
-
-    public void setObjectId(int objectId)
-    {
-        _objectId = objectId;
     }
 
     public String getAntigenLsid()

--- a/elispotassay/src/org/labkey/elispot/query/ElispotRunAntigenTable.java
+++ b/elispotassay/src/org/labkey/elispot/query/ElispotRunAntigenTable.java
@@ -15,31 +15,22 @@
  */
 package org.labkey.elispot.query;
 
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssaySchema;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.query.LookupForeignKey;
-import org.labkey.api.assay.AbstractAssayProvider;
-import org.labkey.api.assay.AssayProvider;
-import org.labkey.api.assay.AssaySchema;
-import org.labkey.elispot.ElispotAssayProvider;
 import org.labkey.elispot.ElispotDataHandler;
 
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * User: klum
- * Date: Jan 27, 2011
- * Time: 1:45:11 PM
- */
 public class ElispotRunAntigenTable extends PlateBasedAssayRunDataTable
 {
     public ElispotRunAntigenTable(final AssaySchema schema, ContainerFilter cf, final Domain domain, ExpProtocol protocol)
@@ -72,34 +63,6 @@ public class ElispotRunAntigenTable extends PlateBasedAssayRunDataTable
         fieldKeys.add(FieldKey.fromParts("RunId"));
         fieldKeys.add(FieldKey.fromParts("SpecimenLsid", "Property", "ParticipantId"));
         return fieldKeys;
-    }
-
-    @Override
-    protected ColumnInfo resolveColumn(String name)
-    {
-        ColumnInfo result = super.resolveColumn(name);
-
-        if ("Properties".equalsIgnoreCase(name))
-        {
-            // Hook up a column that joins back to this table so that the columns formerly under the Properties
-            // node can still be queried there.
-            var wrapped = wrapColumn("Properties", getRealTable().getColumn("ObjectId"));
-            wrapped.setIsUnselectable(true);
-            LookupForeignKey fk = new LookupForeignKey(getContainerFilter(), "ObjectId", null)
-            {
-                @Override
-                public TableInfo getLookupTableInfo()
-                {
-                    Domain domain = AbstractAssayProvider.getDomainByPrefix(_protocol, ElispotAssayProvider.ASSAY_DOMAIN_ANTIGEN_WELLGROUP, false);
-                    return new ElispotRunAntigenTable(_userSchema, getLookupContainerFilter(), domain, _protocol);
-                }
-            };
-            fk.setPrefixColumnCaption(false);
-            wrapped.setFk(fk);
-            result = wrapped;
-        }
-
-        return result;
     }
 
     @Override

--- a/elispotassay/src/org/labkey/elispot/query/ElispotRunDataTable.java
+++ b/elispotassay/src/org/labkey/elispot/query/ElispotRunDataTable.java
@@ -17,12 +17,15 @@
 package org.labkey.elispot.query;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.assay.AbstractAssayProvider;
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssaySchema;
+import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.plate.AbstractPlateBasedAssayProvider;
+import org.labkey.api.assay.plate.PlateReader;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DataColumn;
-import org.labkey.api.data.DisplayColumn;
-import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -31,12 +34,6 @@ import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.query.LookupForeignKey;
-import org.labkey.api.assay.AbstractAssayProvider;
-import org.labkey.api.assay.AssayProvider;
-import org.labkey.api.assay.AssaySchema;
-import org.labkey.api.assay.AssayService;
-import org.labkey.api.assay.plate.PlateReader;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.util.HtmlString;
 import org.labkey.elispot.ElispotAssayProvider;
@@ -47,10 +44,6 @@ import org.labkey.elispot.ElispotProtocolSchema;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * User: Karl Lum
- * Date: Jan 21, 2008
- */
 public class ElispotRunDataTable extends PlateBasedAssayRunDataTable
 {
     public ElispotRunDataTable(final AssaySchema schema, ContainerFilter cf, final ExpProtocol protocol)
@@ -109,33 +102,6 @@ public class ElispotRunDataTable extends PlateBasedAssayRunDataTable
         var antigenLsidColumn = getMutableColumn(FieldKey.fromParts("AntigenLsid"));
         antigenLsidColumn.setLabel("Antigen");
         antigenLsidColumn.setFk(QueryForeignKey.from(getUserSchema(), getContainerFilter()).to(ElispotProtocolSchema.ANTIGEN_TABLE_NAME, "AntigenLsid", null));
-    }
-
-    @Override
-    protected ColumnInfo resolveColumn(String name)
-    {
-        ColumnInfo result = super.resolveColumn(name);
-
-        if ("Properties".equalsIgnoreCase(name))
-        {
-            // Hook up a column that joins back to this table so that the columns formerly under the Properties
-            // node can still be queried there.
-            var wrapped = wrapColumn("Properties", getRealTable().getColumn("ObjectId"));
-            wrapped.setIsUnselectable(true);
-            LookupForeignKey fk = new LookupForeignKey(getContainerFilter(), "ObjectId", null)
-            {
-                @Override
-                public TableInfo getLookupTableInfo()
-                {
-                    return new ElispotRunDataTable(_userSchema, getLookupContainerFilter(), _protocol);
-                }
-            };
-            fk.setPrefixColumnCaption(false);
-            wrapped.setFk(fk);
-            result = wrapped;
-        }
-
-        return result;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Getting rid of an used ObjectId INT column to reduce confusion