### PR TITLE
Constants for many commonly used role names in tests

### DIFF
--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexGuideSetTest.java
@@ -41,6 +41,8 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class, Assays.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 28)
@@ -579,7 +581,7 @@ public final class LuminexGuideSetTest extends LuminexTest
         String editor = "editor1_luminex@luminex.test";
         String reader = "reader1_luminex@luminex.test";
 
-        createAndImpersonateUser(editor, "Editor");
+        createAndImpersonateUser(editor, EDITOR_ROLE);
 
         beginAt(ljUrl);
         _guideSetHelper.setUpLeveyJenningsGraphParams("GS Analyte B");
@@ -587,7 +589,7 @@ public final class LuminexGuideSetTest extends LuminexTest
         stopImpersonating();
         _userHelper.deleteUsers(true, editor);
 
-        createAndImpersonateUser(reader, "Reader");
+        createAndImpersonateUser(reader, READER_ROLE);
 
         beginAt(ljUrl);
         _guideSetHelper.setUpLeveyJenningsGraphParams("GS Analyte B");


### PR DESCRIPTION
#### Rationale
There's an exciting new computer science concept - using constants instead of many copies of hard-code values. Let's give it a try with our most commonly used role names in automated tests.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/2703

#### Changes
- Common role names available in PermissionsHelper
- Update tests to use them