### PR TITLE
Register migration handlers only if we need them

### DIFF
--- a/protein/src/org/labkey/protein/ProteinModule.java
+++ b/protein/src/org/labkey/protein/ProteinModule.java
@@ -133,7 +133,12 @@ public class ProteinModule extends DefaultModule
         }
 
         ProteinService.get().registerProteinSearchView(new ProteinSearchViewProvider());
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(ProteinSchema.getSchema())
+    }
+
+    @Override
+    public void registerMigrationHandlers(@NotNull DatabaseMigrationService service)
+    {
+        service.registerSchemaHandler(new DefaultMigrationSchemaHandler(ProteinSchema.getSchema())
         {
             @Override
             public void beforeSchema()


### PR DESCRIPTION
#### Rationale
We don't need them unless we're migrating