### PR TITLE
Rework CachedResultSetBuilder to require column types

### DIFF
--- a/flow/src/org/labkey/flow/controllers/executescript/SamplesConfirmGridView.java
+++ b/flow/src/org/labkey/flow/controllers/executescript/SamplesConfirmGridView.java
@@ -97,7 +97,7 @@ public class SamplesConfirmGridView extends GridView
     public SamplesConfirmGridView(User user, Container container, Collection<String> keywords, List<? extends ISampleInfo> samples, boolean resolving, Map<String, SelectedSamples.ResolvedSample> rows, Errors errors)
     {
         super(new SamplesConfirmDataRegion(), errors);
-        boolean hasGroupInfo = samples.get(0) instanceof Workspace.SampleInfo;
+        boolean hasGroupInfo = samples.getFirst() instanceof Workspace.SampleInfo;
 
         // Create the list of columns
         keywords = KeywordUtil.filterHidden(keywords);
@@ -190,7 +190,7 @@ public class SamplesConfirmGridView extends GridView
         maps.addAll(matchedList);
 
         // Initialize the ResultSet and DataRegion
-        ResultSet rs = CachedResultSetBuilder.create(maps).build();
+        ResultSet rs = CachedResultSetBuilder.create(maps, columns.values()).build();
         Results results = new ResultsImpl(rs, (Map<FieldKey,ColumnInfo>)(Map)columns);
         setResults(results);
 

--- a/flow/src/org/labkey/flow/reports/FilterFlowReport.java
+++ b/flow/src/org/labkey/flow/reports/FilterFlowReport.java
@@ -267,7 +267,7 @@ public abstract class FilterFlowReport extends FlowReport
         else
         {
             // rs is a CachedResultSet, so its metadata is cached. No need to cache it again
-            ret = CachedResultSetBuilder.create(rows).setMetaData(rs.getMetaData()).build();
+            ret = CachedResultSetBuilder.create(rows, rs.getMetaData()).build();
             rs.close();
         }
 


### PR DESCRIPTION
#### Rationale
We now provide a list of `ColumnInfo`s or `ResultSetMetaData` to `CachedResultSetBuilder` to ensure we have column type information

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7438