### PR TITLE
Add repository owner reference to CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -117,4 +117,4 @@ jobs:
       with:
         category: "/language:${{matrix.language}}"
         ref: ${{ github.repository_owner }} # since we are running this command in the root dir and that root is cloned via LabKey/server
-        #sha: ${{ github.sha }}
+        sha: ${{ github.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -116,3 +116,5 @@ jobs:
       uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"
+        ref: ${{ github.repository_owner }} # since we are running this command in the root dir and that root is cloned via LabKey/server
+        #sha: ${{ github.sha }}


### PR DESCRIPTION
Added a reference to the repository owner in CodeQL analysis.  Action code is likely looking at the directory's git config to detect the repo - this explicitly passes in via action.

