### PR TITLE
Don't need to check for SearchService; it falls back to a no-op now

### DIFF
--- a/flow/src/org/labkey/flow/FlowModule.java
+++ b/flow/src/org/labkey/flow/FlowModule.java
@@ -281,9 +281,7 @@ public class FlowModule extends SpringModule
         AssayService.get().registerAssayProvider(new FlowAssayProvider());
 
         FolderTypeManager.get().registerFolderType(this, new FlowFolderType(this));
-        SearchService ss = SearchService.get();
-        if (null != ss)
-            ss.addDocumentParser(FCSHeader.documentParser);
+        SearchService.get().addDocumentParser(FCSHeader.documentParser);
         FlowController.registerAdminConsoleLinks();
 
         FileContentService fcs = FileContentService.get();

--- a/flow/src/org/labkey/flow/FlowModule.java
+++ b/flow/src/org/labkey/flow/FlowModule.java
@@ -296,10 +296,7 @@ public class FlowModule extends SpringModule
         if (null != svc)
         {
             FlowManager mgr = FlowManager.get();
-            if (null != mgr)
-            {
-                svc.registerUsageMetrics(NAME, mgr::getUsageMetrics);
-            }
+            svc.registerUsageMetrics(NAME, mgr::getUsageMetrics);
         }
 
         FlowSchema.registerContainerListener();

--- a/ms2/src/org/labkey/ms2/MS2Module.java
+++ b/ms2/src/org/labkey/ms2/MS2Module.java
@@ -219,15 +219,11 @@ public class MS2Module extends SpringModule implements ProteomicsModule
         MS2Controller.registerAdminConsoleLinks();
 
         SearchService ss = SearchService.get();
-
-        if (null != ss)
-        {
-            ss.addDocumentParser(new MzXMLDocumentParser());
-            ss.addDocumentParser(new MzMLDocumentParser());
-            ss.addDocumentParser(new DatDocumentParser());
-            ss.addDocumentParser(new SequestLogDocumentParser());
-            ss.addDocumentParser(new MGFDocumentParser());
-        }
+        ss.addDocumentParser(new MzXMLDocumentParser());
+        ss.addDocumentParser(new MzMLDocumentParser());
+        ss.addDocumentParser(new DatDocumentParser());
+        ss.addDocumentParser(new SequestLogDocumentParser());
+        ss.addDocumentParser(new MGFDocumentParser());
 
         FileContentService fcs = FileContentService.get();
         if (fcs != null)


### PR DESCRIPTION
#### Rationale
Recent work on the search queue introduced a no-op implementation for the service. Thus, we don't need to check if it's null anymore.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7035

#### Changes
* Just use the available `SearchService` and let it do nothing if it chooses