### PR TITLE
Remove unused User parameters from service methods

### DIFF
--- a/flow/src/org/labkey/flow/controllers/protocol/EditICSMetadataForm.java
+++ b/flow/src/org/labkey/flow/controllers/protocol/EditICSMetadataForm.java
@@ -228,7 +228,7 @@ public class EditICSMetadataForm extends ProtocolForm
         }
 
         FieldKey sampleProperty = FieldKey.fromParts("FCSFile", "Sample");
-        ExpSampleType sampleType = getProtocol().getSampleType(getUser());
+        ExpSampleType sampleType = getProtocol().getSampleType();
         if (sampleType != null)
         {
             if (sampleType.hasNameAsIdCol())

--- a/flow/src/org/labkey/flow/controllers/protocol/JoinSampleTypeForm.java
+++ b/flow/src/org/labkey/flow/controllers/protocol/JoinSampleTypeForm.java
@@ -69,7 +69,7 @@ public class JoinSampleTypeForm extends ProtocolForm
     {
         LinkedHashMap<String,String> ret = new LinkedHashMap<>();
         ret.put("", "");
-        ExpSampleType sampleType = getProtocol().getSampleType(getUser());
+        ExpSampleType sampleType = getProtocol().getSampleType();
         if (sampleType != null)
         {
             if (sampleType.hasNameAsIdCol())

--- a/flow/src/org/labkey/flow/controllers/protocol/joinSampleType.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/joinSampleType.jsp
@@ -24,7 +24,7 @@
 <%
     JoinSampleTypeForm form = (JoinSampleTypeForm) __form;
 
-    if (form.getProtocol().getSampleType(getUser()) == null)
+    if (form.getProtocol().getSampleType() == null)
     {
         %>
         <p>You must first upload a sample type before specifying how to match samples to FCS files.</p>

--- a/flow/src/org/labkey/flow/controllers/protocol/showProtocol.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/showProtocol.jsp
@@ -27,7 +27,7 @@
 <%
     ProtocolForm form = (ProtocolForm) __form;
     FlowProtocol protocol = form.getProtocol();
-    ExpSampleType sampleType = protocol.getSampleType(getUser());
+    ExpSampleType sampleType = protocol.getSampleType();
 %>
 <p>
     The Flow Protocol describes sample information and metadata about the experiment.

--- a/flow/src/org/labkey/flow/controllers/protocol/showSamples2.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/showSamples2.jsp
@@ -37,7 +37,7 @@
 <%
     ProtocolForm form = (ProtocolForm) __form;
     FlowProtocol protocol = form.getProtocol();
-    ExpSampleType st = protocol.getSampleType(getUser());
+    ExpSampleType st = protocol.getSampleType();
 
     ExperimentUrls expUrls = urlProvider(ExperimentUrls.class);
 

--- a/flow/src/org/labkey/flow/controllers/protocol/updateSamples.jsp
+++ b/flow/src/org/labkey/flow/controllers/protocol/updateSamples.jsp
@@ -25,5 +25,5 @@
     <%= form.fileCount%> FCS files were linked to samples in this sample type.
 </p>
 <p><a href="<%=h(form.getProtocol().urlShowSamples())%>">Show linked samples</a><br>
-<a href="<%=h(form.getProtocol().getSampleType(getUser()).detailsURL())%>">Show all samples</a><br>
+<a href="<%=h(form.getProtocol().getSampleType().detailsURL())%>">Show all samples</a><br>
 <a href="<%=h(form.getProtocol().urlFor(ProtocolController.JoinSampleTypeAction.class))%>">Edit join properties</a></p>

--- a/flow/src/org/labkey/flow/data/FlowProtocol.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocol.java
@@ -255,6 +255,10 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
     /**
      * Returns the sample type in scope
      */
+    public ExpSampleType getSampleType(User user)
+    {
+        return SampleTypeService.get().getSampleType(getContainer(), SAMPLETYPE_NAME, true);
+    }
     public ExpSampleType getSampleType()
     {
         return SampleTypeService.get().getSampleType(getContainer(), SAMPLETYPE_NAME, true);

--- a/flow/src/org/labkey/flow/data/FlowProtocol.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocol.java
@@ -255,9 +255,9 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
     /**
      * Returns the sample type in scope
      */
-    public ExpSampleType getSampleType(User user)
+    public ExpSampleType getSampleType()
     {
-        return SampleTypeService.get().getSampleType(getContainer(), user, SAMPLETYPE_NAME);
+        return SampleTypeService.get().getSampleType(getContainer(), SAMPLETYPE_NAME, true);
     }
 
     /**
@@ -305,14 +305,14 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
         return ret;
     }
 
-    public String getSampleTypeLSID(User user)
+    public String getSampleTypeLSID()
     {
         String propValue = (String) getProperty(ExperimentProperty.SampleTypeLSID.getPropertyDescriptor());
         if (propValue != null)
             return propValue;
 
         // get lsid for sample type with name "Samples"
-        ExpSampleType sampleType = getSampleType(user);
+        ExpSampleType sampleType = getSampleType();
         if (sampleType != null)
             return sampleType.getLSID();
 
@@ -328,7 +328,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
         }
         String value = StringUtils.join(strings.iterator(), "&");
         setProperty(user, FlowProperty.SampleTypeJoin.getPropertyDescriptor(), value);
-        setProperty(user, ExperimentProperty.SampleTypeLSID.getPropertyDescriptor(), getSampleTypeLSID(user));
+        setProperty(user, ExperimentProperty.SampleTypeLSID.getPropertyDescriptor(), getSampleTypeLSID());
         FlowManager.get().flowObjectModified();
     }
 
@@ -352,7 +352,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
 
     public Map<SampleKey, ExpMaterial> getSampleMap(User user)
     {
-        ExpSampleType st = getSampleType(user);
+        ExpSampleType st = getSampleType();
         if (st == null)
             return Collections.emptyMap();
         Set<String> propertyNames = getSampleTypeJoinFields().keySet();
@@ -433,7 +433,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
         Map<SampleKey, ExpMaterial> sampleMap = getSampleMap(user);
         _log.debug("sampleMap=" + sampleMap.size());
 
-        ExpSampleType st = getSampleType(user);
+        ExpSampleType st = getSampleType();
         _log.debug("sampleType=" + (st == null ? "<none>" : st.getName()) + ", lsid=" + (st == null ? "<none>" : st.getLSID()));
 
         FlowSchema schema = new FlowSchema(user, getContainer());
@@ -604,7 +604,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
                 "__FCSFiles.Sample = M.RowId\n" +
                 "ORDER BY M.Name, __FCSFiles.RowId";
 
-        ExpSampleType sampleType = getSampleType(user);
+        ExpSampleType sampleType = getSampleType();
         ContainerFilter cf = getContainerFilter(sampleType, user);
         UserSchema userSchema = QueryService.get().getUserSchema(user, getContainer(), SamplesSchema.SCHEMA_NAME);
         TableInfo sampleTable = userSchema.getTable(SAMPLETYPE_NAME, cf);
@@ -1017,8 +1017,8 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
             assertEquals(0, fcsFiles[1].getSamples().size());
 
             // create sample type
-            assertNull(protocol.getSampleType(user));
-            String sampleTypeLSID = protocol.getSampleTypeLSID(user);
+            assertNull(protocol.getSampleType());
+            String sampleTypeLSID = protocol.getSampleTypeLSID();
             assertNull(sampleTypeLSID);
 
             List<GWTPropertyDescriptor> props = List.of(
@@ -1029,9 +1029,9 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
             );
             ExpSampleType st = SampleTypeService.get().createSampleType(c, user, SAMPLETYPE_NAME, null,
                     props, List.of(), -1,-1,-1,-1,null);
-            assertNotNull(protocol.getSampleType(user));
+            assertNotNull(protocol.getSampleType());
 
-            sampleTypeLSID = protocol.getSampleTypeLSID(user);
+            sampleTypeLSID = protocol.getSampleTypeLSID();
             assertNotNull(sampleTypeLSID);
 
             // add join fields

--- a/flow/src/org/labkey/flow/persist/FlowKeywordAuditProvider.java
+++ b/flow/src/org/labkey/flow/persist/FlowKeywordAuditProvider.java
@@ -100,16 +100,6 @@ public class FlowKeywordAuditProvider extends AbstractAuditTypeProvider implemen
     }
 
     @Override
-    public Map<FieldKey, String> legacyNameMap()
-    {
-        Map<FieldKey, String> legacyNames = super.legacyNameMap();
-        legacyNames.put(FieldKey.fromParts("key1"), COLUMN_NAME_DIRECTORY);
-        legacyNames.put(FieldKey.fromParts("key2"), COLUMN_NAME_FILE);
-        legacyNames.put(FieldKey.fromParts("key3"), COLUMN_NAME_KEYWORD_NAME);
-        return legacyNames;
-    }
-
-    @Override
     public <K extends AuditTypeEvent> Class<K> getEventClass()
     {
         return (Class<K>)FlowKeywordAuditEvent.class;

--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -1359,7 +1359,7 @@ public class FlowManager
         FlowProtocol protocol = FlowProtocol.getForContainer(c);
         if (protocol != null)
         {
-            ExpSampleType st = protocol.getSampleType(user);
+            ExpSampleType st = protocol.getSampleType();
             if (st != null)
             {
                 // put sample count at top-level since it isn't really specific to the protocol

--- a/flow/src/org/labkey/flow/query/FlowSchema.java
+++ b/flow/src/org/labkey/flow/query/FlowSchema.java
@@ -1518,7 +1518,7 @@ public class FlowSchema extends UserSchema implements UserSchema.HasContextualRo
         ExpSampleType st = null;
         if (_protocol != null)
         {
-            st = _protocol.getSampleType(getUser());
+            st = _protocol.getSampleType();
         }
         var colMaterialInput = ret.addMaterialInputColumn("Sample", new SamplesSchema(getUser(), getContainer()), ExpMaterialRunInput.DEFAULT_ROLE, st);
         if (st == null)

--- a/flow/src/org/labkey/flow/reports/statPicker.jsp
+++ b/flow/src/org/labkey/flow/reports/statPicker.jsp
@@ -68,7 +68,7 @@
 
     Collection<String> sampleTypeProperties = new ArrayList<>();
     FlowProtocol protocol = FlowProtocol.ensureForContainer(getUser(), getContainer());
-    ExpSampleType sampleType = protocol.getSampleType(getUser());
+    ExpSampleType sampleType = protocol.getSampleType();
     if (sampleType != null)
     {
         for (DomainProperty dp : sampleType.getDomain().getProperties())

--- a/flow/src/org/labkey/flow/webparts/FlowOverview.java
+++ b/flow/src/org/labkey/flow/webparts/FlowOverview.java
@@ -190,7 +190,7 @@ public class FlowOverview extends Overview
         Step ret = new Step("Assign additional meanings to keywords", status);
         if (protocol != null)
         {
-            ExpSampleType st = protocol.getSampleType(getUser());
+            ExpSampleType st = protocol.getSampleType();
             if (st != null)
             {
                 HtmlStringBuilder sb = HtmlStringBuilder.of();

--- a/flow/src/org/labkey/flow/webparts/FlowSummary.jsp
+++ b/flow/src/org/labkey/flow/webparts/FlowSummary.jsp
@@ -76,7 +76,7 @@
     //int _flaggedCount = FlowManager.get().getFlaggedCount(c);
 
     FlowProtocol _protocol = FlowProtocol.getForContainer(c);
-    ExpSampleType _sampleType = _protocol != null ? _protocol.getSampleType(getUser()) : null;
+    ExpSampleType _sampleType = _protocol != null ? _protocol.getSampleType() : null;
     List<? extends ExpMaterial> _sampleTypeSamples = _sampleType == null ? null : _protocol.getSamples(_sampleType, user);
     ActionURL _sampleTypeDetailsUrl = _sampleType != null ? _protocol.getSampleTypeDetailsURL(_sampleType, getContainer()) : null;
 


### PR DESCRIPTION
#### Rationale
Some `ExperimentService` and `SampleTypeService` methods no longer take a `User` parameter

Also, `legacyNameMap()` is no longer used

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7276
