### PR TITLE
Luminex module property for setting a min filter date for Levey-Jennings reports

### DIFF
--- a/luminex/src/org/labkey/luminex/LuminexModule.java
+++ b/luminex/src/org/labkey/luminex/LuminexModule.java
@@ -28,6 +28,7 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
+import org.labkey.api.module.ModuleProperty;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.luminex.query.LuminexProtocolSchema;
 
@@ -84,6 +85,12 @@ public class LuminexModule extends DefaultModule
         PropertyService.get().registerDomainKind(new LuminexDataDomainKind());
 
         AssayFlagHandler.registerHandler(AssayService.get().getProvider(LuminexAssayProvider.NAME), new AssayDefaultFlagHandler());
+
+        ModuleProperty leveyJenningsMinDateProp = new ModuleProperty(this, "leveyJenningsMinDate");
+        leveyJenningsMinDateProp.setLabel("Levey-Jennings Report Min Date Filter");
+        leveyJenningsMinDateProp.setDescription("If provided, the minimum acquisition date to use as a filter for the Luminex Levey-Jennings report data");
+        leveyJenningsMinDateProp.setInputType(ModuleProperty.InputType.text);
+        addModuleProperty(leveyJenningsMinDateProp);
     }
 
     @Override

--- a/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrackingDataPanel.js
@@ -104,6 +104,11 @@ LABKEY.LeveyJenningsTrackingDataPanel = Ext.extend(Ext.Component, {
             filters.push(LABKEY.Filter.create('Titration/IncludeInQcReport', true));
         }
 
+        var minDateProp = LABKEY.getModuleContext("luminex")?.leveyJenningsMinDate;
+        if (minDateProp) {
+            filters.push(LABKEY.Filter.create('Analyte/Data/AcquisitionDate', minDateProp, LABKEY.Filter.Types.GTE));
+        }
+
         var buttonBarItems = [
             LABKEY.QueryWebPart.standardButtons.views,
             LABKEY.QueryWebPart.standardButtons.exportRows,

--- a/luminex/webapp/luminex/LeveyJenningsTrendPlotPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrendPlotPanel.js
@@ -154,13 +154,9 @@ LABKEY.LeveyJenningsTrendPlotPanel = Ext.extend(Ext.FormPanel, {
         });
         this.items.push(this.trendTabPanel);
 
-        this.fbar = [
-            {xtype: 'label', text: 'The default plot is showing the most recent ' + this.defaultRowSize + ' data points.'},
-        ];
+        this.fbar = [];
 
         LABKEY.LeveyJenningsTrendPlotPanel.superclass.initComponent.call(this);
-
-        this.fbar.hide();
     },
 
     // function called by the JSP when the graph params are selected and the "Apply" button is clicked
@@ -193,8 +189,20 @@ LABKEY.LeveyJenningsTrendPlotPanel = Ext.extend(Ext.FormPanel, {
         }
 
         this.plotDataLoadComplete = true;
-        this.fbar.setVisible(!hasReportFilter && this.trendDataStore.getTotalCount() >= this.defaultRowSize);
+
+        if (!hasReportFilter && this.trendDataStore.getTotalCount() >= this.defaultRowSize) {
+            this.fbar.add({xtype: 'label', text: 'The default plot is showing the most recent ' + this.defaultRowSize + ' data points.'});
+        }
+        if (this.getMinDateModuleProp()) {
+            this.fbar.add({xtype: 'label', text: 'Filtering for acquisition date  greater than or equal to ' + this.getMinDateModuleProp() + '.'});
+        }
+        this.fbar.doLayout();
+
         this.updateTrendPlot();
+    },
+
+    getMinDateModuleProp: function() {
+        return LABKEY.getModuleContext("luminex")?.leveyJenningsMinDate;
     },
 
     setTrendPlotLoading: function() {

--- a/luminex/webapp/luminex/LeveyJenningsTrendPlotPanel.js
+++ b/luminex/webapp/luminex/LeveyJenningsTrendPlotPanel.js
@@ -190,11 +190,12 @@ LABKEY.LeveyJenningsTrendPlotPanel = Ext.extend(Ext.FormPanel, {
 
         this.plotDataLoadComplete = true;
 
+        this.fbar.removeAll();
         if (!hasReportFilter && this.trendDataStore.getTotalCount() >= this.defaultRowSize) {
             this.fbar.add({xtype: 'label', text: 'The default plot is showing the most recent ' + this.defaultRowSize + ' data points.'});
         }
         if (this.getMinDateModuleProp()) {
-            this.fbar.add({xtype: 'label', text: 'Filtering for acquisition date  greater than or equal to ' + this.getMinDateModuleProp() + '.'});
+            this.fbar.add({xtype: 'label', text: 'Filtering for acquisition date greater than or equal to ' + this.getMinDateModuleProp() + '.'});
         }
         this.fbar.doLayout();
 


### PR DESCRIPTION
#### Rationale
Clients that have a lot of historical data on their server are seeing performance issues when viewing the Levey-Jennings report for Luminex data. This is because the report query is complex and pulls in data from all folders on the server where the Luminex assay design is in scope only to then sort that data by AcquisitionDate descending and show the most recent 30 rows. 

This PR adds a module property to the luminex module to allow an admin user to set a min date value to be used for that Lumienx Levey-Jennings report data query to see if that improves performance of the report/query by filtering the data rows before sorting and limiting.

#### Changes
- Add a module property to luminex module for site level "leveyJenningsMinDate"
- If available, apply "leveyJenningsMinDate" as AcquisitionDate min date filter to Levey-Jennings report data query
- If available, show plot footer message for "leveyJenningsMinDate" AcquisitionDate min date filter to Levey-Jennings report data query
