### PR TITLE
GitHub #503: Add option to open URL links in a new tab in the domain designer UI (LabKey Issue: 54178)

### DIFF
--- a/flow/src/org/labkey/flow/persist/FlowKeywordAuditProvider.java
+++ b/flow/src/org/labkey/flow/persist/FlowKeywordAuditProvider.java
@@ -76,7 +76,7 @@ public class FlowKeywordAuditProvider extends AbstractAuditTypeProvider implemen
         url.setStrictContainerContextEval(true);
         table.setDetailsURL(url);
         table.getMutableColumn(COLUMN_NAME_FILE).setURL(url);
-        table.getMutableColumn(COLUMN_NAME_FILE).setURLTargetWindow("_blank");
+        table.getMutableColumn(COLUMN_NAME_FILE).setURLTarget("_blank");
 
         return table;
     }


### PR DESCRIPTION
#### Rationale
[#503](https://github.com/LabKey/internal-issues/issues/503) LKSM: Add option to open URL links in a new tab in the domain designer UI (LabKey Issue: 54178)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1918
- https://github.com/LabKey/platform/pull/7303
- https://github.com/LabKey/limsModules/pull/1886
- https://github.com/LabKey/commonAssays/pull/973
- https://github.com/LabKey/testAutomation/pull/2830

#### Changes
- urlTargetWindow -> urlTarget
