### PR TITLE
Make select inactive modules unreachable

### DIFF
--- a/microarray/src/org/labkey/microarray/MicroarrayModule.java
+++ b/microarray/src/org/labkey/microarray/MicroarrayModule.java
@@ -69,9 +69,9 @@ public class MicroarrayModule extends SpringModule
     }
 
     @Override
-    public boolean isAvailableOnlyWhenActive()
+    public boolean isAvailable(Container container)
     {
-        return true;
+        return container.getActiveModules().contains(this);
     }
 
     @Override

--- a/microarray/src/org/labkey/microarray/MicroarrayModule.java
+++ b/microarray/src/org/labkey/microarray/MicroarrayModule.java
@@ -69,6 +69,12 @@ public class MicroarrayModule extends SpringModule
     }
 
     @Override
+    public boolean isAvailableOnlyWhenActive()
+    {
+        return true;
+    }
+
+    @Override
     @NotNull
     protected Collection<WebPartFactory> createWebPartFactories()
     {


### PR DESCRIPTION
#### Rationale
Many modules don't make sense to access in a container if they're not enabled and intended to be used. Mothership is a good example. We've long hidden their schemas, but they've still been accessible via their controllers and the More Modules admin menu.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7355

#### Changes
* Hide microarray module when not active
