### PR TITLE
Return Set<Class<?>> from Module "get test" methods

### DIFF
--- a/flow/src/org/labkey/flow/FlowModule.java
+++ b/flow/src/org/labkey/flow/FlowModule.java
@@ -312,8 +312,7 @@ public class FlowModule extends SpringModule
 
 
     @Override
-    @NotNull
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             AnalysisSerializer.TestCase.class,
@@ -329,9 +328,8 @@ public class FlowModule extends SpringModule
         );
     }
 
-    @NotNull
     @Override
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             FlowController.TestCase.class,

--- a/flow/src/org/labkey/flow/persist/FlowKeywordAuditProvider.java
+++ b/flow/src/org/labkey/flow/persist/FlowKeywordAuditProvider.java
@@ -50,7 +50,8 @@ public class FlowKeywordAuditProvider extends AbstractAuditTypeProvider implemen
 
     static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
 
-    static {
+    static
+    {
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_CREATED));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_CREATED_BY));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_IMPERSONATED_BY));
@@ -58,6 +59,11 @@ public class FlowKeywordAuditProvider extends AbstractAuditTypeProvider implemen
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_KEYWORD_NAME));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_KEYWORD_OLD_VALUE));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_KEYWORD_NEW_VALUE));
+    }
+
+    public FlowKeywordAuditProvider()
+    {
+        super(new FlowKeywordAuditDomainKind());
     }
 
     @Override
@@ -73,12 +79,6 @@ public class FlowKeywordAuditProvider extends AbstractAuditTypeProvider implemen
         table.getMutableColumn(COLUMN_NAME_FILE).setURLTargetWindow("_blank");
 
         return table;
-    }
-
-    @Override
-    protected AbstractAuditDomainKind getDomainKind()
-    {
-        return new FlowKeywordAuditDomainKind();
     }
 
     @Override

--- a/luminex/src/org/labkey/luminex/LuminexModule.java
+++ b/luminex/src/org/labkey/luminex/LuminexModule.java
@@ -92,9 +92,8 @@ public class LuminexModule extends DefaultModule
         return Collections.singleton(LuminexProtocolSchema.DB_SCHEMA_NAME);
     }
 
-    @NotNull
     @Override
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             AssayQCFlagColumn.TestCase.class,

--- a/ms2/src/org/labkey/ms2/MS2Module.java
+++ b/ms2/src/org/labkey/ms2/MS2Module.java
@@ -299,8 +299,7 @@ public class MS2Module extends SpringModule implements ProteomicsModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             Comet2014ParamsBuilder.FullParseTestCase.class,
@@ -312,8 +311,7 @@ public class MS2Module extends SpringModule implements ProteomicsModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             BibliospecSpectrumRenderer.TestCase.class,

--- a/nab/src/org/labkey/nab/NabModule.java
+++ b/nab/src/org/labkey/nab/NabModule.java
@@ -116,9 +116,8 @@ public class NabModule extends DefaultModule
         PropertyService.get().registerDomainKind(new NabVirusDomainKind());
     }
 
-    @NotNull
     @Override
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(PlateParserTests.class);
     }

--- a/protein/src/org/labkey/protein/ProteinModule.java
+++ b/protein/src/org/labkey/protein/ProteinModule.java
@@ -180,7 +180,7 @@ public class ProteinModule extends DefaultModule
     }
 
     @Override
-    public @NotNull Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             ProteinController.TestCase.class
@@ -188,7 +188,7 @@ public class ProteinModule extends DefaultModule
     }
 
     @Override
-    public @NotNull Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             FastaDbLoader.TestCase.class

--- a/viability/src/org/labkey/viability/ViabilityModule.java
+++ b/viability/src/org/labkey/viability/ViabilityModule.java
@@ -84,8 +84,7 @@ public class ViabilityModule extends DefaultModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             ViabilityAssayDataHandler.TestCase.class,


### PR DESCRIPTION
#### Rationale
Eliminate IntelliJ warnings caused by `Module` methods `getUnitTests()` and `getIntegrationTests()` returning raw `Set<Class>`; they now return `Set<Class<?>>`.

Also, eliminate use of the deprecated `AbstractAuditTypeProvider()` constructor and overrides of `getDomainKind()` in its subclasses; we now always call the constructor that passes in a `DomainKind`.