### PR TITLE
Speed up cloning/migrating of loaded GO schemas

### DIFF
--- a/protein/api-src/org/labkey/api/protein/go/GoLoader.java
+++ b/protein/api-src/org/labkey/api/protein/go/GoLoader.java
@@ -143,14 +143,25 @@ public abstract class GoLoader implements Closeable
         });
     }
 
-    private void loadGoFromGz() throws SQLException, IOException, ServletException
+    public static void dropGoIndexes()
     {
         DbSchema schema = ProteinSchema.getSchema();
+        new SqlExecutor(schema).execute(schema.getSqlDialect().execute(schema, "drop_go_indexes", ""));
+    }
+
+    public static void createGoIndexes()
+    {
+        DbSchema schema = ProteinSchema.getSchema();
+        new SqlExecutor(schema).execute(schema.getSqlDialect().execute(schema, "create_go_indexes", ""));
+    }
+
+    private void loadGoFromGz() throws SQLException, IOException, ServletException
+    {
         Map<String, GoLoadBean> map = getGoLoadMap();
         long start = System.currentTimeMillis();
 
         clearGoLoaded();
-        new SqlExecutor(schema).execute(schema.getSqlDialect().execute(schema, "drop_go_indexes", ""));
+        dropGoIndexes();
 
         logStatus("Starting to load GO annotation files");
         logStatus("");
@@ -175,7 +186,7 @@ public abstract class GoLoader implements Closeable
             }
         }
 
-        new SqlExecutor(schema).execute(schema.getSqlDialect().execute(schema, "create_go_indexes", ""));
+        createGoIndexes();
         long elapsed = System.currentTimeMillis() - start;
 
         logStatus("Successfully loaded all GO annotation files (" + DateUtil.formatDuration(elapsed) + ")");

--- a/protein/src/org/labkey/protein/ProteinModule.java
+++ b/protein/src/org/labkey/protein/ProteinModule.java
@@ -141,15 +141,6 @@ public class ProteinModule extends DefaultModule
             }
 
             @Override
-            public List<TableInfo> getTablesToCopy()
-            {
-                // Temporary: we've proven we can copy the GO tables, but they take a long time; skip them for now. TODO: Remove this override for production testing
-                return super.getTablesToCopy().stream()
-                    .filter(tableInfo -> !tableInfo.getName().startsWith("Go"))
-                    .toList();
-            }
-
-            @Override
             public @Nullable FieldKey getContainerFieldKey(TableInfo sourceTable)
             {
                 return switch (sourceTable.getName())

--- a/protein/src/org/labkey/protein/ProteinModule.java
+++ b/protein/src/org/labkey/protein/ProteinModule.java
@@ -22,7 +22,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DatabaseMigrationService;
 import org.labkey.api.data.DatabaseMigrationService.DefaultMigrationHandler;
-import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.files.FileContentService;
@@ -130,19 +129,19 @@ public class ProteinModule extends DefaultModule
         }
 
         ProteinService.get().registerProteinSearchView(new ProteinSearchViewProvider());
-        DatabaseMigrationService.get().registerHandler(ProteinSchema.getSchema(), new DefaultMigrationHandler()
+        DatabaseMigrationService.get().registerHandler(new DefaultMigrationHandler(ProteinSchema.getSchema())
         {
             @Override
-            public void beforeSchema(DbSchema targetSchema)
+            public void beforeSchema()
             {
-                new SqlExecutor(targetSchema).execute("ALTER TABLE prot.Organisms DROP CONSTRAINT FK_ProtOrganisms_ProtIdentifiers");
+                new SqlExecutor(getSchema()).execute("ALTER TABLE prot.Organisms DROP CONSTRAINT FK_ProtOrganisms_ProtIdentifiers");
                 GoLoader.dropGoIndexes();
             }
 
             @Override
-            public void afterSchema(DbSchema targetSchema)
+            public void afterSchema()
             {
-                new SqlExecutor(targetSchema).execute("ALTER TABLE prot.Organisms ADD CONSTRAINT FK_ProtOrganisms_ProtIdentifiers FOREIGN KEY (IdentId) REFERENCES prot.Identifiers (IdentId)");
+                new SqlExecutor(getSchema()).execute("ALTER TABLE prot.Organisms ADD CONSTRAINT FK_ProtOrganisms_ProtIdentifiers FOREIGN KEY (IdentId) REFERENCES prot.Identifiers (IdentId)");
                 GoLoader.dropGoIndexes();            }
         });
     }

--- a/protein/src/org/labkey/protein/ProteinModule.java
+++ b/protein/src/org/labkey/protein/ProteinModule.java
@@ -141,6 +141,15 @@ public class ProteinModule extends DefaultModule
             }
 
             @Override
+            public List<TableInfo> getTablesToCopy()
+            {
+                // Temporary: we've proven we can copy the GO tables, but they take a long time; skip them for now. TODO: Remove this override for production testing
+                return super.getTablesToCopy().stream()
+                    .filter(tableInfo -> !tableInfo.getName().startsWith("Go"))
+                    .toList();
+            }
+
+            @Override
             public @Nullable FieldKey getContainerFieldKey(TableInfo sourceTable)
             {
                 return switch (sourceTable.getName())
@@ -154,7 +163,7 @@ public class ProteinModule extends DefaultModule
             public void afterSchema()
             {
                 new SqlExecutor(getSchema()).execute("ALTER TABLE prot.Organisms ADD CONSTRAINT FK_ProtOrganisms_ProtIdentifiers FOREIGN KEY (IdentId) REFERENCES prot.Identifiers (IdentId)");
-                GoLoader.dropGoIndexes();
+                GoLoader.createGoIndexes();
             }
         });
     }

--- a/protein/src/org/labkey/protein/ProteinModule.java
+++ b/protein/src/org/labkey/protein/ProteinModule.java
@@ -23,6 +23,7 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DatabaseMigrationService;
 import org.labkey.api.data.DatabaseMigrationService.DefaultMigrationHandler;
 import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.files.FileContentService;
 import org.labkey.api.files.TableUpdaterFileListener;
@@ -39,6 +40,7 @@ import org.labkey.api.protein.go.GoLoader;
 import org.labkey.api.protein.query.CustomAnnotationSchema;
 import org.labkey.api.protein.query.ProteinUserSchema;
 import org.labkey.api.protein.search.MSSearchWebpart;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.usageMetrics.UsageMetricsService;
 import org.labkey.api.view.BaseWebPartFactory;
 import org.labkey.api.view.Portal;
@@ -136,6 +138,16 @@ public class ProteinModule extends DefaultModule
             {
                 new SqlExecutor(getSchema()).execute("ALTER TABLE prot.Organisms DROP CONSTRAINT FK_ProtOrganisms_ProtIdentifiers");
                 GoLoader.dropGoIndexes();
+            }
+
+            @Override
+            public @Nullable FieldKey getContainerFieldKey(TableInfo sourceTable)
+            {
+                return switch (sourceTable.getName())
+                {
+                    case "AnnotationTypes", "AnnotInsertions", "FastaFiles", "FastaLoads", "GoGraphPath", "GoTerm", "GoTerm2Term", "GoTermDefinition", "GoTermSynonym", "Identifiers", "IdentTypes", "InfoSources", "SprotOrgMap" -> SITE_WIDE_TABLE;
+                    default -> super.getContainerFieldKey(sourceTable);
+                };
             }
 
             @Override

--- a/protein/src/org/labkey/protein/ProteinModule.java
+++ b/protein/src/org/labkey/protein/ProteinModule.java
@@ -145,8 +145,8 @@ public class ProteinModule extends DefaultModule
             {
                 return switch (sourceTable.getName())
                 {
-                    case "AnnotationTypes", "AnnotInsertions", "FastaFiles", "FastaLoads", "GoGraphPath", "GoTerm", "GoTerm2Term", "GoTermDefinition", "GoTermSynonym", "Identifiers", "IdentTypes", "InfoSources", "SprotOrgMap" -> SITE_WIDE_TABLE;
-                    default -> super.getContainerFieldKey(sourceTable);
+                    case "CustomAnnotation", "CustomAnnotationSet" -> super.getContainerFieldKey(sourceTable);
+                    default -> SITE_WIDE_TABLE;
                 };
             }
 
@@ -154,7 +154,8 @@ public class ProteinModule extends DefaultModule
             public void afterSchema()
             {
                 new SqlExecutor(getSchema()).execute("ALTER TABLE prot.Organisms ADD CONSTRAINT FK_ProtOrganisms_ProtIdentifiers FOREIGN KEY (IdentId) REFERENCES prot.Identifiers (IdentId)");
-                GoLoader.dropGoIndexes();            }
+                GoLoader.dropGoIndexes();
+            }
         });
     }
 

--- a/protein/src/org/labkey/protein/ProteinModule.java
+++ b/protein/src/org/labkey/protein/ProteinModule.java
@@ -36,6 +36,7 @@ import org.labkey.api.protein.ProteomicsWebPartFactory;
 import org.labkey.api.protein.annotation.CustomAnnotationSetManager;
 import org.labkey.api.protein.annotation.ProteinAnnotationPipelineProvider;
 import org.labkey.api.protein.fasta.FastaDbLoader;
+import org.labkey.api.protein.go.GoLoader;
 import org.labkey.api.protein.query.CustomAnnotationSchema;
 import org.labkey.api.protein.query.ProteinUserSchema;
 import org.labkey.api.protein.search.MSSearchWebpart;
@@ -135,13 +136,14 @@ public class ProteinModule extends DefaultModule
             public void beforeSchema(DbSchema targetSchema)
             {
                 new SqlExecutor(targetSchema).execute("ALTER TABLE prot.Organisms DROP CONSTRAINT FK_ProtOrganisms_ProtIdentifiers");
+                GoLoader.dropGoIndexes();
             }
 
             @Override
             public void afterSchema(DbSchema targetSchema)
             {
                 new SqlExecutor(targetSchema).execute("ALTER TABLE prot.Organisms ADD CONSTRAINT FK_ProtOrganisms_ProtIdentifiers FOREIGN KEY (IdentId) REFERENCES prot.Identifiers (IdentId)");
-            }
+                GoLoader.dropGoIndexes();            }
         });
     }
 


### PR DESCRIPTION
#### Rationale
Drop indices before transferring data and re-add them after

#### Related Pull Requests
* https://github.com/LabKey/premiumModules/pull/351