### PR TITLE
Select all checkbox for QC grid

### DIFF
--- a/signalData/resources/web/signaldata/QCView/SampleCreator.js
+++ b/signalData/resources/web/signaldata/QCView/SampleCreator.js
@@ -99,6 +99,21 @@ Ext4.define('LABKEY.SignalData.SampleCreator', {
                     xtype: 'toolbar',
                     dock: 'top',
                     items: [{
+                        id: 'selectall-btn',
+                        boxLabel: 'Select All',
+                        xtype: 'checkbox',
+                        padding: '0 0 0 5',
+                        handler: function (cmp, checked) {
+                            if (checked)
+                                this.getInputsSelectionModel().selectAll();
+                            else
+                                this.getInputsSelectionModel().deselectAll();
+                        },
+                        scope: this
+                    },
+                    {xtype: 'tbspacer'},
+                    {xtype: 'tbseparator'},
+                    {
                         id: 'startqcbtn',
                         text: 'Overlay Selected',
                         disabled: true,

--- a/signalData/test/src/org/labkey/test/pages/signaldata/SignalDataRunViewerPage.java
+++ b/signalData/test/src/org/labkey/test/pages/signaldata/SignalDataRunViewerPage.java
@@ -17,15 +17,18 @@ package org.labkey.test.pages.signaldata;
 
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.util.Ext4Helper;
 import org.openqa.selenium.WebElement;
 
-/**
- * User: tgaluhn
- * Date: 9/6/2016
- */
+import static org.labkey.test.components.ext4.Checkbox.Ext4Checkbox;
+
 public class SignalDataRunViewerPage extends LabKeyPage
 {
+    private static final String SELECT_ALL_LABEL = "Select All";
+    private static final String OVERLAY_SELECTED_BUTTON_ID = "startqcbtn";
+
     public SignalDataRunViewerPage(WebDriverWrapper test)
     {
         super(test);
@@ -39,6 +42,44 @@ public class SignalDataRunViewerPage extends LabKeyPage
     public void checkRunViewerCheckbox(String resultName)
     {
         _ext4Helper.checkGridRowCheckbox(resultName);
+    }
+
+    /**
+     * Check or uncheck the "Select All" checkbox on the QC tool's Available Inputs toolbar. Checking it selects every
+     * input in the grid; unchecking it deselects them all. Waits for the "Overlay Selected" button to reflect the new
+     * selection state before returning.
+     */
+    public void setSelectAll(boolean checked)
+    {
+        Checkbox selectAll = Ext4Checkbox().withLabel(SELECT_ALL_LABEL).waitFor(getDriver());
+        if (checked)
+            selectAll.check();
+        else
+            selectAll.uncheck();
+
+        // 'Overlay Selected' is enabled only when at least one input is selected, so it is a reliable signal that the
+        // grid selection has settled after toggling Select All.
+        waitFor(() -> isOverlaySelectedEnabled() == checked,
+                "'Overlay Selected' button did not reflect the Select All state (expected enabled=" + checked + ")",
+                WAIT_FOR_JAVASCRIPT);
+    }
+
+    /**
+     * @param resultName the input (result) name shown in the Available Inputs grid
+     * @return whether that input's grid row is currently selected
+     */
+    public boolean isInputSelected(String resultName)
+    {
+        return _ext4Helper.isGridRowSelected(resultName, 0);
+    }
+
+    /**
+     * @return whether the "Overlay Selected" button is currently enabled
+     */
+    public boolean isOverlaySelectedEnabled()
+    {
+        WebElement button = Locator.id(OVERLAY_SELECTED_BUTTON_ID).findElement(getDriver());
+        return Ext4Helper.elementIfEnabled(button) != null;
     }
 
     public WebElement showPlot()

--- a/signalData/test/src/org/labkey/test/tests/signaldata/SignalDataRawTest.java
+++ b/signalData/test/src/org/labkey/test/tests/signaldata/SignalDataRawTest.java
@@ -47,6 +47,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @Category({Daily.class})
@@ -161,6 +162,36 @@ public class SignalDataRawTest extends BaseWebDriverTest implements PostgresOnly
                 .toList();
         assertTrue("Legend labels " + legendLabels + " do not contain all expected run names " + expectedRunNames,
                 legendLabels.containsAll(expectedRunNames));
+    }
+
+    @Test
+    public void testQCToolSelectAll()
+    {
+        List<String> filenames = List.of(RESULT_FILENAME_1, RESULT_FILENAME_2, RESULT_FILENAME_3);
+        List<String> expectedRunNames = filenames.stream().map(this::resultNameFromFilename).toList();
+
+        log("Select " + filenames.size() + " runs and open the QC tool");
+        SignalDataAssayBeginPage beginPage = navigateToAssayLandingPage(SignalDataInitializer.RAW_SignalData_ASSAY);
+        for (String filename : filenames)
+            beginPage.selectData(filename, DEFAULT_RUN);
+        SignalDataRunViewerPage runsPage = beginPage.viewRuns();
+
+        log("Verify no inputs are selected and 'Overlay Selected' is disabled before using Select All");
+        for (String runName : expectedRunNames)
+            assertFalse("Input '" + runName + "' should not be selected before Select All is checked", runsPage.isInputSelected(runName));
+        assertFalse("'Overlay Selected' should be disabled with no inputs selected", runsPage.isOverlaySelectedEnabled());
+
+        log("Check 'Select All' and verify every input is selected");
+        runsPage.setSelectAll(true);
+        for (String runName : expectedRunNames)
+            assertTrue("Input '" + runName + "' should be selected after Select All is checked", runsPage.isInputSelected(runName));
+        assertTrue("'Overlay Selected' should be enabled after selecting all inputs", runsPage.isOverlaySelectedEnabled());
+
+        log("Uncheck 'Select All' and verify every input is deselected");
+        runsPage.setSelectAll(false);
+        for (String runName : expectedRunNames)
+            assertFalse("Input '" + runName + "' should be deselected after Select All is unchecked", runsPage.isInputSelected(runName));
+        assertFalse("'Overlay Selected' should be disabled after deselecting all inputs", runsPage.isOverlaySelectedEnabled());
     }
 
     private String resultNameFromFilename(String filename)


### PR DESCRIPTION
## Rationale
This adds a checkbox to the Signal Data run QC view to select / deselect all inputs for the grid panel. Added a selenium test for the new functionality. The overlay selected button will enable / disable on selection.

<img width="477" height="447" alt="image" src="https://github.com/user-attachments/assets/627b735b-9fb7-4bc6-bf6d-60f03a6a94e1" />
