### PR TITLE
Fix MS2 filepath

### DIFF
--- a/ms2/src/org/labkey/ms2/PepXmlImporter.java
+++ b/ms2/src/org/labkey/ms2/PepXmlImporter.java
@@ -301,9 +301,16 @@ public class PepXmlImporter extends PeptideImporter
             {
                 return f;
             }
+
+            if (NetworkDrive.exists(mzXMLFile) && mzXMLFile.isFile())
+            {
+                return mzXMLFile;
+            }
+
+            return f; // return file under root, even if it doesn't exist
         }
 
-        return mzXmlFileName == null ? null : new File(mzXmlFileName);
+        return null;
     }
 
     public static boolean isFractionsFile(File pepXmlFile, String joinedBaseName)

--- a/ms2/test/src/org/labkey/test/tests/ms2/LibraTest.java
+++ b/ms2/test/src/org/labkey/test/tests/ms2/LibraTest.java
@@ -63,11 +63,11 @@ public class LibraTest extends MS2TestBase
     protected void configure()
     {
         _containerHelper.createProject(getProjectName(), "MS2");
-        setPipelineRoot(TestFileUtils.getSampleData("xarfiles/ms2pipe/iTRAQ/").getAbsolutePath());
+        setPipelineRoot(TestFileUtils.getSampleData("xarfiles/ms2pipe/").getAbsolutePath());
         clickProject(getProjectName());
 
         clickButton("Process and Import Data");
-        _fileBrowserHelper.importFile("xtandem/Libra/iTRAQ.search.xar.xml", "Import Experiment");
+        _fileBrowserHelper.importFile("/iTRAQ/xtandem/Libra/iTRAQ.search.xar.xml", "Import Experiment");
         goToModule("Pipeline");
         waitForPipelineJobsToComplete(1, "Experiment Import - iTRAQ.search.xar.xml", false);
     }


### PR DESCRIPTION
#### Rationale
The effort to clean up file path warnings shows usages of relative and absolute filepath in MS2. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7075

#### Changes
- Update LibraTest to set pipeline root at higher level so it won't trip on invalid path error
- Prefer to return missing mzXMLFile that's under pipeline root, then without parent path (which is tomcat root). 