### PR TITLE
Issue 53620: Luminex import update to writeSameCheckboxCell to use "disabled" behavior instead of hiding the column inputs

### DIFF
--- a/luminex/src/org/labkey/luminex/LuminexUploadWizardAction.java
+++ b/luminex/src/org/labkey/luminex/LuminexUploadWizardAction.java
@@ -441,14 +441,16 @@ public class LuminexUploadWizardAction extends UploadWizardAction<LuminexRunUplo
                         InputBuilder.checkbox().name(id).id(id)
                     ).appendTo(out);
 
-                    StringBuilder onchange = new StringBuilder("b = this.checked;");
+                    StringBuilder onchange = new StringBuilder("b = this.checked;\n");
                     // Index starts at 1 -- always leave the first column visible (Issue 53620)
                     for (int i = 1; i < getColumns().size(); i++)
                     {
                         DisplayColumn col = getColumns().get(i);
-                        onchange.append("document.getElementsByName('").append(col.getFormFieldName(ctx)).append("')[0].style.display = b ? 'none' : 'block';\n");
+                        // Issue 53620: instead of hiding the input, set it "disabled" via CSS (but not actually disabled so it will still submit)
+                        onchange.append("document.getElementsByName('").append(col.getFormFieldName(ctx)).append("')[0].style.opacity = b ? 0.6 : 1;\n");
+                        onchange.append("document.getElementsByName('").append(col.getFormFieldName(ctx)).append("')[0].style.pointerEvents = b ? 'none' : 'all';\n");
                     }
-                    onchange.append("if (b) { ").append(groupName).append("Updated(); }");
+                    onchange.append("if (b) { ").append(groupName).append("Updated(); }\n");
                     HttpView.currentPageConfig().addHandler(id, "change", onchange.toString());
                 }
 

--- a/luminex/src/org/labkey/luminex/query/NegativeBeadDisplayColumnGroup.java
+++ b/luminex/src/org/labkey/luminex/query/NegativeBeadDisplayColumnGroup.java
@@ -55,18 +55,15 @@ public class NegativeBeadDisplayColumnGroup extends DisplayColumnGroup
                     DisplayColumn col = getColumns().get(i);
                     if (col.getColumnInfo() != null)
                     {
-                        onChange.append("s = document.getElementsByName('")
-                            .append(col.getFormFieldName(ctx))
-                            .append("')[0].options.length;\n")
-                            .append("document.getElementsByName('")
-                            .append(col.getFormFieldName(ctx))
-                            .append("')[0].style.display = b || s == 0 ? 'none' : 'block';\n");
+                        // Issue 53620: instead of hiding the input, set it "disabled" via CSS (but not actually disabled so it will still submit)
+                        onChange.append("document.getElementsByName('").append(col.getFormFieldName(ctx)).append("')[0].style.opacity = b ? 0.6 : 1;\n");
+                        onChange.append("document.getElementsByName('").append(col.getFormFieldName(ctx)).append("')[0].style.pointerEvents = b ? 'none' : 'all';\n");
                     }
                 }
 
                 onChange.append(" if (b) { ")
                     .append(inputName)
-                    .append("Updated(); }");
+                    .append("Updated(); }\n");
                 HttpView.currentPageConfig().addHandler(id, "change", onChange.toString());
 
                 return ret;

--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexRTransformTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexRTransformTest.java
@@ -132,8 +132,7 @@ public final class LuminexRTransformTest extends LuminexTest
         // make sure the Standard checkboxes are checked
         checkCheckbox(Locator.name("_titrationRole_standard_Standard1"));
         checkCheckbox(Locator.name("titration_" + ANALYTE1 + "_Standard1"));
-        checkCheckbox(Locator.name("titration_" + ANALYTE2 + "_Standard1"));
-        checkCheckbox(Locator.name("titration_" + ANALYTE3 + "_Standard1"));
+        checkCheckbox(Locator.name("titration_" + ANALYTE1 + "_Standard1CheckBox")); // Issue 53620: "Same" checkbox for standards
         // make sure that that QC Control checkbox is checked
         checkCheckbox(Locator.name("_titrationRole_qccontrol_Standard1"));
         // set LotNumber for the first analyte


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53620

For the last step of the Luminex assay import, we have been hiding column inputs when the "Same" checkbox is clicked. This causes some user confusion about what values will actually be submitted for those hidden inputs. This PR instead disables those inputs instead of hiding them (note: not actually using the disabled prop of the input as that prevents the value from being submitted).

<img width="584" height="476" alt="Screenshot 2025-08-15 at 4 48 46 PM" src="https://github.com/user-attachments/assets/f7916d0f-df3c-486f-bc99-0a2195266b3b" />


#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6938

#### Changes
- Luminex import update to writeSameCheckboxCell to use "disabled" behavior instead of hiding the column inputs
