### PR TITLE
Issue 53586: Domain field with long name can result in "PropertyURI cannot exceed 300 characters, but was 302 characters long."

### DIFF
--- a/elispotassay/src/org/labkey/elispot/ElispotAssayProvider.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotAssayProvider.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.plate.AbstractPlateBasedAssayProvider;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.PropertyStorageSpec;
+import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpData;
@@ -269,7 +270,7 @@ public class ElispotAssayProvider extends AbstractPlateBasedAssayProvider implem
         DomainKind<?> domainKind = PropertyService.get().getDomainKindByName(ElispotAntigenDomainKind.KINDNAME);
         for (PropertyStorageSpec propSpec : domainKind.getBaseProperties(null))
         {
-            DomainProperty prop = antigenWellGroupDomain.addProperty(propSpec);
+            DomainProperty prop = antigenWellGroupDomain.addProperty(propSpec, Lsid.encodePart(propSpec.getName()));
             prop.setShownInInsertView(false);
             prop.setShownInUpdateView(false);
             prop.setShownInDetailsView(false);

--- a/elispotassay/src/org/labkey/elispot/ElispotAssayProvider.java
+++ b/elispotassay/src/org/labkey/elispot/ElispotAssayProvider.java
@@ -270,7 +270,7 @@ public class ElispotAssayProvider extends AbstractPlateBasedAssayProvider implem
         DomainKind<?> domainKind = PropertyService.get().getDomainKindByName(ElispotAntigenDomainKind.KINDNAME);
         for (PropertyStorageSpec propSpec : domainKind.getBaseProperties(null))
         {
-            DomainProperty prop = antigenWellGroupDomain.addProperty(propSpec, Lsid.encodePart(propSpec.getName()));
+            DomainProperty prop = antigenWellGroupDomain.addProperty(propSpec, propSpec.getName());
             prop.setShownInInsertView(false);
             prop.setShownInUpdateView(false);
             prop.setShownInDetailsView(false);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53586
see related PR for rationale

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6939

#### Changes
- Elispot domain case to use Domain.addProperty method with option to provide your own propURISuffix
