### PR TITLE
GitHub Issue 1188: Stop JDBC caching by default in QueryService

### DIFF
--- a/flow/src/org/labkey/flow/persist/FlowManager.java
+++ b/flow/src/org/labkey/flow/persist/FlowManager.java
@@ -1400,20 +1400,20 @@ public class FlowManager
     // get the count of analysis folders
     public int getAnalysisFolderCount(FlowSchema schema)
     {
-        return QueryService.get().selector(schema, "SELECT COUNT(*) FROM " + FlowSchema.SCHEMANAME + "." + FlowTableType.Analyses.name()).getObject(Long.class).intValue();
+        return QueryService.get().getSelectBuilder(schema, "SELECT COUNT(*) FROM " + FlowSchema.SCHEMANAME + "." + FlowTableType.Analyses.name()).buildSqlSelector().getObject(Long.class).intValue();
     }
 
     // get the count of analysis scripts
     public int getAnalysisScriptCount(FlowSchema schema)
     {
-        return QueryService.get().selector(schema, "SELECT COUNT(*) FROM " + FlowSchema.SCHEMANAME + "." + FlowTableType.AnalysisScripts.name()).getObject(Long.class).intValue();
+        return QueryService.get().getSelectBuilder(schema, "SELECT COUNT(*) FROM " + FlowSchema.SCHEMANAME + "." + FlowTableType.AnalysisScripts.name()).buildSqlSelector().getObject(Long.class).intValue();
     }
 
     // get the count of samples in the sample set
     public int getSampleCount(Container c, User user, ExpSampleType st)
     {
         UserSchema schema = QueryService.get().getUserSchema(user, c, SamplesSchema.SCHEMA_SAMPLES);
-        return QueryService.get().selector(schema, "SELECT COUNT(*) FROM samples." + st.getName()).getObject(Long.class).intValue();
+        return QueryService.get().getSelectBuilder(schema, "SELECT COUNT(*) FROM samples." + st.getName()).buildSqlSelector().getObject(Long.class).intValue();
     }
 
     public int getTempTableCount()
@@ -1494,7 +1494,7 @@ public class FlowManager
     // count of runs created from an Analysis Script
     public Map<String, Object> getAnalysisScriptRunCount(FlowSchema schema)
     {
-        return removeRowNum(QueryService.get().selector(schema, """
+        return removeRowNum(QueryService.get().getSelectBuilder(schema, """
                         SELECT
                           COUNT(*) AS RunCount,
                           MAX(Created) AS CreatedMax,
@@ -1502,13 +1502,13 @@ public class FlowManager
                           SUM(CompensationControlCount) AS CompControlCount,
                           SUM(FCSFileCount) AS FCSFileCount
                         FROM flow.Runs
-                        WHERE AnalysisScript IS NOT NULL""").getMap());
+                        WHERE AnalysisScript IS NOT NULL""").buildSqlSelector().getMap());
     }
 
     // count of runs created from a FlowJo Workspace
     public Map<String, Object> getWorkspaceRunCount(FlowSchema schema)
     {
-        return removeRowNum(QueryService.get().selector(schema, """
+        return removeRowNum(QueryService.get().getSelectBuilder(schema, """
                         SELECT
                           COUNT(*) AS RunCount,
                           MAX(Created) AS CreatedMax,
@@ -1516,13 +1516,13 @@ public class FlowManager
                           SUM(CompensationControlCount) AS CompControlCount,
                           SUM(FCSFileCount) AS FCSFileCount
                         FROM flow.Runs
-                        WHERE Workspace IS NOT NULL""").getMap());
+                        WHERE Workspace IS NOT NULL""").buildSqlSelector().getMap());
     }
 
     // count of runs created from an analysis archive import
     public Map<String, Object> getExternalAnalysisRunCount(FlowSchema schema)
     {
-        return removeRowNum(QueryService.get().selector(schema,
+        return removeRowNum(QueryService.get().getSelectBuilder(schema,
                 "SELECT\n" +
                 "  COUNT(*) AS RunCount,\n" +
                 "  MAX(Created) AS CreatedMax,\n" +
@@ -1530,12 +1530,12 @@ public class FlowManager
                 "  SUM(CompensationControlCount) AS CompControlCount,\n" +
                 "  SUM(FCSFileCount) AS FCSFileCount\n" +
                 "FROM flow.Runs\n" +
-                "WHERE AnalysisEngine = '" + AnalysisEngine.Archive.name() + "'").getMap());
+                "WHERE AnalysisEngine = '" + AnalysisEngine.Archive.name() + "'").buildSqlSelector().getMap());
     }
 
     public Map<String, Object> getFCSFileOnlyRunCount(FlowSchema schema)
     {
-        return removeRowNum(QueryService.get().selector(schema, """
+        return removeRowNum(QueryService.get().getSelectBuilder(schema, """
                         SELECT
                           COUNT(*) AS RunCount,
                           MAX(Created) AS CreatedMax,
@@ -1543,7 +1543,7 @@ public class FlowManager
                           SUM(CompensationControlCount) AS CompControlCount,
                           SUM(FCSFileCount) AS FCSFileCount
                         FROM flow.Runs
-                        WHERE ProtocolStep = 'Keywords'""").getMap());
+                        WHERE ProtocolStep = 'Keywords'""").buildSqlSelector().getMap());
     }
 
     public int getRunCount(Container container, ObjectType type)

--- a/flow/src/org/labkey/flow/query/FCSFileCoalescingColumn.java
+++ b/flow/src/org/labkey/flow/query/FCSFileCoalescingColumn.java
@@ -130,7 +130,7 @@ public class FCSFileCoalescingColumn extends ExprColumn
         fields.addAll(coalesceFields);
 
         Map<FieldKey, ColumnInfo> columnMap = QueryService.get().getColumns(parentTable, fields);
-        SQLFragment sub = QueryService.get().getSelectSQL(parentTable, columnMap.values(), null, null, Table.ALL_ROWS, Table.NO_OFFSET, false);
+        SQLFragment sub = QueryService.get().getSelectBuilder(parentTable).columns(columnMap.values()).buildSqlFragment();
 
         SQLFragment coalesceFrag = new SQLFragment();
         coalesceFrag.append("SELECT\n");

--- a/flow/src/org/labkey/flow/reports/FilterFlowReport.java
+++ b/flow/src/org/labkey/flow/reports/FilterFlowReport.java
@@ -385,8 +385,7 @@ public abstract class FilterFlowReport extends FlowReport
         }
 
         _query = query.toString();
-        Results results = QueryService.get().getSelectBuilder(flow, _query)
-                        .select(null, true);
+        Results results = QueryService.get().getSelectBuilder(flow, _query).select();
         // This still breaks encapsulation, but it's better than a direct cast.
         CachedResultSet rs = results.getWrapped(CachedResultSet.class);
         if (null == rs)

--- a/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
+++ b/luminex/src/org/labkey/luminex/query/AnalyteSinglePointControlTable.java
@@ -82,7 +82,7 @@ public class AnalyteSinglePointControlTable extends AbstractLuminexTable
         // TODO ContainerFilter -- Do we really want a non-permission checking container filter here?
         LuminexDataTable dataTable = schema.createDataTable(ContainerFilter.getUnsafeEverythingFilter(), false);
         List<ColumnInfo> dataColumns = Arrays.asList(dataTable.getColumn("FlaggedAsExcluded"), dataTable.getColumn("FIBackground"), dataTable.getColumn("Description"), dataTable.getColumn("Data"), dataTable.getColumn("Analyte"));
-        avgFiSQL.append(QueryService.get().getSelectSQL(dataTable, dataColumns, null, null, Table.ALL_ROWS, 0, false));
+        avgFiSQL.append(QueryService.get().getSelectBuilder(dataTable).columns(dataColumns).buildSqlFragment());
         avgFiSQL.append(") dr, ");
         avgFiSQL.append(ExperimentService.get().getTinfoData(), "d");
         avgFiSQL.append(", ");

--- a/luminex/src/org/labkey/luminex/query/GuideSetTable.java
+++ b/luminex/src/org/labkey/luminex/query/GuideSetTable.java
@@ -206,7 +206,7 @@ public class GuideSetTable extends AbstractCurveFitPivotTable
                 joinTable.getColumn("IncludeInGuideSetCalculation"),
                 joinTable.getColumn(srcFIColumnName));
         SQLFragment baseSQL = new SQLFragment(" FROM (");
-        baseSQL.append(QueryService.get().getSelectSQL(joinTable, columns, null, null, Table.ALL_ROWS, 0, false));
+        baseSQL.append(QueryService.get().getSelectBuilder(joinTable).columns(columns).buildSqlFragment());
         baseSQL.append(") x WHERE x.");
         baseSQL.append(guideSetColumnName);
         baseSQL.append(" = ");

--- a/microarray/src/org/labkey/microarray/matrix/ExpressionMatrixAssayProvider.java
+++ b/microarray/src/org/labkey/microarray/matrix/ExpressionMatrixAssayProvider.java
@@ -220,8 +220,8 @@ public class ExpressionMatrixAssayProvider extends AbstractAssayProvider
                     QuerySchema microarray = DefaultSchema.get(user, container).getSchema("Microarray");
                     if (null == microarray)
                         return;
-                    Map<Long,String> map = QueryService.get().selector(microarray, "SELECT RowId, Name FROM FeatureAnnotationSet")
-                            .getValueMap(Long.class);
+                    Map<Long,String> map = QueryService.get().getSelectBuilder(microarray, "SELECT RowId, Name FROM FeatureAnnotationSet")
+                            .buildSqlSelector().getValueMap(Long.class);
                     mapRowIdName = (Map<Long,String>)map;
                     // Make sure this is really <Integer,String>?
                     if (!mapRowIdName.isEmpty())
@@ -253,8 +253,8 @@ public class ExpressionMatrixAssayProvider extends AbstractAssayProvider
                     if (null == microarray)
                         return;
                     Map<String,Long> map = new HashMap<>();
-                    QueryService.get().selector(microarray, "SELECT Name, RowId FROM FeatureAnnotationSet")
-                            .forEach(rs -> map.put(rs.getString(1),rs.getLong(2)));
+                    QueryService.get().getSelectBuilder(microarray, "SELECT Name, RowId FROM FeatureAnnotationSet")
+                            .buildSqlSelector().forEach(rs -> map.put(rs.getString(1),rs.getLong(2)));
                     mapNameRowId = map;
                     // Make sure this is really <Integer,String>?
                     if (!mapNameRowId.isEmpty())

--- a/ms2/src/org/labkey/ms2/peptideview/AbstractMS2RunView.java
+++ b/ms2/src/org/labkey/ms2/peptideview/AbstractMS2RunView.java
@@ -410,7 +410,7 @@ public abstract class AbstractMS2RunView
 
         QueryService.get().ensureRequiredColumns(tinfo, columns, filter, sort, new HashSet<>());
 
-        SQLFragment sql = QueryService.get().getSelectSQL(tinfo, columns, filter, sort, Table.ALL_ROWS, Table.NO_OFFSET, false);
+        SQLFragment sql = QueryService.get().getSelectBuilder(tinfo).columns(columns).filter(filter).sort(sort).buildSqlFragment();
         return new Pair<>(desiredCol, sql);
     }
 

--- a/ms2/src/org/labkey/ms2/query/MS2Schema.java
+++ b/ms2/src/org/labkey/ms2/query/MS2Schema.java
@@ -1085,7 +1085,7 @@ public class MS2Schema extends UserSchema
         TableInfo proteinGroupMembershipTable = createProteinGroupMembershipTable(form, context, false);
         ColumnInfo proteinGroupColumn = proteinGroupMembershipTable.getColumn("ProteinGroupId");
 
-        SQLFragment selectSQL = QueryService.get().getSelectSQL(proteinGroupMembershipTable, Collections.singleton(proteinGroupColumn), null, null, Table.ALL_ROWS, Table.NO_OFFSET, false);
+        SQLFragment selectSQL = QueryService.get().getSelectBuilder(proteinGroupMembershipTable).columns(Collections.singleton(proteinGroupColumn)).buildSqlFragment();
         SQLFragment filterSQL = new SQLFragment("ProteinGroupId IN (SELECT ").appendIdentifier(proteinGroupColumn.getAlias()).append(" FROM (");
         filterSQL.append(selectSQL);
         filterSQL.append(") x)");

--- a/viability/src/org/labkey/viability/ViabilityManager.java
+++ b/viability/src/org/labkey/viability/ViabilityManager.java
@@ -400,7 +400,7 @@ public class ViabilityManager
             // Only update results in the run
             filter.addCondition(FieldKey.fromParts("ResultID", "Run"), run.getRowId());
         }
-        SQLFragment sub = QueryService.get().getSelectSQL(rs, columnMap.values(), filter, null, Table.ALL_ROWS, Table.NO_OFFSET, false);
+        SQLFragment sub = QueryService.get().getSelectBuilder(rs).columns(columnMap.values()).filter(filter).buildSqlFragment();
 
         SQLFragment groupFrag = new SQLFragment();
         groupFrag.append("SELECT\n");


### PR DESCRIPTION
#### Rationale
We can improve our memory usage by avoiding unwanted JDBC caching. We can also simplify `QueryService` usage by consolidating to use `SelectBuilder`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7708

#### Changes
- Disable Postgres JDBC caching by default for `QueryService` method like `select()`
- Switch to `getSelectBuilder()` and `SelectBuilder` patterns
- Eliminate unneeded parameters, using defaults when possible