### PR TITLE
Improve nullability treatment for PageFlowUtil.urlProvider()

### DIFF
--- a/flow/src/org/labkey/flow/data/FlowWorkspace.java
+++ b/flow/src/org/labkey/flow/data/FlowWorkspace.java
@@ -124,8 +124,7 @@ public class FlowWorkspace extends FlowDataObject
     {
         if (!getData().isFileOnDisk())
             return null;
-        ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getShowFileURL(getData(), false);
-        return url;
+        return PageFlowUtil.urlProvider(ExperimentUrls.class).getShowFileURL(getData(), false);
     }
 
     @Override

--- a/flow/src/org/labkey/flow/query/FlowSchema.java
+++ b/flow/src/org/labkey/flow/query/FlowSchema.java
@@ -480,7 +480,7 @@ public class FlowSchema extends UserSchema implements UserSchema.HasContextualRo
                 {
                     var ss = StudyService.get();
                     Study study = null == ss ? null : ss.getStudy(c);
-                    var urlProvider = PageFlowUtil.urlProvider(ProjectUrls.class);
+                    var urlProvider = PageFlowUtil.urlProviderOptional(ProjectUrls.class);
                     if (study != null && urlProvider != null)
                     {
                         LinkBuilder.simpleLink(HtmlString.unsafe(PageFlowUtil.filter(study.getLabel()).replaceAll(" ", "&nbsp;")), urlProvider.getBeginURL(c)).appendTo(out);


### PR DESCRIPTION
#### Rationale
The vast majority of callers of PageFlowUtil.urlProvider() are in the module that supplies the provider, or in a module that has a hard dependency on the supplying module. We can eliminate thousands of warnings in the code about null return values by differentiating between nullable and non-nullable use cases.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/7618

#### Changes
- Split `PageFlowUtil.urlProvider()` (throws a clear exception instead of returning null) and `PageFlowUtil.urlProviderOptional()` (may return null)
- Update select callers to eliminate their own null special-casing
- Minor code cleanup