### PR TITLE
Update CodeQL analysis ref to use github.ref

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -115,6 +115,6 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
       with:
-        category: "/language:${{matrix.language}}"
-        ref: ${{ github.repository_owner }} # since we are running this command in the root dir and that root is cloned via LabKey/server
+        category: "/language:${{matrix.language}}
+        ref: ${{ github.ref }} # since we are running this command in the root dir and that root is cloned via LabKey/server
         sha: ${{ github.sha }}


### PR DESCRIPTION

Based on the most recent build error, github.repository_owner wasn't providing the correct data type that we anticipated. Our changes to be more specific about github.sha may have been enough.