### PR TITLE
Update MS2 `SpectrumImporter` to work with Java 25

### DIFF
--- a/ms2/src/org/labkey/ms2/PepXmlImporter.java
+++ b/ms2/src/org/labkey/ms2/PepXmlImporter.java
@@ -226,8 +226,7 @@ public class PepXmlImporter extends PeptideImporter
 
     protected void processSpectrumFile(PepXmlFraction fraction, Set<Integer> scans, MS2Progress progress, boolean shouldLoadSpectra, boolean shouldLoadRetentionTimes)
     {
-        File mzXmlFile = getMzXMLFile(fraction);
-        FileLike mzXmlFileLike = null;
+        FileLike mzXmlFile = FileSystemLike.wrapFile(getMzXMLFile(fraction));
         if ((_run.getType().equalsIgnoreCase(MS2RunType.Mascot.name())||_run.getType().equalsIgnoreCase(MS2RunType.Sequest.name()))   // TODO: Move this check (perhaps all the code) into the appropriate run classes
                 && null == mzXmlFile)
         {
@@ -242,25 +241,19 @@ public class PepXmlImporter extends PeptideImporter
             String mzXmlFileName = engineProtocolMzXMLFile.getName();
             FileLike engineProtocolDir = engineProtocolMzXMLFile.getParent();
             FileLike engineDir = engineProtocolDir.getParent();
-            FileLike mzXMLFile = engineDir.getParent().resolveFile(Path.parse(mzXmlFileName));
-            mzXmlFileLike = mzXMLFile;
+            mzXmlFile = engineDir.getParent().resolveFile(Path.parse(mzXmlFileName));
         }
-        String gzFileName = _path + "/" + _gzFileName;
-        File gzFile = _context.findFile(gzFileName);
-        if (gzFile != null)
-        {
-            gzFileName = gzFile.toString();
-        }
+        FileLike gzFile = FileSystemLike.wrapFile(_context.findFile(_path)).resolveChild(_gzFileName);
         //sequest spectra are imported from the tgz but are deleted after they are imported.
-        if(_run.getType().equalsIgnoreCase("sequest") && mzXmlFile != null)   // TODO: Move this check (perhaps all the code) into the appropriate run classes
+        if(_run.getType().equalsIgnoreCase(MS2RunType.Sequest.name()) && mzXmlFile != null)   // TODO: Move this check (perhaps all the code) into the appropriate run classes
         {
             if (NetworkDrive.exists(mzXmlFile))
             {
-                gzFileName = "";
+                gzFile = null;
             }
         }
 
-        SpectrumImporter sl = new SpectrumImporter(gzFileName, "", mzXmlFileLike, scans, progress, _fractionId, _log, shouldLoadSpectra, shouldLoadRetentionTimes);
+        SpectrumImporter sl = new SpectrumImporter(gzFile, "", mzXmlFile, scans, progress, _fractionId, _log, shouldLoadSpectra, shouldLoadRetentionTimes);
         sl.upload();
         updateFractionSpectrumFileName(sl.getFile() == null ? null : sl.getFile().toNioPathForRead().toFile());
     }

--- a/ms2/src/org/labkey/ms2/SpectrumImporter.java
+++ b/ms2/src/org/labkey/ms2/SpectrumImporter.java
@@ -16,17 +16,18 @@
 
 package org.labkey.ms2;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.Pair;
-import org.labkey.ms2.reader.*;
+import org.labkey.ms2.reader.AbstractMzxmlIterator;
+import org.labkey.ms2.reader.SimpleScan;
+import org.labkey.ms2.reader.SimpleScanIterator;
+import org.labkey.ms2.reader.TarIterator;
 import org.labkey.vfs.FileLike;
-import org.labkey.vfs.FileSystemLike;
 
 import javax.xml.stream.XMLStreamException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -55,7 +56,7 @@ public class SpectrumImporter
     private final boolean _shouldImportRetentionTime;
 
 
-    protected SpectrumImporter(String gzFileName, String dtaFileNamePrefix, FileLike mzXmlFile, Set<Integer> scans, MS2Importer.MS2Progress progress, int fractionId, Logger log, boolean shouldImportSpectra, boolean shouldImportRetentionTime)
+    protected SpectrumImporter(FileLike gzFile, String dtaFileNamePrefix, FileLike mzXmlFile, Set<Integer> scans, MS2Importer.MS2Progress progress, int fractionId, Logger log, boolean shouldImportSpectra, boolean shouldImportRetentionTime)
     {
         _scans = scans;
         _progress = progress;
@@ -70,22 +71,20 @@ public class SpectrumImporter
         try
         {
             // Try to access the gz file first... if that fails, try to open the mzXML file
-            File gz = new File(gzFileName);
-
-            if (NetworkDrive.exists(gz))
+            if (NetworkDrive.exists(gzFile))
             {
-                _file = FileSystemLike.wrapFile(gz);
-                _scanIterator = new TarIterator(gz, dtaFileNamePrefix);
+                _file = gzFile;
+                _scanIterator = new TarIterator(gzFile, dtaFileNamePrefix);
             }
             else
             {
                 if (null == mzXmlFile)
-                    _log.warn("Spectra were not imported: " + gzFileName + " could not be opened and no mzXML file name was specified.");
+                    _log.warn("Spectra were not imported: " + gzFile + " could not be opened and no mzXML file name was specified.");
                 else
                 {
                     _file = mzXmlFile;
                     // prefer ProteoWizard's RAMPAdapter interface
-                    // (with JNI bindings via SWIG) as it's actively 
+                    // (with JNI bindings via SWIG) as it's actively
                     // maintained, handles mzML and mzXML, and gzipped
                     // files natively
                     _scanIterator = AbstractMzxmlIterator.createParser(_file, 2);
@@ -99,7 +98,7 @@ public class SpectrumImporter
         catch (XMLStreamException x)
         {
             throw new RuntimeException(x);
-        }        
+        }
     }
 
     protected void upload()

--- a/ms2/src/org/labkey/ms2/reader/TarIterator.java
+++ b/ms2/src/org/labkey/ms2/reader/TarIterator.java
@@ -165,6 +165,14 @@ public class TarIterator implements SimpleScanIterator
         }
     }
 
+    @Override
+    protected void finalize() throws Throwable
+    {
+        super.finalize();
+
+        assert null == _is && null == _gzInputStream && null == _tis;
+    }
+
 
     private static byte[] realloc(int size, byte[] buf)
     {

--- a/ms2/src/org/labkey/ms2/reader/TarIterator.java
+++ b/ms2/src/org/labkey/ms2/reader/TarIterator.java
@@ -17,15 +17,14 @@ package org.labkey.ms2.reader;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.arrays.FloatArray;
 import org.labkey.ms2.FloatParser;
 import org.labkey.ms2.MS2Importer;
+import org.labkey.vfs.FileLike;
 
 import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.GZIPInputStream;
@@ -53,13 +52,13 @@ public class TarIterator implements SimpleScanIterator
     private byte[] _spectrumData = new byte[BUFFER_SIZE];
 
 
-    public TarIterator(File gzFile, String dtaFileNamePrefix) throws java.io.IOException
+    public TarIterator(FileLike gzFile, String dtaFileNamePrefix) throws java.io.IOException
     {
         boolean success = false;
         try
         {
             _dtaFileNamePrefix = dtaFileNamePrefix;
-            _is = new BufferedInputStream(new FileInputStream(gzFile), STREAM_BUFFER_SIZE);
+            _is = new BufferedInputStream(gzFile.openInputStream(), STREAM_BUFFER_SIZE);
             _gzInputStream = new GZIPInputStream(_is);
             _tis = new TarArchiveInputStream(_gzInputStream);
             success = true;
@@ -164,14 +163,6 @@ public class TarIterator implements SimpleScanIterator
             }
             _is = null;
         }
-    }
-
-    @Override
-    protected void finalize() throws Throwable
-    {
-        super.finalize();
-
-        assert null == _is && null == _gzInputStream && null == _tis;
     }
 
 


### PR DESCRIPTION
#### Rationale
Java 25 fixes an [inconsistency in the behavior of `File.exists`](https://bugs.openjdk.org/browse/JDK-8024695) where `new File("")` refers to the working directory in most cases but `new File("").exists` erroneously returns `false`. `SpectrumImporter` depended on the old behavior to determine which file to import.
```
java.lang.NullPointerException: Cannot invoke "java.io.File.toURI()" because "f" is null
	at org.labkey.vfs.FileSystemLike$Builder.<init>(FileSystemLike.java:135)
	at org.labkey.vfs.FileSystemLike.wrapFile(FileSystemLike.java:257)
	at org.labkey.ms2.SpectrumImporter.<init>(SpectrumImporter.java:77)
	at org.labkey.ms2.PepXmlImporter.processSpectrumFile(PepXmlImporter.java:263)
	at org.labkey.ms2.PepXmlImporter.importRun(PepXmlImporter.java:150)
	at org.labkey.ms2.MS2Importer.upload(MS2Importer.java:201)
	at org.labkey.ms2.MS2Manager.importRun(MS2Manager.java:619)
	at org.labkey.ms2.pipeline.MS2ImportPipelineJob.run(MS2ImportPipelineJob.java:110)
```

While investigating this issue, I noticed that `PepXmlImporter.processSpectrumFile` won't ever upload the file returned by `getMzXMLFile`. This seems to be a regression caused by the latest FileLike changes.

Using `FileLike` a little more, with `null` representing non-existent files (instead of empty Strings) fixes both of these issues.

#### Related Pull Requests
* #960 

#### Changes
* Update MS2 `SpectrumImporter` to work with Java 25
* Restore `mzXmlFile` import behavior in `PepXmlImporter.processSpectrumFile`
