### PR TITLE
Fix flow test failure - int vs long

### DIFF
--- a/flow/src/org/labkey/flow/controllers/attribute/summary.jsp
+++ b/flow/src/org/labkey/flow/controllers/attribute/summary.jsp
@@ -44,8 +44,8 @@
             FlowEntry primary = entry.getKey();
             Collection<FlowEntry> aliases = entry.getValue();
 
-            Map<Integer, Number> counts = FlowManager.get().getUsageCount(primary._type, primary._rowId);
-            Number primaryUsages = counts.get(primary._rowId);
+            Map<Long, Number> counts = FlowManager.get().getUsageCount(primary._type, primary._rowId);
+            Number primaryUsages = counts.get((long)primary._rowId);
     %>
     <tr>
         <td>

--- a/flow/src/org/labkey/flow/controllers/attribute/summary.jsp
+++ b/flow/src/org/labkey/flow/controllers/attribute/summary.jsp
@@ -44,11 +44,7 @@
             FlowEntry primary = entry.getKey();
             Collection<FlowEntry> aliases = entry.getValue();
 
-            Map<Long, Number> counts = FlowManager.get().getUsageCount(primary._type, primary._rowId);
-            long totalCount = 0;
-            for (Number count : counts.values())
-                totalCount += count.longValue();
-
+            Map<Integer, Number> counts = FlowManager.get().getUsageCount(primary._type, primary._rowId);
             Number primaryUsages = counts.get(primary._rowId);
     %>
     <tr>

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -48,7 +48,6 @@ import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpSampleType;
-import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.BatchValidationException;
@@ -628,7 +627,6 @@ public class FlowManager
     // Update any attribute usages of the current rowId to the new rowId, keeping the original id the same
     private int updateAttributeValuesPreferredId(@NotNull String containerId, @NotNull AttributeType type, int currentRowId, int newRowId)
     {
-        TableInfo attrTable = attributeTable(type);
         TableInfo valueTable = valueTable(type);
         String valueTableAttrIdColumn = valueTableAttrIdColumn(type);
 
@@ -739,20 +737,6 @@ public class FlowManager
         });
 
         return aliases;
-    }
-
-    public Collection<Integer> getAliasIds(final FlowEntry entry)
-    {
-        //_log.info("getAliasIds");
-        // Get the attributes that have an id equal to the entry and exclude the entry itself.
-        TableInfo table = attributeTable(entry._type);
-        SimpleFilter filter = new SimpleFilter();
-        filter.addCondition(table.getColumn("Container"), entry._containerId);
-        filter.addCondition(table.getColumn("Id"), entry._rowId);
-        filter.addCondition(table.getColumn("RowId"), entry._rowId, CompareType.NEQ);
-        TableSelector selector = new TableSelector(table, Collections.singleton("RowId"), filter, null);
-
-        return selector.getArrayList(Integer.class);
     }
 
     public Map<FlowEntry, Collection<FlowEntry>> getAliases(Container c, final AttributeType type)
@@ -873,13 +857,12 @@ public class FlowManager
     /**
      * Get a usage count for an attribute and its aliases.
      */
-    public Map<Long, Number> getUsageCount(AttributeType type, int rowId)
+    public Map<Integer, Number> getUsageCount(AttributeType type, int rowId)
     {
         FlowEntry entry = getAttributeEntry(type, rowId);
         if (entry == null)
             return Collections.emptyMap();
 
-        TableInfo attrTable = attributeTable(type);
         TableInfo valueTable = valueTable(type);
         String valueTableAttrIdColumn = valueTableAttrIdColumn(type);
         String valueTableOriginalAttrIdColumn = valueTableOriginalAttrIdColumn(type);
@@ -894,7 +877,7 @@ public class FlowManager
                 .append("GROUP BY val.").append(valueTableOriginalAttrIdColumn).append("\n");
 
         SqlSelector selector = new SqlSelector(getSchema(), sql);
-        return selector.getValueMap(Long.class);
+        return selector.getValueMap(Integer.class);
     }
 
     /**
@@ -913,7 +896,6 @@ public class FlowManager
         if (entry == null)
             return Collections.emptyList();
 
-        TableInfo attrTable = attributeTable(entry._type);
         TableInfo valueTable = valueTable(entry._type);
         String valueTableAttrIdColumn = valueTableAttrIdColumn(entry._type);
         String valueTableOriginalAttrIdColumn = valueTableOriginalAttrIdColumn(entry._type);
@@ -949,7 +931,6 @@ public class FlowManager
         if (entry == null)
             return Collections.emptyMap();
 
-        TableInfo attrTable = attributeTable(type);
         TableInfo valueTable = valueTable(type);
         String valueTableAttrIdColumn = valueTableAttrIdColumn(type);
         String valueTableOriginalAttrIdColumn = valueTableOriginalAttrIdColumn(type);
@@ -1094,15 +1075,6 @@ public class FlowManager
         }
     }
 
-    public void deleteAttributes(ExpData data)
-    {
-        AttrObject obj = getAttrObject(data);
-        if (obj == null)
-            return;
-        deleteAttributes(new Integer[] {obj.getRowId()});
-    }
-
-
     private void deleteObjectIds(Integer[] oids, Set<Container> containers)
     {
         DbScope scope = getSchema().getScope();
@@ -1212,7 +1184,7 @@ public class FlowManager
         String sampleLabel = data.getName();
         ensureKeywordName(c, sampleLabel, keyword, true);
 
-        AttributeCache.Entry a = AttributeCache.KEYWORDS.byAttribute(c, keyword);
+        AttributeCache.Entry<?, ?> a = AttributeCache.KEYWORDS.byAttribute(c, keyword);
         assert a != null : "Expected to find keyword entry for '" + keyword + "'";
         int preferredId = a.getAliasedId() == null ? a.getRowId() : a.getAliasedId();
         int originalId = a.getRowId();
@@ -1478,7 +1450,7 @@ public class FlowManager
 
         // count(fcsfile)
         TableInfo table = schema.getTable(FlowTableType.FCSFiles, null);
-        List<Aggregate> aggregates = Collections.singletonList(new Aggregate("RowId", Aggregate.BaseType.COUNT));
+        List<Aggregate> aggregates = Collections.singletonList(new Aggregate(FieldKey.fromParts("RowId"), Aggregate.BaseType.COUNT));
         List<ColumnInfo> columns = Collections.singletonList(table.getColumn("RowId"));
 
         // filter to those wells that were imported from a Keywords run
@@ -1489,8 +1461,8 @@ public class FlowManager
         Map<String, List<Aggregate.Result>> agg = new TableSelector(table, columns, filter, null).getAggregates(aggregates);
         //TODO: multiple aggregates
         Aggregate.Result result = agg.get(aggregates.get(0).getColumnName()).get(0);
-        if (result != null && result.getValue() instanceof Number)
-            return ((Number)result.getValue()).intValue();
+        if (result != null && result.getValue() instanceof Number n)
+            return n.intValue();
 
         return 0;
     }
@@ -1503,7 +1475,7 @@ public class FlowManager
         filter.addCondition(FieldKey.fromParts("FCSFileCount"), 0, CompareType.NEQ);
         filter.addCondition(FieldKey.fromParts("ProtocolStep"), "Keywords", CompareType.EQUAL);
         TableInfo table = schema.getTable(FlowTableType.Runs, null);
-        List<Aggregate> aggregates = Collections.singletonList(new Aggregate("RowId", Aggregate.BaseType.COUNT));
+        List<Aggregate> aggregates = Collections.singletonList(new Aggregate(FieldKey.fromParts("RowId"), Aggregate.BaseType.COUNT));
         List<ColumnInfo> columns = Collections.singletonList(table.getColumn("RowId"));
         Map<String, List<Aggregate.Result>> agg = new TableSelector(table, columns, filter, null).getAggregates(aggregates);
         Aggregate.Result result = agg.get("RowId").get(0);
@@ -1629,7 +1601,7 @@ public class FlowManager
         final OntologyManager.ImportHelper helper = new OntologyManager.ImportHelper()
         {
             @Override
-            public String beforeImportObject(Map<String, Object> map) throws SQLException
+            public String beforeImportObject(Map<String, Object> map)
             {
                 String lsid = (String)map.get("lsid");
                 assert lsid != null;

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -287,12 +287,12 @@ public class FlowManager
     public static class FlowEntry implements Comparable<FlowEntry>
     {
         public final AttributeType _type;
-        public final Integer _rowId;
+        public final int _rowId;
         public final String _containerId;
         public final String _name;
-        public final Integer _aliasId;
+        public final int _aliasId;
 
-        public FlowEntry(@NotNull AttributeType type, @NotNull Integer rowId, @NotNull String containerId, @NotNull String name, @NotNull Integer aliasId)
+        public FlowEntry(@NotNull AttributeType type, @NotNull int rowId, @NotNull String containerId, @NotNull String name, @NotNull Integer aliasId)
         {
             _type = type;
             _rowId = rowId;
@@ -303,7 +303,7 @@ public class FlowManager
 
         public boolean isAlias()
         {
-            return !_rowId.equals(_aliasId);
+            return _rowId != _aliasId;
         }
 
         @Override
@@ -314,7 +314,7 @@ public class FlowManager
 
             FlowEntry flowEntry = (FlowEntry) o;
 
-            if (!_rowId.equals(flowEntry._rowId)) return false;
+            if (_rowId != flowEntry._rowId) return false;
             if (_type != flowEntry._type) return false;
 
             return true;
@@ -324,7 +324,7 @@ public class FlowManager
         public int hashCode()
         {
             int result = _type.hashCode();
-            result = 31 * result + _rowId.hashCode();
+            result = 31 * result + Integer.hashCode(_rowId);
             return result;
         }
 
@@ -547,7 +547,7 @@ public class FlowManager
                     return;
 
                 // If this existing entry is already an alias of entry, do nothing
-                if (existing._aliasId.equals(entry._rowId))
+                if (existing._aliasId == entry._rowId)
                     return;
 
                 // If this existing entry doesn't have any aliases, we can make this existing entry an alias of the entry.
@@ -857,7 +857,7 @@ public class FlowManager
     /**
      * Get a usage count for an attribute and its aliases.
      */
-    public Map<Integer, Number> getUsageCount(AttributeType type, int rowId)
+    public Map<Long, Number> getUsageCount(AttributeType type, int rowId)
     {
         FlowEntry entry = getAttributeEntry(type, rowId);
         if (entry == null)
@@ -877,7 +877,7 @@ public class FlowManager
                 .append("GROUP BY val.").append(valueTableOriginalAttrIdColumn).append("\n");
 
         SqlSelector selector = new SqlSelector(getSchema(), sql);
-        return selector.getValueMap(Integer.class);
+        return selector.getValueMap(Long.class);
     }
 
     /**

--- a/flow/src/org/labkey/flow/persist/PersistTests.java
+++ b/flow/src/org/labkey/flow/persist/PersistTests.java
@@ -140,7 +140,7 @@ public class PersistTests
             AttributeCache.KeywordEntry cacheEntry = AttributeCache.KEYWORDS.byName(c, "keyword1");
             assertEquals("keyword1", cacheEntry.getAttribute());
             assertEquals(c, cacheEntry.getContainer());
-            assertEquals(entry._rowId.intValue(), cacheEntry.getRowId());
+            assertEquals(entry._rowId, cacheEntry.getRowId());
 
             // verify cached keyword alias
             Collection<AttributeCache.KeywordEntry> cacheAliases = cacheEntry.getAliases();


### PR DESCRIPTION
#### Rationale
The exp.Object BIGINT conversion looks like it accidentally migrated this use from `Integer` to `Long` though the flow.Object table is still using ints.

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyCPostgres/3717647?buildTab=tests&status=failed&name=FlowSpecimenTest

#### Changes
* Use to `Long` more consistently
* Code cleanup, including deleting unused methods and variables
