### PR TITLE
Disable LabKey caching of ResultSet by default

### DIFF
--- a/flow/src/org/labkey/flow/data/FlowProtocol.java
+++ b/flow/src/org/labkey/flow/data/FlowProtocol.java
@@ -625,7 +625,7 @@ public class FlowProtocol extends FlowObject<ExpProtocol>
         Map<Long, Pair<Long, String>> fcsFileRuns = new LongHashMap<>();
         int linkedFcsFileCount = 0;
 
-        try (TableResultSet rs = QueryService.get().select(schema, sql, tableMap, false, false))
+        try (TableResultSet rs = QueryService.get().getSelectBuilder(schema, sql, false, tableMap).select())
         {
             for (Map<String, Object> row : rs)
             {

--- a/flow/src/org/labkey/flow/data/FlowRun.java
+++ b/flow/src/org/labkey/flow/data/FlowRun.java
@@ -16,6 +16,7 @@
 
 package org.labkey.flow.data;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.attachments.Attachment;
 import org.labkey.api.attachments.AttachmentService;
@@ -42,8 +43,6 @@ import org.labkey.flow.controllers.run.RunController;
 import org.labkey.flow.persist.InputRole;
 import org.labkey.flow.query.FlowSchema;
 import org.labkey.flow.query.FlowTableType;
-
-import jakarta.servlet.http.HttpServletRequest;
 import org.labkey.vfs.FileLike;
 
 import java.io.File;
@@ -433,7 +432,7 @@ public class FlowRun extends FlowObject<ExpRun>
             filter.addAllClauses(protocol.getFCSAnalysisFilter());
         if (settings != null)
             filter.addAllClauses(settings.getFilter());
-        try (ResultSet rs = QueryService.get().getSelectBuilder(table).columns(new ArrayList<>(Arrays.asList(colRowId))).filter(filter).select())
+        try (ResultSet rs = QueryService.get().getSelectBuilder(table).columns(List.of(colRowId)).filter(filter).select())
         {
             while (rs.next())
             {

--- a/flow/src/org/labkey/flow/data/FlowRun.java
+++ b/flow/src/org/labkey/flow/data/FlowRun.java
@@ -124,7 +124,7 @@ public class FlowRun extends FlowObject<ExpRun>
         {
             _allDatas = getDatas(null);
         }
-        
+
         List<FlowWell> wells = new ArrayList<>();
         for (FlowDataObject obj : _allDatas)
         {
@@ -181,7 +181,7 @@ public class FlowRun extends FlowObject<ExpRun>
             return null;
         return new FlowCompensationMatrix(datas.getFirst());
     }
-    
+
     public long getRunId()
     {
         return getExperimentRun().getRowId();
@@ -384,7 +384,7 @@ public class FlowRun extends FlowObject<ExpRun>
             childProtocol = childFlowProtocol.getProtocol();
         }
 
-        ExperimentService.get().getExpRuns(container, null, childProtocol, run -> 
+        ExperimentService.get().getExpRuns(container, null, childProtocol, run ->
                 runFilePathRoot == null || (run.getFilePathRoot() != null && runFilePathRoot.toNioPathForRead().toFile().equals(run.getFilePathRoot()))
             ).forEach( run -> ret.add(new FlowRun(run)));
 
@@ -433,7 +433,7 @@ public class FlowRun extends FlowObject<ExpRun>
             filter.addAllClauses(protocol.getFCSAnalysisFilter());
         if (settings != null)
             filter.addAllClauses(settings.getFilter());
-        try (ResultSet rs = QueryService.get().select(table, new ArrayList<>(Arrays.asList(colRowId)), filter, null))
+        try (ResultSet rs = QueryService.get().getSelectBuilder(table).columns(new ArrayList<>(Arrays.asList(colRowId))).filter(filter).select())
         {
             while (rs.next())
             {

--- a/flow/src/org/labkey/flow/persist/PersistTests.java
+++ b/flow/src/org/labkey/flow/persist/PersistTests.java
@@ -19,6 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.Results;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
@@ -154,13 +155,13 @@ public class PersistTests
             // verify query
             FlowSchema schema = new FlowSchema(user, c);
 
-            try (ResultSet results = QueryService.get().select(schema, "SELECT " +
+            try (ResultSet results = QueryService.get().getSelectBuilder(schema, "SELECT " +
                     "A.Name, " +
                     "A.Keyword.keyword1 AS k1, " +
                     "A.Keyword.\"keyword1-alias\" AS k1_alias, " +
                     "A.Keyword('keyword1') AS k1_method, " +
                     "A.Keyword('keyword1-alias') AS k1_alias_method " +
-                    "FROM flow.FCSFiles AS A"))
+                    "FROM flow.FCSFiles AS A").select())
             {
                 assertTrue(results.next());
                 assertEquals(this.getClass().getSimpleName(), results.getString("Name"));
@@ -221,13 +222,13 @@ public class PersistTests
             // verify query
             FlowSchema schema = new FlowSchema(user, c);
 
-            try (ResultSet results = QueryService.get().select(schema, "SELECT " +
+            try (ResultSet results = QueryService.get().getSelectBuilder(schema, "SELECT " +
                     "A.Name, " +
                     "A.Keyword.keyword2 AS k2, " +
                     "A.Keyword.\"keyword2-alias\" AS k2_alias, " +
                     "A.Keyword('keyword2') AS k2_method, " +
                     "A.Keyword('keyword2-alias') AS k2_alias_method " +
-                    "FROM flow.FCSFiles AS A"))
+                    "FROM flow.FCSFiles AS A").select())
             {
                 assertTrue(results.next());
                 assertEquals(this.getClass().getSimpleName(), results.getString("Name"));
@@ -301,14 +302,14 @@ public class PersistTests
         // verify stat values
         FlowSchema schema = new FlowSchema(user, c);
 
-        try (TableResultSet rs = (TableResultSet)QueryService.get().select(schema, "SELECT " +
+        try (Results rs = QueryService.get().getSelectBuilder(schema, "SELECT " +
                 "A.Name, " +
                 "A.Statistic.\"X:Count\" AS stat, " +
                 "A.Statistic.\"x:count\" AS stat_lowercase, " +
                 "A.Statistic.\"X-alias:Count\" AS stat_alias, " +
                 "A.Statistic('X:Count') AS stat_method, " +
                 "A.Statistic('X-alias:Count') AS stat_alias_method " +
-                "FROM flow.FCSAnalyses AS A ORDER BY Name"))
+                "FROM flow.FCSAnalyses AS A ORDER BY Name").select(true))
         {
             assertEquals(2, rs.getSize());
 

--- a/flow/src/org/labkey/flow/reports/FilterFlowReport.java
+++ b/flow/src/org/labkey/flow/reports/FilterFlowReport.java
@@ -385,7 +385,8 @@ public abstract class FilterFlowReport extends FlowReport
         }
 
         _query = query.toString();
-        Results results = QueryService.get().getSelectBuilder(flow, _query).select();
+        // Pass true to get a CachedResultSet, which this code requires (see getWrapped() and date manipulation below)
+        Results results = QueryService.get().getSelectBuilder(flow, _query).select(true);
         // This still breaks encapsulation, but it's better than a direct cast.
         CachedResultSet rs = results.getWrapped(CachedResultSet.class);
         if (null == rs)


### PR DESCRIPTION
#### Rationale
As we work to reduce OutOfMemoryError risk, we need to have places that rely on caching Results behavior opt-in. Here, it's so that we can ask the size of the result set before iterating it.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7711

#### Changes
* Opt-in to a `CachedResultSet`