### PR TITLE
Add a timeout for querying for Uniprot features

### DIFF
--- a/protein/api-src/org/labkey/api/protein/fasta/FastaProtein.java
+++ b/protein/api-src/org/labkey/api/protein/fasta/FastaProtein.java
@@ -84,7 +84,7 @@ public class FastaProtein
         if (header.startsWith("gi|"))
         {
             firstAliasIndex = header.indexOf(" gi|", 2) + 1;
-            if (firstAliasIndex < 0 || firstAliasIndex > 30)
+            if (firstAliasIndex > 30)
                 firstAliasIndex = 0;
         }
 

--- a/protein/src/org/labkey/protein/ProteinServiceImpl.java
+++ b/protein/src/org/labkey/protein/ProteinServiceImpl.java
@@ -300,6 +300,8 @@ public class ProteinServiceImpl implements ProteinService
                 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
                 con.setRequestProperty("Accept", "application/xml");
                 con.setRequestMethod("GET");
+                con.setConnectTimeout(20_000);
+                con.setReadTimeout(20_000);
                 int responseCode = con.getResponseCode();
                 if (responseCode == HttpURLConnection.HTTP_OK)
                 { // success


### PR DESCRIPTION
#### Rationale
If the EBI server is having problems, don't wait indefinitely for it to respond. This should make a few Panorama tests more robust.

#### Changes
* Give up after 20 seconds
* Minor code cleanup