### PR TITLE
ProcessBuilder -> LabKeyProcessBuilder

### DIFF
--- a/flow/src/org/labkey/flow/controllers/run/RunController.java
+++ b/flow/src/org/labkey/flow/controllers/run/RunController.java
@@ -18,6 +18,7 @@ package org.labkey.flow.controllers.run;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
@@ -54,6 +55,7 @@ import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.FileNameUniquifier;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
@@ -92,7 +94,6 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -844,7 +845,7 @@ public class RunController extends BaseFlowController
             env.put("exportFormat", _exportToScriptFormat);
             List<String> params = parse(_exportToScriptCommandLine, env);
 
-            ProcessBuilder pb = new ProcessBuilder(params);
+            LabKeyProcessBuilder pb = new LabKeyProcessBuilder(params);
             info("Executing script: " + StringUtils.join(pb.command(), " "));
 
             try

--- a/ms2/src/org/labkey/ms2/pipeline/Sqt2PinTask.java
+++ b/ms2/src/org/labkey/ms2/pipeline/Sqt2PinTask.java
@@ -30,6 +30,7 @@ import org.labkey.api.pipeline.WorkDirectoryTask;
 import org.labkey.api.pipeline.cmd.TaskPath;
 import org.labkey.api.pipeline.file.AbstractFileAnalysisJob;
 import org.labkey.api.util.FileType;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.api.writer.PrintWriters;
 import org.labkey.vfs.FileLike;
 
@@ -108,7 +109,7 @@ public class Sqt2PinTask extends WorkDirectoryTask<Sqt2PinTask.Factory>
                 args.add(targetListFile.getName());
                 args.add(decoyListFile.getName());
 
-                ProcessBuilder pb = new ProcessBuilder(args);
+                LabKeyProcessBuilder pb = new LabKeyProcessBuilder(args);
                 pb.directory(_wd.getDir().toNioPathForRead().toFile());
 
                 job.runSubProcess(pb, _wd.getDir());

--- a/ms2/src/org/labkey/ms2/pipeline/TPPTask.java
+++ b/ms2/src/org/labkey/ms2/pipeline/TPPTask.java
@@ -15,12 +15,12 @@
  */
 package org.labkey.ms2.pipeline;
 
-import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jmock.Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.pipeline.AbstractTaskFactory;
@@ -34,6 +34,7 @@ import org.labkey.api.pipeline.ToolExecutionException;
 import org.labkey.api.pipeline.WorkDirectory;
 import org.labkey.api.pipeline.WorkDirectoryTask;
 import org.labkey.api.util.FileType;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.PepXMLFileType;
@@ -448,7 +449,7 @@ public class TPPTask extends WorkDirectoryTask<TPPTask.Factory>
             for (FileLike fileInput : inputWorkFiles)
                 interactCmd.add(_wd.getRelativePath(fileInput));
 
-            ProcessBuilder builder = new ProcessBuilder(interactCmd);
+            LabKeyProcessBuilder builder = new LabKeyProcessBuilder(interactCmd);
             // Add the TPP directory to the PATH so that xinteract can find it
             if (null != xinteractFile.getParentFile() && xinteractFile.getParentFile().exists())
             {

--- a/ms2/src/org/labkey/ms2/pipeline/comet/CometSearchTask.java
+++ b/ms2/src/org/labkey/ms2/pipeline/comet/CometSearchTask.java
@@ -24,6 +24,7 @@ import org.labkey.api.pipeline.RecordedAction;
 import org.labkey.api.pipeline.RecordedActionSet;
 import org.labkey.api.pipeline.WorkDirectory;
 import org.labkey.api.util.FileType;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.ms2.pipeline.AbstractMS2SearchPipelineJob;
 import org.labkey.ms2.pipeline.AbstractMS2SearchTask;
 import org.labkey.ms2.pipeline.TPPTask;
@@ -33,7 +34,6 @@ import org.labkey.vfs.FileLike;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -47,7 +47,7 @@ public class CometSearchTask extends AbstractMS2SearchTask<CometSearchTask.Facto
 
     private static final String COMET_ACTION_NAME = "Comet Search";
 
-    public static class Factory extends AbstractSequestSearchTaskFactory
+    public static class Factory extends AbstractSequestSearchTaskFactory<Factory>
     {
         public Factory()
         {
@@ -55,7 +55,7 @@ public class CometSearchTask extends AbstractMS2SearchTask<CometSearchTask.Facto
         }
 
         @Override
-        public PipelineJob.Task createTask(PipelineJob job)
+        public CometSearchTask createTask(PipelineJob job)
         {
             return new CometSearchTask(this, job);
         }
@@ -63,7 +63,7 @@ public class CometSearchTask extends AbstractMS2SearchTask<CometSearchTask.Facto
         @Override
         public List<String> getProtocolActionNames()
         {
-            return Arrays.asList(COMET_ACTION_NAME);
+            return List.of(COMET_ACTION_NAME);
         }
     }
 
@@ -110,7 +110,7 @@ public class CometSearchTask extends AbstractMS2SearchTask<CometSearchTask.Facto
             String cometPath = PipelineJobService.get().getExecutablePath("comet", null, "comet", null, getJob().getLogger());
             args.add(cometPath);
             args.add(localMzXML.getName());
-            ProcessBuilder processBuilder = new ProcessBuilder(args);
+            LabKeyProcessBuilder processBuilder = new LabKeyProcessBuilder(args);
             getJob().runSubProcess(processBuilder, _wd.getDir());
 
 

--- a/ms2/src/org/labkey/ms2/pipeline/mascot/MascotSearchTask.java
+++ b/ms2/src/org/labkey/ms2/pipeline/mascot/MascotSearchTask.java
@@ -25,6 +25,7 @@ import org.labkey.api.pipeline.RecordedActionSet;
 import org.labkey.api.pipeline.WorkDirectory;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.PepXMLFileType;
 import org.labkey.ms2.MS2RunType;
@@ -219,7 +220,7 @@ public class MascotSearchTask extends AbstractMS2SearchTask<MascotSearchTask.Fac
                 argsM2S.add("-P" + paramMinPeakCount);
             argsM2S.add(fileWorkSpectra.toNioPathForRead().toFile().getAbsolutePath());
 
-            getJob().runSubProcess(new ProcessBuilder(argsM2S), _wd.getDir());
+            getJob().runSubProcess(new LabKeyProcessBuilder(argsM2S), _wd.getDir());
 
             //  1. perform Mascot search
             getJob().header("mascot client output");
@@ -354,7 +355,7 @@ public class MascotSearchTask extends AbstractMS2SearchTask<MascotSearchTask.Fac
                 //     will fail to access protein associated information in mascot run
                 //,"-shortid"
             };
-            getJob().runSubProcess(new ProcessBuilder(args), _wd.getDir());
+            getJob().runSubProcess(new LabKeyProcessBuilder(args), _wd.getDir());
 
             PepXMLFileType pepxft = new PepXMLFileType(true); // "true" == accept .xml as valid extension for older converters
             FileLike fileOutputPepXML = _wd.newFile(pepxft);

--- a/ms2/src/org/labkey/ms2/pipeline/sequest/SequestSearchTask.java
+++ b/ms2/src/org/labkey/ms2/pipeline/sequest/SequestSearchTask.java
@@ -28,14 +28,15 @@ import org.labkey.api.pipeline.WorkDirectory;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.writer.PrintWriters;
 import org.labkey.ms2.pipeline.AbstractMS2SearchPipelineJob;
 import org.labkey.ms2.pipeline.AbstractMS2SearchProtocol;
 import org.labkey.ms2.pipeline.AbstractMS2SearchTask;
-import org.labkey.ms2.pipeline.TPPTask;
 import org.labkey.ms2.pipeline.ParameterNames;
+import org.labkey.ms2.pipeline.TPPTask;
 import org.labkey.vfs.FileLike;
 import org.labkey.vfs.FileSystemLike;
 
@@ -88,7 +89,7 @@ public class SequestSearchTask extends AbstractMS2SearchTask<SequestSearchTask.F
         return AbstractMS2SearchPipelineJob.getPepXMLConvertFile(dirAnalysis,baseName,gzSupport);
     }
 
-    public static class Factory extends AbstractSequestSearchTaskFactory
+    public static class Factory extends AbstractSequestSearchTaskFactory<Factory>
     {
         public Factory()
         {
@@ -96,7 +97,7 @@ public class SequestSearchTask extends AbstractMS2SearchTask<SequestSearchTask.F
         }
 
         @Override
-        public PipelineJob.Task createTask(PipelineJob job)
+        public SequestSearchTask createTask(PipelineJob job)
         {
             return new SequestSearchTask(this, job);
         }
@@ -221,7 +222,7 @@ public class SequestSearchTask extends AbstractMS2SearchTask<SequestSearchTask.F
                 args.add(makeDBExecutable.getAbsolutePath());
                 args.add("-O" + indexFileBase);
                 args.add("-P" + fileWorkParams.toNioPathForRead().toFile().getAbsolutePath());
-                ProcessBuilder pb = new ProcessBuilder(args);
+                LabKeyProcessBuilder pb = new LabKeyProcessBuilder(args);
 
                 // In order to find sort.exe, use the Sequest directory as the working directory
                 File dir = makeDBExecutable.getParentFile();
@@ -303,7 +304,7 @@ public class SequestSearchTask extends AbstractMS2SearchTask<SequestSearchTask.F
             sequestArgs.add("-F" + dirOutputDta.toNioPathForRead().toFile().getAbsolutePath());
             // Trailing argument that makes Sequest not barf
             sequestArgs.add("x");
-            ProcessBuilder sequestPB = new ProcessBuilder(sequestArgs);
+            LabKeyProcessBuilder sequestPB = new LabKeyProcessBuilder(sequestArgs);
             FileLike sequestLogFileWork = SEQUEST_LOG_FILE_TYPE.getFile(_wd.getDir(), getJob().getBaseName());
             _wd.newFile(sequestLogFileWork.getName());
             boolean copySequestLogFile = true;
@@ -330,7 +331,7 @@ public class SequestSearchTask extends AbstractMS2SearchTask<SequestSearchTask.F
                 out2XMLArgs.add("1");
                 out2XmlParams.getParam("-E").setValue(enzyme);
                 out2XMLArgs.addAll(convertParams(out2XmlParams.getParams(), params));
-                ProcessBuilder out2XMLPB = new ProcessBuilder(out2XMLArgs);
+                LabKeyProcessBuilder out2XMLPB = new LabKeyProcessBuilder(out2XMLArgs);
                 out2XMLPB.environment().put("WEBSERVER_ROOT", StringUtils.trimToEmpty(new File(out2XMLPath).getParent()));
                 getJob().runSubProcess(out2XMLPB, _wd.getDir());
 
@@ -491,7 +492,7 @@ public class SequestSearchTask extends AbstractMS2SearchTask<SequestSearchTask.F
 
         actions.add(action);
 
-        getJob().runSubProcess(new ProcessBuilder(mzXML2SearchArgs), _wd.getDir());
+        getJob().runSubProcess(new LabKeyProcessBuilder(mzXML2SearchArgs), _wd.getDir());
     }
 
     private FileLike writeDtaList(FileLike dirOutputDta) throws IOException
@@ -546,13 +547,13 @@ public class SequestSearchTask extends AbstractMS2SearchTask<SequestSearchTask.F
             assertEquals(Collections.<String>emptyList(), convertParams(out2XmlParams.getParams(), Collections.singletonMap("out2xml, all", "0")));
             assertEquals(Collections.<String>emptyList(), convertParams(out2XmlParams.getParams(), Collections.singletonMap("out2xml, all", "")));
 
-            assertEquals(Arrays.asList("-all"), convertParams(out2XmlParams.getParams(), Collections.singletonMap("out2xml, all", "1")));
+            assertEquals(List.of("-all"), convertParams(out2XmlParams.getParams(), Collections.singletonMap("out2xml, all", "1")));
         }
 
         @Test
         public void testOut2XmlEnzyme() throws SequestParamsException
         {
-            assertEquals(Arrays.asList("-EtestEnzyme"), convertParams(new Out2XmlParams().getParams(), Collections.singletonMap("out2xml, enzyme", "testEnzyme")));
+            assertEquals(List.of("-EtestEnzyme"), convertParams(new Out2XmlParams().getParams(), Collections.singletonMap("out2xml, enzyme", "testEnzyme")));
             assertEquals(Collections.<String>emptyList(), convertParams(new Out2XmlParams().getParams(), Collections.singletonMap("out2xml, enzyme", "")));
         }
     }

--- a/ms2/src/org/labkey/ms2/pipeline/tandem/XTandemSearchTask.java
+++ b/ms2/src/org/labkey/ms2/pipeline/tandem/XTandemSearchTask.java
@@ -24,6 +24,7 @@ import org.labkey.api.pipeline.RecordedAction;
 import org.labkey.api.pipeline.RecordedActionSet;
 import org.labkey.api.pipeline.WorkDirectory;
 import org.labkey.api.util.FileType;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.writer.PrintWriters;
 import org.labkey.ms2.pipeline.AbstractMS2SearchPipelineJob;
@@ -143,7 +144,7 @@ public class XTandemSearchTask extends AbstractMS2SearchTask<XTandemSearchTask.F
 
             // Avoid re-running an X! Tandem search, if the .xtan.xml already exists.
             // Several labs soft-link or copy .xtan.xml files to reduce processing time.
-            ProcessBuilder xTandemPB = null;
+            LabKeyProcessBuilder xTandemPB = null;
             FileLike fileOutputXML = getNativeFileType(support.getGZPreference()).newFile(support.getAnalysisDirectory(), baseName);
             FileLike fileWorkOutputXML = null;
             FileLike fileJobTandemXML = null;
@@ -151,7 +152,7 @@ public class XTandemSearchTask extends AbstractMS2SearchTask<XTandemSearchTask.F
 
             FileLike fileMzXML = _factory.findInputFile(getJobSupport());
             FileLike fileInputSpectra;
-            try (WorkDirectory.CopyingResource lock = _wd.ensureCopyingLock())
+            try (WorkDirectory.CopyingResource _ = _wd.ensureCopyingLock())
             {
                 fileInputSpectra = _wd.inputFile(fileMzXML, false);
                 if (searchComplete)
@@ -186,7 +187,7 @@ public class XTandemSearchTask extends AbstractMS2SearchTask<XTandemSearchTask.F
                     // Try it again without the file extension
                     exePath = PipelineJobService.get().getExecutablePath("tandem", null, "xtandem", ver, getJob().getLogger());
                 }
-                xTandemPB = new ProcessBuilder(exePath, INPUT_XML);
+                xTandemPB = new LabKeyProcessBuilder(exePath, INPUT_XML);
 
                 getJob().runSubProcess(xTandemPB, _wd.getDir());
 
@@ -202,7 +203,7 @@ public class XTandemSearchTask extends AbstractMS2SearchTask<XTandemSearchTask.F
 
             String ver = TPPTask.getTPPVersion(getJob());
             String exePath = PipelineJobService.get().getExecutablePath("Tandem2XML", null, "tpp", ver, getJob().getLogger());
-            ProcessBuilder tandem2XmlPB = new ProcessBuilder(exePath,
+            LabKeyProcessBuilder tandem2XmlPB = new LabKeyProcessBuilder(exePath,
                 _wd.getRelativePath(fileWorkOutputXML),
                 fileWorkPepXMLRaw.getName());
             getJob().runSubProcess(tandem2XmlPB,
@@ -210,7 +211,7 @@ public class XTandemSearchTask extends AbstractMS2SearchTask<XTandemSearchTask.F
 
             // Move final outputs to analysis directory.
             FileLike filePepXMLRaw;
-            try (WorkDirectory.CopyingResource lock = _wd.ensureCopyingLock())
+            try (WorkDirectory.CopyingResource _ = _wd.ensureCopyingLock())
             {
                 if (!searchComplete)
                     fileOutputXML = _wd.outputFile(fileWorkOutputXML);
@@ -269,16 +270,6 @@ public class XTandemSearchTask extends AbstractMS2SearchTask<XTandemSearchTask.F
         // Default parameters are just written into this parameters file, so don't need to
         // specify them again.
         params.remove("list path, default parameters");
-
-        // CONSIDER: If we remove these, they will not end up in the pepXML file.
-        //  ... which is a bad thing, since we currently rely on "pipeline, import spectra"
-        //  to keep from loading all spectra into the database.
-/*        for (String key : params.keySet().toArray(new String[params.size()]))
-        {
-            if (key.startsWith("pipeline"))
-                params.remove(key);
-        }
-*/
 
         try
         {

--- a/ms2/src/org/labkey/ms2/pipeline/tandem/XTandemToXMLTask.java
+++ b/ms2/src/org/labkey/ms2/pipeline/tandem/XTandemToXMLTask.java
@@ -25,6 +25,7 @@ import org.labkey.api.pipeline.RecordedActionSet;
 import org.labkey.api.pipeline.WorkDirectory;
 import org.labkey.api.pipeline.file.FileAnalysisJobSupport;
 import org.labkey.api.util.FileType;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.ms2.pipeline.AbstractMS2SearchPipelineJob;
 import org.labkey.ms2.pipeline.AbstractMS2SearchTask;
@@ -34,7 +35,6 @@ import org.labkey.vfs.FileLike;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -70,7 +70,7 @@ public class XTandemToXMLTask extends AbstractMS2SearchTask<XTandemToXMLTask.Fac
         @Override
         public List<String> getProtocolActionNames()
         {
-            return Arrays.asList(XTandemSearchTask.TANDEM2_XML_ACTION_NAME);
+            return List.of(XTandemSearchTask.TANDEM2_XML_ACTION_NAME);
         }
 
         @Override
@@ -108,7 +108,7 @@ public class XTandemToXMLTask extends AbstractMS2SearchTask<XTandemToXMLTask.Fac
 
             String ver = TPPTask.getTPPVersion(getJob());
             String exePath = PipelineJobService.get().getExecutablePath("Tandem2XML", null, "tpp", ver, getJob().getLogger());
-            ProcessBuilder tandem2XmlPB = new ProcessBuilder(exePath,
+            LabKeyProcessBuilder tandem2XmlPB = new LabKeyProcessBuilder(exePath,
                 _wd.getRelativePath(fileWorkOutputXML),
                 fileWorkPepXMLRaw.getName());
             getJob().runSubProcess(tandem2XmlPB,


### PR DESCRIPTION
#### Rationale
We want to consistently use our own `ProcessBuilder` variant, `LabKeyProcessBuilder` to standardize the environment variables we pass to forked processes.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7704

#### Changes
- Adopt LabKeyProcessBuilder
- Misc cleanup