### PR TITLE
Customize build to enable full Java code analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -116,5 +116,5 @@ jobs:
       uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"
-        ref: ${{ github.ref }} # since we are running this command in the root dir and that root is cloned via LabKey/server
-        sha: ${{ github.sha }}
+        ref: ${{ github.event.pull_request.head.ref || github.ref }} # since we are running this command in the root dir and that root is cloned via LabKey/server
+        sha: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,8 +45,8 @@ jobs:
         include:
         - language: actions
           build-mode: none
-        #- language: java-kotlin
-        #  build-mode: manual # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
+        - language: java-kotlin
+          build-mode: manual # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
         - language: javascript-typescript
           build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,7 +74,7 @@ jobs:
       with:
         repository: LabKey/commonAssays
         path: server/modules/commonAssays
-
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,103 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "develop", "release*" ]
+  pull_request:
+    branches: [ "develop", "release*" ]
+  schedule:
+    - cron: '36 17 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: java-kotlin
+          build-mode: autobuild # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
+        - language: javascript-typescript
+          build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Add any setup steps before running the `github/codeql-action/init` action.
+    # This includes steps like installing compilers or runtimes (`actions/setup-node`
+    # or others). This is typically only required for manual builds.
+    # - name: Setup runtime (example)
+    #   uses: actions/setup-example@v1
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - name: Run manual build steps
+      if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -111,7 +111,6 @@ jobs:
         echo '  make bootstrap'
         echo '  make release'
         ./gradlew deployApp
-        exit 1
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -116,5 +116,5 @@ jobs:
       uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"
-        ref: ${{ github.event.pull_request.head.ref || github.ref }} # since we are running this command in the root dir and that root is cloned via LabKey/server
+        ref: "refs/heads/${{ github.event.pull_request.head.ref || github.ref_name }}" # since we are running this command in the root dir and that root is cloned via LabKey/server
         sha: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -115,6 +115,6 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
       with:
-        category: "/language:${{matrix.language}}
+        category: "/language:${{matrix.language}}"
         ref: ${{ github.ref }} # since we are running this command in the root dir and that root is cloned via LabKey/server
         sha: ${{ github.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -115,6 +115,6 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
       with:
-        category: "/language:${{matrix.language}}"
-        ref: ${{ github.repository_owner }} # since we are running this command in the root dir and that root is cloned via LabKey/server
+        category: "/language:${{matrix.language}}
+        ref: ${{ github.ref }} # since we are running this command in the root dir and that root is cloned via LabKey/server
         sha: ${{ github.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -116,3 +116,5 @@ jobs:
       uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"
+        ref: ${{ github.repository_owner }} # since we are running this command in the root dir and that root is cloned via LabKey/server
+        sha: ${{ github.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,8 +45,8 @@ jobs:
         include:
         - language: actions
           build-mode: none
-        - language: java-kotlin
-          build-mode: manual # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
+        #- language: java-kotlin
+        #  build-mode: manual # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
         - language: javascript-typescript
           build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
@@ -62,12 +62,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: LabKey/server
-
-    - name: Checkout LabKey/platform
-      uses: actions/checkout@v4
-      with:
-        repository: LabKey/platform
-        path: server/modules/platform
 
     - name: Checkout LabKey/commonAssays
       uses: actions/checkout@v4
@@ -116,5 +110,6 @@ jobs:
       uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"
+        checkout_path: "server/modules/commonAssays"
         ref: "refs/heads/${{ github.event.pull_request.head.ref || github.ref_name }}" # since we are running this command in the root dir and that root is cloned via LabKey/server
         sha: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,8 +58,23 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-    - name: Checkout repository
+    - name: Checkout LabKey/server
       uses: actions/checkout@v4
+      with:
+        repository: LabKey/server
+
+    - name: Checkout LabKey/platform
+      uses: actions/checkout@v4
+      with:
+        repository: LabKey/platform
+        path: server/modules/platform
+
+    - name: Checkout LabKey/commonAssays
+      uses: actions/checkout@v4
+      with:
+        repository: LabKey/commonAssays
+        path: server/modules/commonAssays
+
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -95,11 +110,6 @@ jobs:
           'your code, for example:'
         echo '  make bootstrap'
         echo '  make release'
-        git clone https://github.com/LabKey/server
-        cd server/modules
-        git clone https://github.com/LabKey/platform
-        git clone https://github.com/LabKey/commonAssays
-        cd ../..
         ./gradlew deployApp
         exit 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
         - language: actions
           build-mode: none
         - language: java-kotlin
-          build-mode: autobuild # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
+          build-mode: manual # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
         - language: javascript-typescript
           build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
@@ -95,6 +95,12 @@ jobs:
           'your code, for example:'
         echo '  make bootstrap'
         echo '  make release'
+        git clone https://github.com/LabKey/server
+        cd server/modules
+        git clone https://github.com/LabKey/platform
+        git clone https://github.com/LabKey/commonAssays
+        cd ../..
+        ./gradlew deployApp
         exit 1
 
     - name: Perform CodeQL Analysis


### PR DESCRIPTION
#### Rationale
Customize build to enable full Java code analysis.

#### Changes
* Check out `server` repo, build together, and push CodeQL results for `commonAssays`
