### PR TITLE
GitHub Issue #159: Require all assay transform scripts to reside in container's @scripts dir

### DIFF
--- a/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
+++ b/luminex/test/src/org/labkey/test/tests/luminex/LuminexTest.java
@@ -39,6 +39,7 @@ import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.pages.ReactAssayDesignerPage;
+import org.labkey.test.pages.files.WebDavPage;
 import org.labkey.test.pages.luminex.LuminexImportWizard;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ExtHelper;
@@ -103,6 +104,7 @@ public abstract class LuminexTest extends BaseWebDriverTest
 
     public static final File RTRANSFORM_SCRIPT_FILE_LABKEY = new File(TestFileUtils.getLabKeyRoot(), "server/modules/commonAssays/luminex/resources/transformscripts/labkey_luminex_transform.R");
     public static final File RTRANSFORM_SCRIPT_FILE_LAB =  new File(TestFileUtils.getLabKeyRoot(), "server/modules/commonAssays/luminex/resources/transformscripts/tomaras_luminex_transform.R");
+    public static final File RTRANSFORM_YOUTIL_FILE =  new File(TestFileUtils.getLabKeyRoot(), "server/modules/commonAssays/luminex/resources/transformscripts/youtil.R");
     public static final File RTRANSFORM_SCRIPT_FILE_NOOP = TestFileUtils.getSampleData("qc/noopTransform.R");
 
     public static final String ASSAY_DATA_FILE_LOCATION_MULTIPLE_FIELD = "__primaryFile__";
@@ -279,6 +281,13 @@ public abstract class LuminexTest extends BaseWebDriverTest
             SaveProtocolCommand saveProtocolCommand = new SaveProtocolCommand(assayProtocol);
             saveProtocolCommand.execute(createDefaultConnection(), getProjectName());
         }
+
+        // Assay designs that use the luminex transform scripts need to upload youtil.R script as sibling in @scripts
+        // so just include it there now for all cases
+        WebDavPage webDavPage = WebDavPage.beginAt(this, getProjectName() + "/@scripts");
+        if (!webDavPage.getFileBrowserHelper().getFileList().contains(RTRANSFORM_YOUTIL_FILE.getName()))
+            webDavPage.getFileBrowserHelper().uploadFile(RTRANSFORM_YOUTIL_FILE);
+        goToProjectHome();
     }
 
     private void setFieldsToDomain(List<PropertyDescriptor> fields, Domain domain)


### PR DESCRIPTION
## Rationale
Backport Luminex test fix from https://github.com/LabKey/commonAssays/pull/1048

## Related Pull Requests
- https://github.com/LabKey/commonAssays/pull/1048

## Changes
- Luminex test fixes to add youtil.R file to `@scripts` dir