### PR TITLE
Migrate away from deprecated methods

### DIFF
--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -91,7 +91,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertNotNull;
-import static org.labkey.api.exp.api.ExperimentService.asInteger;
+import static org.labkey.api.util.IntegerUtils.asInteger;
 import static org.labkey.flow.data.AttributeType.keyword;
 
 public class FlowManager

--- a/flow/src/org/labkey/flow/persist/PersistTests.java
+++ b/flow/src/org/labkey/flow/persist/PersistTests.java
@@ -57,12 +57,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.labkey.api.exp.api.ExperimentService.asInteger;
+import static org.labkey.api.util.IntegerUtils.asInteger;
 
-/**
- * User: kevink
- * Date: 4/30/14
- */
 public class PersistTests
 {
     private Container c;

--- a/microarray/src/org/labkey/microarray/MicroarrayManager.java
+++ b/microarray/src/org/labkey/microarray/MicroarrayManager.java
@@ -65,7 +65,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.labkey.api.exp.api.ExperimentService.asInteger;
+import static org.labkey.api.util.IntegerUtils.asInteger;
 
 public class MicroarrayManager
 {

--- a/ms2/src/org/labkey/ms2/MS2Importer.java
+++ b/ms2/src/org/labkey/ms2/MS2Importer.java
@@ -55,13 +55,8 @@ import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.labkey.api.exp.api.ExperimentService.asInteger;
+import static org.labkey.api.util.IntegerUtils.asInteger;
 
-/**
- * User: arauch
- * Date: Aug 18, 2005
- * Time: 1:56:35 AM
- */
 public abstract class MS2Importer
 {
     public static final int STATUS_RUNNING = 0;

--- a/protein/api-src/org/labkey/api/protein/ProteinManager.java
+++ b/protein/api-src/org/labkey/api/protein/ProteinManager.java
@@ -52,7 +52,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static org.labkey.api.exp.api.ExperimentService.asInteger;
+import static org.labkey.api.util.IntegerUtils.asInteger;
 
 public class ProteinManager
 {


### PR DESCRIPTION
#### Rationale
Prefer `IntegerUtils` methods