### PR TITLE
Add `DomainUtil.getNamesAndLabels` utility method for use in reserving variants of column names 

### DIFF
--- a/elispotassay/src/org/labkey/elispot/query/ElispotAntigenDomainKind.java
+++ b/elispotassay/src/org/labkey/elispot/query/ElispotAntigenDomainKind.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.elispot.query;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.AssayDomainKind;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcType;
@@ -87,7 +88,7 @@ public class ElispotAntigenDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return getAssayReservedPropertyNames();
     }

--- a/luminex/src/org/labkey/luminex/LuminexAnalyteDomainKind.java
+++ b/luminex/src/org/labkey/luminex/LuminexAnalyteDomainKind.java
@@ -33,8 +33,7 @@ public class LuminexAnalyteDomainKind extends AssayDomainKind
 {
     private static final Set<String> RESERVED_NAMES;
     static {
-        RESERVED_NAMES = new CaseInsensitiveHashSet(getAssayReservedPropertyNames());
-        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(
+        RESERVED_NAMES = DomainUtil.getNamesAndLabels(
                 List.of("Name",
                         "FitProb",
                         "RegressionType",
@@ -45,7 +44,8 @@ public class LuminexAnalyteDomainKind extends AssayDomainKind
                         LuminexDataHandler.POSITIVITY_THRESHOLD_COLUMN_NAME,
                         LuminexDataHandler.NEGATIVE_BEAD_COLUMN_NAME
                 )
-        ));
+        );
+        RESERVED_NAMES.addAll(getAssayReservedPropertyNames());
     }
     public LuminexAnalyteDomainKind()
     {

--- a/luminex/src/org/labkey/luminex/LuminexAnalyteDomainKind.java
+++ b/luminex/src/org/labkey/luminex/LuminexAnalyteDomainKind.java
@@ -15,10 +15,14 @@
  */
 package org.labkey.luminex;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.AssayDomainKind;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.security.User;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -27,6 +31,22 @@ import java.util.Set;
  */
 public class LuminexAnalyteDomainKind extends AssayDomainKind
 {
+    private static final Set<String> RESERVED_NAMES;
+    static {
+        RESERVED_NAMES = new CaseInsensitiveHashSet(getAssayReservedPropertyNames());
+        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(
+                List.of("Name",
+                        "FitProb",
+                        "RegressionType",
+                        "ResVar",
+                        "StdCurve",
+                        "MinStandardRecovery",
+                        "MaxStandardRecovery",
+                        LuminexDataHandler.POSITIVITY_THRESHOLD_COLUMN_NAME,
+                        LuminexDataHandler.NEGATIVE_BEAD_COLUMN_NAME
+                )
+        ));
+    }
     public LuminexAnalyteDomainKind()
     {
         super(LuminexAssayProvider.ASSAY_DOMAIN_ANALYTE);
@@ -39,27 +59,9 @@ public class LuminexAnalyteDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        Set<String> result = getAssayReservedPropertyNames();
-        result.add("Name");
-        result.add("FitProb");
-        result.add("Fit Prob");
-        result.add("RegressionType");
-        result.add("Regression Type");
-        result.add("ResVar");
-        result.add("Res Var");
-        result.add("StdCurve");
-        result.add("Std Curve");
-        result.add("MinStandardRecovery");
-        result.add("Min Standard Recovery");
-        result.add("MaxStandardRecovery");
-        result.add("Max Standard Recovery");
-        result.add(LuminexDataHandler.POSITIVITY_THRESHOLD_COLUMN_NAME);
-        result.add(LuminexDataHandler.POSITIVITY_THRESHOLD_DISPLAY_NAME);
-        result.add(LuminexDataHandler.NEGATIVE_BEAD_COLUMN_NAME);
-        result.add(LuminexDataHandler.NEGATIVE_BEAD_DISPLAY_NAME);
-        return result;
+        return RESERVED_NAMES;
     }
 
     @Override

--- a/luminex/src/org/labkey/luminex/LuminexDataDomainKind.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataDomainKind.java
@@ -15,8 +15,11 @@
  */
 package org.labkey.luminex;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.AssayDomainKind;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.security.User;
 import org.labkey.luminex.query.LuminexDataTable;
 import org.labkey.luminex.query.LuminexProtocolSchema;
@@ -30,6 +33,20 @@ import java.util.Set;
  */
 public class LuminexDataDomainKind extends AssayDomainKind
 {
+    public static final Set<String> RESERVED_NAMES;
+
+    static {
+        // Standard reserved names
+        RESERVED_NAMES = new CaseInsensitiveHashSet(getAssayReservedPropertyNames());
+        // All from the basic Luminex data table
+        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(LuminexProtocolSchema.getTableInfoDataRow().getColumnNameSet()));
+        // Also reserve the aliased names of the columns
+        for (Map.Entry<String,String> entry : LuminexDataTable.REMAPPED_SCHEMA_COLUMNS.entrySet())
+        {
+            RESERVED_NAMES.addAll(DomainUtil.getNameAndLabels(entry.getKey()));
+            RESERVED_NAMES.addAll(DomainUtil.getNameAndLabels(entry.getValue()));
+        }
+    }
     public LuminexDataDomainKind()
     {
         super(LuminexAssayProvider.ASSAY_DOMAIN_CUSTOM_DATA);
@@ -42,20 +59,8 @@ public class LuminexDataDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        // Standard reserved names
-        Set<String> result = getAssayReservedPropertyNames();
-
-        // All from the basic Luminex data table
-        result.addAll(LuminexProtocolSchema.getTableInfoDataRow().getColumnNameSet());
-
-        // Also reserve the aliased names of the columns
-        for (Map.Entry<String,String> entry : LuminexDataTable.REMAPPED_SCHEMA_COLUMNS.entrySet())
-        {
-            result.add(entry.getKey());
-            result.add(entry.getValue());
-        }
-        return result;
+        return RESERVED_NAMES;
     }
 }

--- a/luminex/src/org/labkey/luminex/LuminexDataDomainKind.java
+++ b/luminex/src/org/labkey/luminex/LuminexDataDomainKind.java
@@ -24,6 +24,7 @@ import org.labkey.api.security.User;
 import org.labkey.luminex.query.LuminexDataTable;
 import org.labkey.luminex.query.LuminexProtocolSchema;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -37,15 +38,17 @@ public class LuminexDataDomainKind extends AssayDomainKind
 
     static {
         // Standard reserved names
-        RESERVED_NAMES = new CaseInsensitiveHashSet(getAssayReservedPropertyNames());
+        Set<String> names = new HashSet<>(getAssayReservedPropertyNames());
         // All from the basic Luminex data table
-        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(LuminexProtocolSchema.getTableInfoDataRow().getColumnNameSet()));
+        names.addAll(LuminexProtocolSchema.getTableInfoDataRow().getColumnNameSet());
         // Also reserve the aliased names of the columns
         for (Map.Entry<String,String> entry : LuminexDataTable.REMAPPED_SCHEMA_COLUMNS.entrySet())
         {
-            RESERVED_NAMES.addAll(DomainUtil.getNameAndLabels(entry.getKey()));
-            RESERVED_NAMES.addAll(DomainUtil.getNameAndLabels(entry.getValue()));
+            names.add(entry.getKey());
+            names.add(entry.getValue());
         }
+
+        RESERVED_NAMES = DomainUtil.getNamesAndLabels(names);
     }
     public LuminexDataDomainKind()
     {

--- a/nab/src/org/labkey/nab/query/NabVirusDomainKind.java
+++ b/nab/src/org/labkey/nab/query/NabVirusDomainKind.java
@@ -47,8 +47,8 @@ public class NabVirusDomainKind extends AssayDomainKind
         baseFields.add(new PropertyStorageSpec(DATLSID_COLUMN_NAME, JdbcType.VARCHAR));
 
         _baseFields = Collections.unmodifiableSet(baseFields);
-        RESERVED_PROPERTY_NAMES = new CaseInsensitiveHashSet(getAssayReservedPropertyNames());
-        RESERVED_PROPERTY_NAMES.addAll(DomainUtil.getNamesAndLabels(_baseFields.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet())));
+        RESERVED_PROPERTY_NAMES = DomainUtil.getNamesAndLabels(_baseFields.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()));
+        RESERVED_PROPERTY_NAMES.addAll(getAssayReservedPropertyNames());
     }
 
     public NabVirusDomainKind()

--- a/nab/src/org/labkey/nab/query/NabVirusDomainKind.java
+++ b/nab/src/org/labkey/nab/query/NabVirusDomainKind.java
@@ -15,11 +15,14 @@
  */
 package org.labkey.nab.query;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.AssayDomainKind;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.security.User;
 import org.labkey.nab.NabAssayProvider;
 import org.labkey.nab.NabManager;
@@ -27,12 +30,14 @@ import org.labkey.nab.NabManager;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class NabVirusDomainKind extends AssayDomainKind
 {
     public static final String VIRUS_LSID_COLUMN_NAME = "virusLsid";
     public static final String DATLSID_COLUMN_NAME = "dataLsid";
     private static final Set<PropertyStorageSpec> _baseFields;
+    private static final Set<String> RESERVED_PROPERTY_NAMES;
 
     static
     {
@@ -42,6 +47,8 @@ public class NabVirusDomainKind extends AssayDomainKind
         baseFields.add(new PropertyStorageSpec(DATLSID_COLUMN_NAME, JdbcType.VARCHAR));
 
         _baseFields = Collections.unmodifiableSet(baseFields);
+        RESERVED_PROPERTY_NAMES = new CaseInsensitiveHashSet(getAssayReservedPropertyNames());
+        RESERVED_PROPERTY_NAMES.addAll(DomainUtil.getNamesAndLabels(_baseFields.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet())));
     }
 
     public NabVirusDomainKind()
@@ -74,13 +81,8 @@ public class NabVirusDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        Set<String> names = getAssayReservedPropertyNames();
-
-        for (PropertyStorageSpec spec : getBaseProperties(domain))
-            names.add(spec.getName());
-
-        return names;
+        return RESERVED_PROPERTY_NAMES;
     }
 }


### PR DESCRIPTION
#### Rationale
Because we generally allow users to provide either the name of a field or its label during import, we should consistently be reserving both the name and the label for each domain so there will not be ambiguity when trying to resolve a column during import. This PR gets us closer to consistency by adding a utility method that will create the set of reservable strings given a field's name and then uses that in various domains, also making more of the reserved field sets static constants.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7060

#### Changes
* Update `getReservedPropertyNames` with proper annotation.
* Use static set for reserved names
