### PR TITLE
Replace AbstractContainerListener with ContainerListener default

### DIFF
--- a/elisa/src/org/labkey/elisa/ElisaContainerListener.java
+++ b/elisa/src/org/labkey/elisa/ElisaContainerListener.java
@@ -5,7 +5,7 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.User;
 import org.labkey.elisa.query.ElisaManager;
 
-public class ElisaContainerListener extends ContainerManager.AbstractContainerListener
+public class ElisaContainerListener implements ContainerManager.ContainerListener
 {
     @Override
     public void containerDeleted(Container c, User user)

--- a/elisa/src/org/labkey/elisa/ElisaModule.java
+++ b/elisa/src/org/labkey/elisa/ElisaModule.java
@@ -19,9 +19,8 @@ package org.labkey.elisa;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayService;
-import org.labkey.api.assay.plate.AbstractPlateBasedAssayProvider;
 import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
@@ -75,18 +74,9 @@ public class ElisaModule extends DefaultModule
     @Override
     public void doStartup(ModuleContext moduleContext)
     {
+        ContainerManager.addContainerListener(new ElisaContainerListener());
         PlateService.get().registerPlateLayoutHandler(new ElisaPlateLayoutHandler());
         ExperimentService.get().registerExperimentDataHandler(new ElisaDataHandler());
-
-        AbstractPlateBasedAssayProvider provider = new ElisaAssayProvider();
-
-        AssayService.get().registerAssayProvider(provider);
-    }
-
-    @NotNull
-    @Override
-    public Collection<String> getSummary(Container c)
-    {
-        return Collections.emptyList();
+        AssayService.get().registerAssayProvider(new ElisaAssayProvider());
     }
 }

--- a/flow/src/org/labkey/flow/persist/FlowContainerListener.java
+++ b/flow/src/org/labkey/flow/persist/FlowContainerListener.java
@@ -16,16 +16,12 @@
 
 package org.labkey.flow.persist;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.User;
 
-public class FlowContainerListener extends ContainerManager.AbstractContainerListener
+public class FlowContainerListener implements ContainerManager.ContainerListener
 {
-    static final private Logger _log = LogManager.getLogger(FlowContainerListener.class);
-
     /**
      * Delete all Flow data from the container.
      * This code should not really be necessary since all flow data should get deleted when the associated Experiment Data object is deleted.

--- a/flow/src/org/labkey/flow/query/FlowSchema.java
+++ b/flow/src/org/labkey/flow/query/FlowSchema.java
@@ -124,7 +124,6 @@ import org.labkey.flow.reports.FlowReportManager;
 import org.labkey.flow.view.FlowQueryView;
 import org.springframework.validation.BindException;
 
-import java.beans.PropertyChangeEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1974,11 +1973,6 @@ public class FlowSchema extends UserSchema implements UserSchema.HasContextualRo
         {
             fastflowCache.removeUsingFilter(new Cache.StringPrefixFilter(c.getId() + "/"));
         }
-
-        @Override public void containerCreated(Container c, User user) { }
-        @Override public void containerMoved(Container c, Container oldParent, User user) { }
-        @NotNull @Override public Collection<String> canMove(Container c, Container newParent, User user) { return Collections.emptyList(); }
-        @Override public void propertyChange(PropertyChangeEvent evt) { }
     };
 
     public static void registerContainerListener()

--- a/microarray/src/org/labkey/microarray/MicroarrayContainerListener.java
+++ b/microarray/src/org/labkey/microarray/MicroarrayContainerListener.java
@@ -19,12 +19,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.User;
 
-/**
- * User: bbimber
- * Date: 2/23/12
- * Time: 4:42 PM
- */
-public class MicroarrayContainerListener extends ContainerManager.AbstractContainerListener
+public class MicroarrayContainerListener implements ContainerManager.ContainerListener
 {
     @Override
     public void containerDeleted(Container c, User user)

--- a/ms2/src/org/labkey/ms2/MS2ContainerListener.java
+++ b/ms2/src/org/labkey/ms2/MS2ContainerListener.java
@@ -1,42 +1,15 @@
 package org.labkey.ms2;
 
-import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.User;
 
-import java.beans.PropertyChangeEvent;
-import java.util.Collection;
-import java.util.Collections;
-
 public class MS2ContainerListener implements ContainerManager.ContainerListener
 {
-    @Override
-    public void containerCreated(Container c, User user)
-    {
-    }
-
     @Override
     public void containerDeleted(Container c, User user)
     {
         MS2Manager.markAsDeleted(c, user);
         MS2Manager.deleteExpressionData(c);
-    }
-
-    @Override
-    public void containerMoved(Container c, Container oldParent, User user)
-    {
-    }
-
-    @NotNull
-    @Override
-    public Collection<String> canMove(Container c, Container newParent, User user)
-    {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public void propertyChange(PropertyChangeEvent evt)
-    {
     }
 }

--- a/nab/src/org/labkey/nab/NabContainerListener.java
+++ b/nab/src/org/labkey/nab/NabContainerListener.java
@@ -19,12 +19,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.User;
 
-/**
- * User: adam
- * Date: Nov 5, 2008
- * Time: 3:09:06 PM
- */
-public class NabContainerListener extends ContainerManager.AbstractContainerListener
+public class NabContainerListener implements ContainerManager.ContainerListener
 {
     @Override
     public void containerDeleted(Container c, User user)

--- a/protein/src/org/labkey/protein/ProteinContainerListener.java
+++ b/protein/src/org/labkey/protein/ProteinContainerListener.java
@@ -16,24 +16,14 @@
 
 package org.labkey.protein;
 
-import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager.ContainerListener;
 import org.labkey.api.protein.annotation.CustomAnnotationSet;
 import org.labkey.api.protein.annotation.CustomAnnotationSetManager;
 import org.labkey.api.security.User;
 
-import java.beans.PropertyChangeEvent;
-import java.util.Collection;
-import java.util.Collections;
-
 public class ProteinContainerListener implements ContainerListener
 {
-    @Override
-    public void containerCreated(Container c, User user)
-    {
-    }
-
     @Override
     public void containerDeleted(Container c, User user)
     {
@@ -41,21 +31,5 @@ public class ProteinContainerListener implements ContainerListener
         {
             CustomAnnotationSetManager.deleteCustomAnnotationSet(set);
         }
-    }
-
-    @Override
-    public void propertyChange(PropertyChangeEvent evt)
-    {
-    }
-
-    @Override
-    public void containerMoved(Container c, Container oldParent, User user)
-    {
-    }
-
-    @NotNull @Override
-    public Collection<String> canMove(Container c, Container newParent, User user)
-    {
-        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
#### Rationale
Reduce boilerplate and empty methods. Most implementations only override one or two methods.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7154

#### Changes
- Remove `AbstractContainerListener`. Replace with default implementation of methods on `ContainerListener` interface.